### PR TITLE
ojph_arch: no need to XOR with 31

### DIFF
--- a/src/core/common/ojph_arch.h
+++ b/src/core/common/ojph_arch.h
@@ -114,7 +114,7 @@ namespace ojph {
   #ifdef OJPH_COMPILER_MSVC
     unsigned long result = 0;
     _BitScanForward(&result, val);
-    return 31 ^ (int)result;
+    return (int)result;
   #elif (defined OJPH_COMPILER_GNUC)
     return __builtin_ctz(val);
   #else


### PR DESCRIPTION
Hi Aous,
Just a small fix for windows - _BitScanForward calculates trailing zeros directly.
Regards,
Aaron