### PR TITLE
add tiff-io support to development branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 mytest/*
 others/*
+
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ set(OPENJPH_VERSION "${OPENJPH_VERSION_MAJOR}.${OPENJPH_VERSION_MINOR}.${OPENJPH
 
 option(OJPH_DISABLE_INTEL_SIMD "Disables the use of SIMD instructions and associated files" OFF)
 option(BUILD_SHARED_LIBS "Shared Libraries" ON)
+option(OJPH_ENABLE_TIFF_SUPPORT "Enables input and output support for TIFF files" ON)
 
 if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
@@ -55,6 +56,42 @@ endif()
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/../bin)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/../bin)
+
+############################################################
+if( OJPH_ENABLE_TIFF_SUPPORT )
+
+  if( WIN32 )
+    
+    set(TIFF_INCLUDE_DIR "C:\\Program Files\\tiff\\include" CACHE PATH "the directory containing the TIFF headers")
+    set(TIFF_LIBRARY_DEBUG   "C:\\Program Files\\tiff\\lib\\tiffd.lib" CACHE FILEPATH "the path to the TIFF library for debug configurations")
+    set(TIFF_LIBRARY_RELEASE "C:\\Program Files\\tiff\\lib\\tiff.lib"  CACHE FILEPATH "the path to the TIFF library for release configurations")
+    set(TIFFXX_LIBRARY_DEBUG  "C:\\Program Files\\tiff\\lib\\tiffxxd.lib" CACHE FILEPATH "the path to the TIFFXX  library for debug configurations")
+    set(TIFFXX_LIBRARY_RELEASE "C:\\Program Files\\tiff\\lib\\tiffxx.lib" CACHE FILEPATH "the path to the TIFFXX  library for release configurations")
+    
+    MESSAGE( STATUS "WIN32 detected: Setting CMakeCache TIFF values as follows, use CMake-gui Advanced to modify them" )
+    MESSAGE( STATUS "   TIFF_INCLUDE_DIR : \"${TIFF_INCLUDE_DIR}\"" )
+    MESSAGE( STATUS "   TIFF_LIBRARY_DEBUG : \"${TIFF_LIBRARY_DEBUG}\"" )
+    MESSAGE( STATUS "   TIFF_LIBRARY_RELEASE : \"${TIFF_LIBRARY_RELEASE}\"" )
+    MESSAGE( STATUS "   TIFFXX_LIBRARY_DEBUG : \"${TIFFXX_LIBRARY_DEBUG}\"" )
+    MESSAGE( STATUS "   TIFFXX_LIBRARY_RELEASE : \"${TIFFXX_LIBRARY_RELEASE}\"" )
+
+  endif( WIN32 )
+
+  FIND_PACKAGE( TIFF )
+
+  IF( TIFF_FOUND )
+    SET(USE_TIFF TRUE CACHE BOOL "Add TIFF support")
+    include_directories( ${TIFF_INCLUDE_DIR} ) 
+    if (MSVC)
+		  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D \"OJPH_ENABLE_TIFF_SUPPORT\"")
+	  else()
+		  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DOJPH_ENABLE_TIFF_SUPPORT")
+	  endif()
+    #include_directories(${CMAKE_BINARY_DIR}/libtiff) # for tiffconf.h on windows
+  endif( TIFF_FOUND )
+
+endif() 
+############################################################
 
 include_directories(src/core/common)
 include_directories(src/apps/common)
@@ -101,10 +138,18 @@ else()
 endif()
 
 add_executable(ojph_expand src/apps/ojph_expand/ojph_expand.cpp src/apps/others/ojph_img_io.cpp)
-target_link_libraries(ojph_expand openjph)
+IF( USE_TIFF )
+  target_link_libraries(ojph_expand openjph ${TIFF_LIBRARIES})
+ELSE()
+  target_link_libraries(ojph_expand openjph)
+ENDIF()
 
 add_executable(ojph_compress src/apps/ojph_compress/ojph_compress.cpp src/apps/others/ojph_img_io.cpp)
-target_link_libraries (ojph_compress openjph)
+IF( USE_TIFF )
+  target_link_libraries (ojph_compress openjph ${TIFF_LIBRARIES})
+ELSE()
+  target_link_libraries (ojph_compress openjph)
+ENDIF()
 
 INSTALL(TARGETS ojph_expand
         DESTINATION bin)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:focal
+
+RUN apt-get update
+
+# disable interactive install 
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get -y install cmake
+RUN apt-get -y install g++
+RUN apt-get -y install libtiff-dev
+
+# OpenJPH
+WORKDIR /usr/src/openjph/
+COPY . .
+WORKDIR /usr/src/openjph/build
+RUN cmake -DCMAKE_BUILD_TYPE=Release ../
+RUN make
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/src/openjph/bin
+ENV PATH=$PATH:/usr/src/openjph/bin
+
+# finalize docker environment
+WORKDIR /usr/src/openjph
+
+# step 1 - build docker image
+# docker build --rm -f Dockerfile -t openjph:latest .
+# step 2 - run docker image
+# docker run -it --rm openjph:latest
+# docker run -it --rm -v C:\\temp:/usr/src/openjph/build openjph:latest

--- a/README.md
+++ b/README.md
@@ -93,6 +93,23 @@ To compile for platforms where x86_64 SIMD instructions are not supported, such 
 
 As I do not have an ARM board, I tested this using QEMU for aarch64 architecture, targeting a Cortex-A57 CPU. The code worked without issues, but because the ARM platform is emulated, the whole process was slow.
 
+# Compiling and Running in Docker #
+
+## Step 1 - clone repository   
+`https://github.com/aous72/OpenJPH.git`
+
+## Step 2 - build docker image  
+`cd OpenJPH`   
+`docker build --rm -f Dockerfile -t openjph:latest .`
+
+## Step 3 - run docker image
+
+### in isolated container   
+`docker run -it --rm openjph:latest`
+
+### mapping /usr/src/openjph/build directory in the container to local windows c:\temp
+`docker run -it --rm -v C:\\temp:/usr/src/openjph/build openjph:latest`
+
 # Usage Example #
 
 Here are some usage examples:

--- a/src/apps/others/ojph_img_io.cpp
+++ b/src/apps/others/ojph_img_io.cpp
@@ -95,6 +95,7 @@ namespace ojph {
       OJPH_ERROR(0x030000001, "Unable to open file %s", filename);
     fname = filename;
 
+    // read magic number
     char t[2];
     if (fread(t, 1, 2, fh) != 2)
     {
@@ -102,6 +103,7 @@ namespace ojph {
       OJPH_ERROR(0x030000002, "Error reading file %s", filename);
     }
 
+    // check magic number
     if (t[0] != 'P' || (t[1] != '5' && t[1] != '6'))
     {
       close();
@@ -122,9 +124,11 @@ namespace ojph {
         "must have a .pgm extension fir file %s", filename);
     }
 
+    // set number of components based on file-type
     num_comps = t[1] == '5' ? 1 : 3;
     eat_white_spaces(fh);
 
+    // read width, height and max value in header
     if (fscanf(fh, "%d %d %d", &width, &height, &max_val) != 3)
     {
       close();
@@ -137,6 +141,7 @@ namespace ojph {
     fgetc(fh);
     start_of_data = ojph_ftell(fh);
 
+    // allocate linebuffer to hold a line of image data
     if (temp_buf_byte_size < num_comps * width * bytes_per_sample)
     {
       if (alloc_p == NULL)
@@ -371,6 +376,304 @@ namespace ojph {
     }
     return 0;
   }
+
+  ////////////////////////////////////////////////////////////////////////////
+ //
+ //
+ //
+ //
+ //
+ ////////////////////////////////////////////////////////////////////////////
+#ifdef OJPH_ENABLE_TIFF_SUPPORT
+ /////////////////////////////////////////////////////////////////////////////
+  void tif_in::open(const char* filename)
+  {
+    tiff_handle = NULL;
+    if ((tiff_handle = TIFFOpen(filename, "r")) == NULL)
+      OJPH_ERROR(0x0300000B1, "Unable to open file %s", filename);
+    fname = filename;
+
+    unsigned int tiff_width = 0;
+    unsigned int tiff_height = 0; 
+    TIFFGetField(tiff_handle, TIFFTAG_IMAGEWIDTH, &tiff_width);
+    TIFFGetField(tiff_handle, TIFFTAG_IMAGELENGTH, &tiff_height);
+
+    unsigned short tiff_bits_per_sample = 0;
+    unsigned short tiff_samples_per_pixel = 0;
+    TIFFGetField(tiff_handle, TIFFTAG_BITSPERSAMPLE, &tiff_bits_per_sample);
+    TIFFGetField(tiff_handle, TIFFTAG_SAMPLESPERPIXEL, &tiff_samples_per_pixel);
+    // some TIFs have tiff_samples_per_pixel=0 when it is a single channel image - set to 1
+    tiff_samples_per_pixel = (tiff_samples_per_pixel < 1) ? 1 : tiff_samples_per_pixel;
+
+    unsigned short tiff_planar_configuration = 0;
+    unsigned short tiff_photometric = 0;
+    TIFFGetField(tiff_handle, TIFFTAG_PLANARCONFIG, &tiff_planar_configuration);
+    TIFFGetField(tiff_handle, TIFFTAG_PHOTOMETRIC, &tiff_photometric);
+
+    planar_configuration = tiff_planar_configuration;
+
+    unsigned short tiff_compression = 0;
+    unsigned int tiff_rows_per_strip = 0;
+    TIFFGetField(tiff_handle, TIFFTAG_COMPRESSION, &tiff_compression);
+    TIFFGetField(tiff_handle, TIFFTAG_ROWSPERSTRIP, &tiff_rows_per_strip);
+
+    if (tiff_planar_configuration == PLANARCONFIG_SEPARATE)
+    {
+      bytes_per_line = tiff_samples_per_pixel * TIFFScanlineSize(tiff_handle);
+    }
+    else
+    {
+      bytes_per_line = TIFFScanlineSize(tiff_handle);
+    }
+    // allocate linebuffer to hold a line of image data
+    line_buffer = malloc(bytes_per_line);
+    if (NULL == line_buffer)
+      OJPH_ERROR(0x0300000B2, "Unable to allocate %d bytes for line_buffer[] for file %s", bytes_per_line, filename);
+      
+    cur_line = 0;
+
+    // Error on known incompatilbe input formats
+    if( tiff_bits_per_sample != 8 && tiff_bits_per_sample != 16 )
+    {
+      OJPH_ERROR(0x0300000B3, "\nTIFF IO is currently limited to file limited to files with TIFFTAG_BITSPERSAMPLE=8 and TIFFTAG_BITSPERSAMPLE=16 \ninput file = %s has TIFFTAG_BITSPERSAMPLE=%d", filename, tiff_bits_per_sample);
+    }
+
+    if( TIFFIsTiled( tiff_handle ) )
+    {
+      OJPH_ERROR(0x0300000B4, "\nTIFF IO is currently limited to TIF files without tiles. \nInput file %s has been detected as tiled", filename);
+    }
+
+    if( PHOTOMETRIC_RGB != tiff_photometric && PHOTOMETRIC_MINISBLACK != tiff_photometric )
+    {
+      OJPH_ERROR(0x0300000B5, "\nTIFF IO is currently limited to TIFFTAG_PHOTOMETRIC=PHOTOMETRIC_MINISBLACK=%d and PHOTOMETRIC_RGB=%d. \nInput file %s has been detected TIFFTAG_PHOTOMETRIC=%d", 
+      PHOTOMETRIC_MINISBLACK, PHOTOMETRIC_RGB, filename, tiff_photometric);
+    }
+
+    if( tiff_samples_per_pixel > 4 )
+    {
+      OJPH_ERROR(0x0300000B6, "\nTIFF IO is currently limited to TIFFTAG_SAMPLESPERPIXEL=4 \nInput file %s has been detected with TIFFTAG_SAMPLESPERPIXEL=%d",
+        filename, tiff_samples_per_pixel);
+    }
+
+    // set number of components based on tiff_samples_per_pixel
+    width = tiff_width;
+    height = tiff_height;
+    num_comps = tiff_samples_per_pixel;
+    bytes_per_sample = (tiff_bits_per_sample + 7) / 8;
+    for (ui32 comp_num = 0; comp_num < num_comps; comp_num++)
+      bit_depth[comp_num] = tiff_bits_per_sample;
+
+    // allocate intermediate linebuffers to hold a line of a single component of image data
+    if (tiff_planar_configuration == PLANARCONFIG_SEPARATE && bytes_per_sample == 1)
+    {
+      line_buffer_for_planar_support_uint8 = (uint8_t*)calloc(width, sizeof(uint8_t));
+      if (NULL == line_buffer_for_planar_support_uint8)
+        OJPH_ERROR(0x0300000B7, "Unable to allocate %d bytes for line_buffer_for_planar_support_uint8[] for file %s", width * sizeof(uint8_t), filename);
+    }
+    if (tiff_planar_configuration == PLANARCONFIG_SEPARATE && bytes_per_sample == 2)
+    {
+      line_buffer_for_planar_support_uint16 = (uint16_t*)calloc(width, sizeof(uint16_t));
+      if (NULL == line_buffer_for_planar_support_uint16)
+        OJPH_ERROR(0x0300000B8, "Unable to allocate %d bytes for line_buffer_for_planar_support_uint16[] for file %s", width * sizeof(uint16_t), filename);
+    }
+  }
+
+  /////////////////////////////////////////////////////////////////////////////
+
+  /////////////////////////////////////////////////////////////////////////////
+  ui32 tif_in::read(const line_buf* line, ui32 comp_num)
+  {
+    assert(bytes_per_line != 0 && tiff_handle != 0 && comp_num < num_comps);
+    assert((int)line->size >= width);
+
+    // do a read from the file if this is the first component and therefore the first time trying to access this line
+    if (PLANARCONFIG_SEPARATE == planar_configuration && 0 == comp_num )
+    {
+      for (unsigned short color = 0; color < num_comps; color++)
+      {
+        if (bytes_per_sample == 1)
+        {
+          TIFFReadScanline(tiff_handle, line_buffer_for_planar_support_uint8, cur_line, color);
+          unsigned int x = color;
+          uint8_t* line_buffer_of_interleaved_components = (uint8_t*)line_buffer;
+          for (int i = 0; i < width; i++, x += num_comps)
+          {
+            line_buffer_of_interleaved_components[x] = line_buffer_for_planar_support_uint8[i];
+          }
+        }
+        else if (bytes_per_sample == 2)
+        {
+          TIFFReadScanline(tiff_handle, line_buffer_for_planar_support_uint16, cur_line, color);
+          unsigned int x = color;
+          uint16_t* line_buffer_of_interleaved_components = (uint16_t*)line_buffer;
+          for (int i = 0; i < width; i++, x += num_comps)
+          {
+            line_buffer_of_interleaved_components[x] = line_buffer_for_planar_support_uint16[i];
+          }
+        }
+      }
+      cur_line++;
+      
+    }
+    else if (planar_configuration == PLANARCONFIG_CONTIG && 0 == comp_num)
+    {
+      TIFFReadScanline(tiff_handle, line_buffer, cur_line++);
+    }
+    if (cur_line >= height)
+    {
+      cur_line = 0;
+    }
+
+    if (bytes_per_sample == 1)
+    {
+      const ui8* sp = (ui8*)line_buffer + comp_num;
+      si32* dp = line->i32;
+      for (int i = width; i > 0; --i, sp += num_comps)
+        *dp++ = (si32)*sp;
+    }
+    else
+    {
+      const ui16* sp = (ui16*)line_buffer + comp_num;
+      si32* dp = line->i32;
+      for (int i = width; i > 0; --i, sp += num_comps)
+        *dp++ = (si32)*sp;
+    }
+
+    return width;
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  //
+  //
+  //
+  //
+  //
+  ////////////////////////////////////////////////////////////////////////////
+
+  ////////////////////////////////////////////////////////////////////////////
+  void tif_out::open(char* filename)
+  {
+    // Error on known incompatilbe output formats
+    if (bit_depth != 8 && bit_depth != 16)
+    {
+      OJPH_ERROR(0x0300000C2, "TIFF IO is currently limited to files with TIFFTAG_BITSPERSAMPLE=8 and TIFFTAG_BITSPERSAMPLE=16, the source codestream has bit_depth=%d", filename, bit_depth);
+    }
+    if (num_components > 4)
+    {
+      OJPH_ERROR(0x0300000C3, "TIFF IO is currently limited to files with num_components=1 to 4");
+    }
+
+    assert(tiff_handle == NULL && buffer == NULL);
+    if ((tiff_handle = TIFFOpen(filename, "w")) == NULL)
+    {
+      OJPH_ERROR(0x0300000C1, "unable to open file %s for writing", filename);
+    }
+
+    buffer_size = width * num_components * bytes_per_sample;
+    buffer = (ui8*)malloc(buffer_size);
+    fname = filename;
+    cur_line = 0;
+
+    // set tiff fields
+
+    // Write the tiff tags to the file
+    TIFFSetField(tiff_handle, TIFFTAG_IMAGEWIDTH, width);
+    TIFFSetField(tiff_handle, TIFFTAG_IMAGELENGTH, height);
+
+    TIFFSetField(tiff_handle, TIFFTAG_BITSPERSAMPLE, bit_depth);
+    TIFFSetField(tiff_handle, TIFFTAG_SAMPLESPERPIXEL, num_components);
+
+    planar_configuration = PLANARCONFIG_CONTIG;
+    TIFFSetField(tiff_handle, TIFFTAG_PLANARCONFIG, planar_configuration);
+
+    if (num_components == 1)
+    {
+      TIFFSetField(tiff_handle, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_MINISBLACK);
+    }
+    else if (num_components == 2)
+    {
+      TIFFSetField(tiff_handle, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_MINISBLACK);
+      const uint16_t extra_samples_description[1] = { EXTRASAMPLE_ASSOCALPHA }; // possible values are EXTRASAMPLE_UNSPECIFIED = 0; EXTRASAMPLE_ASSOCALPHA = 1; EXTRASAMPLE_UNASSALPHA = 2;
+      TIFFSetField(tiff_handle, TIFFTAG_EXTRASAMPLES, (uint16_t)1, &extra_samples_description);
+    }
+    else if (num_components == 3)
+    {
+      TIFFSetField(tiff_handle, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_RGB);
+    }
+    else if (num_components == 4)
+    {
+      TIFFSetField(tiff_handle, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_RGB);
+      const uint16_t extra_samples_description[1] = { EXTRASAMPLE_ASSOCALPHA }; // possible values are EXTRASAMPLE_UNSPECIFIED = 0; EXTRASAMPLE_ASSOCALPHA = 1; EXTRASAMPLE_UNASSALPHA = 2;
+      TIFFSetField(tiff_handle, TIFFTAG_EXTRASAMPLES, (uint16_t)1, &extra_samples_description);
+    }
+      
+    TIFFSetField(tiff_handle, TIFFTAG_ORIENTATION, ORIENTATION_TOPLEFT);
+    TIFFSetField(tiff_handle, TIFFTAG_COMPRESSION, COMPRESSION_NONE);
+    //TIFFSetField(tiff_handle, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_UINT);
+    TIFFSetField(tiff_handle, TIFFTAG_ROWSPERSTRIP, height);
+    
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  void tif_out::configure(ui32 width, ui32 height, int num_components,
+    int bit_depth)
+  {
+    assert(tiff_handle == NULL); //configure before opening
+
+    this->width = width;
+    this->height = height;
+    this->num_components = num_components;
+    this->bit_depth = bit_depth;
+
+    bytes_per_sample = 1 + (bit_depth > 8 ? 1 : 0);
+    samples_per_line = num_components * width;
+    bytes_per_line = bytes_per_sample * samples_per_line;
+
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  ui32 tif_out::write(const line_buf* line, ui32 comp_num)
+  {
+    assert(tiff_handle);
+    
+    if (bit_depth <= 8)
+      {
+        int max_val = (1 << bit_depth) - 1;
+        const si32* sp = line->i32;
+        ui8* dp = buffer + comp_num;
+        for (int i = width; i > 0; --i, dp += num_components)
+        {
+          int val = *sp++;
+          val = val >= 0 ? val : 0;
+          val = val <= max_val ? val : max_val;
+          *dp = (ui8)val;
+        }
+      }
+      else
+      {
+        int max_val = (1 << bit_depth) - 1;
+        const si32* sp = line->i32;
+        ui16* dp = (ui16*)buffer + comp_num;
+        for (int i = width; i > 0; --i, dp += num_components)
+        {
+          int val = *sp++;
+          val = val >= 0 ? val : 0;
+          val = val <= max_val ? val : max_val;
+          *dp = (ui16)val;
+        }
+      }
+      
+      // write scanline when the last component is reached 
+      if (comp_num == num_components-1)
+      {
+        int result = TIFFWriteScanline(tiff_handle, buffer,
+          cur_line++);
+        if (result != 1)
+          OJPH_ERROR(0x0300000C4, "error writing to file %s", fname);
+      }
+    return 0;
+  }
+  #endif /* OJPH_ENABLE_TIFF_SUPPORT */
 
   ////////////////////////////////////////////////////////////////////////////
   //


### PR DESCRIPTION
this adds support for TIF file reading and writing to the ojph_compress and ojph_expand applications respectively.  It uses LIBTIFF for the TIFF reading/writing functionality.