### PR TITLE
Do not ignore cmake build type.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,7 @@ project (openjph DESCRIPTION "Open source implementation of JPH" LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 11)
 if (MSVC)
-	set(CMAKE_CXX_FLAGS "/O2 /EHsc")
-else()
-	set(CMAKE_CXX_FLAGS "-O3 -DNDEBUG")
+	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
 endif()
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/../bin)


### PR DESCRIPTION
Build type can be Release, Debug etc.

Currently, it's not possible to build a Debug version of the
library. Let cmake set the appropriate optimization flags;
for MSVC, just add the /EHsc flag to the existing compiler flags.