### PR TITLE
precinct: convert scratch to struct member, rather than static

### DIFF
--- a/src/core/codestream/ojph_codestream.cpp
+++ b/src/core/codestream/ojph_codestream.cpp
@@ -1596,7 +1596,9 @@ namespace ojph {
       else
         for (int i = 1; i < 4; ++i)
           bands[i].get_cb_indices(num_precincts, precincts);
-      precinct::alloc_scratch(codestream);
+      for (int i = 0; i < num_precincts.area(); ++i){
+    	  precincts->alloc_scratch(codestream);
+      }
       size log_cb = cd.get_log_block_dims();
       log_PP.w -= (res_num?1:0);
       log_PP.h -= (res_num?1:0);
@@ -2129,7 +2131,6 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
 
     //////////////////////////////////////////////////////////////////////////
-    ui8* precinct::scratch = NULL;
 
     //////////////////////////////////////////////////////////////////////////
     void precinct::alloc_scratch(codestream *codestream)

--- a/src/core/codestream/ojph_codestream_local.h
+++ b/src/core/codestream/ojph_codestream_local.h
@@ -252,8 +252,8 @@ namespace ojph {
                  mem_elastic_allocator *elastic,
                  int& data_left, infile_base *file);
 
-      static ui8 *scratch;
-      static void alloc_scratch(codestream *codestream);
+      ui8 *scratch;
+      void alloc_scratch(codestream *codestream);
       point img_point;   //the precinct projected to full resolution
       rect cb_idxs[4]; //indices of codeblocks
       subband *bands;  //the subbands


### PR DESCRIPTION
This allows the codestream to be re-used.