### PR TITLE
support different bitdepths per component for TIFF IO

### DIFF
--- a/src/apps/common/ojph_img_io.h
+++ b/src/apps/common/ojph_img_io.h
@@ -196,6 +196,7 @@ namespace ojph {
 
     size get_size() { assert(tiff_handle); return size(width, height); }
     ui32 get_num_components() { assert(tiff_handle); return num_comps; }
+	void set_bit_depth(ui32 num_bit_depths, ui32* bit_depth);
     ui32 get_bit_depth(ui32 comp_num)
     {
       assert(tiff_handle && comp_num < num_comps); return bit_depth[comp_num];
@@ -367,7 +368,8 @@ namespace ojph {
       fname = NULL;
       buffer = NULL;
       width = height = num_components = 0;
-      bit_depth = bytes_per_sample = 0;
+      bytes_per_sample = 0;
+	  bit_depth_of_data[0] = bit_depth_of_data[1] = bit_depth_of_data[2] = bit_depth_of_data[3] = 0;
       buffer_size = 0;
       cur_line = samples_per_line = 0;
       bytes_per_line = 0;
@@ -383,7 +385,7 @@ namespace ojph {
 
     void open(char* filename);
     void configure(ui32 width, ui32 height, ui32 num_components,
-      ui32 bit_depth);
+      ui32 *bit_depth);
     virtual ui32 write(const line_buf* line, ui32 comp_num);
     virtual void close() { 
       if (tiff_handle) { 
@@ -400,7 +402,8 @@ namespace ojph {
 
     const char* fname;
     ui32 width, height, num_components;
-    ui32 bit_depth, bytes_per_sample;
+	ui32 bit_depth_of_data[4]; 
+    ui32 bytes_per_sample;
     ui8* buffer;
     ui32 buffer_size;
     ui32 cur_line, samples_per_line;

--- a/src/apps/ojph_compress/ojph_compress.cpp
+++ b/src/apps/ojph_compress/ojph_compress.cpp
@@ -665,6 +665,8 @@ int main(int argc, char * argv[]) {
           image_offset.y + tif.get_size().h));
         ojph::ui32 num_comps = tif.get_num_components();
         siz.set_num_components(num_comps);
+        if(num_bit_depths > 0 )
+          tif.set_bit_depth(num_bit_depths, bit_depth);
         for (ojph::ui32 c = 0; c < num_comps; ++c)
           siz.set_component(c, tif.get_comp_subsampling(c),
             tif.get_bit_depth(c), tif.get_is_signed(c));
@@ -698,9 +700,6 @@ int main(int argc, char * argv[]) {
         if (is_signed[0] != -1)
           OJPH_WARN(0x01000063,
             "-signed is not needed and was not used\n");
-        if (bit_depth[0] != 0)
-          OJPH_WARN(0x01000064,
-            "-bit_depth is not needed and was not used\n");
         if (comp_downsampling[0].x != 0 || comp_downsampling[0].y != 0)
           OJPH_WARN(0x01000065,
             "-downsamp is not needed and was not used\n");

--- a/src/apps/ojph_expand/ojph_expand.cpp
+++ b/src/apps/ojph_expand/ojph_expand.cpp
@@ -262,8 +262,13 @@ int main(int argc, char *argv[]) {
           OJPH_ERROR(0x020000008,
             "To save an image to tif(f), all the components must have the "
             "downsampling ratio\n");
+        ojph::ui32 bit_depths[4] = { 0, 0, 0, 0 };
+        for (ojph::ui32 c = 0; c < siz.get_num_components(); c++)
+        {
+          bit_depths[c] = siz.get_bit_depth(c);
+        }
         tif.configure(siz.get_recon_width(0), siz.get_recon_height(0),
-          siz.get_num_components(), siz.get_bit_depth(0));
+          siz.get_num_components(), bit_depths);
         tif.open(output_filename);
         base = &tif;
       }

--- a/src/apps/others/ojph_img_io.cpp
+++ b/src/apps/others/ojph_img_io.cpp
@@ -500,6 +500,25 @@ namespace ojph {
 
   /////////////////////////////////////////////////////////////////////////////
 
+  ////////////////////////////////////////////////////////////////////////////
+  void tif_in::set_bit_depth(ui32 num_bit_depths, ui32* bit_depth)
+  {
+    if (num_bit_depths < 1)
+      OJPH_ERROR(0x030000B9, "one or more bit_depths must be provided");
+    ui32 last_bd_idx = 0;
+    for (ui32 i = 0; i < 4; ++i)
+    {
+      ui32 bd = bit_depth[i < num_bit_depths ? i : last_bd_idx];
+      last_bd_idx += last_bd_idx + 1 < num_bit_depths ? 1 : 0;
+
+      if (bd > 32 || bd < 1)
+      {
+        OJPH_ERROR(0x0300000BA, "bit_depth = %d, this must be an integer from 1-32", bd);
+      }
+      this->bit_depth[i] = bd;
+    }
+  }
+
   /////////////////////////////////////////////////////////////////////////////
   ui32 tif_in::read(const line_buf* line, ui32 comp_num)
   {
@@ -554,15 +573,56 @@ namespace ojph {
     {
       const ui8* sp = (ui8*)line_buffer + comp_num;
       si32* dp = line->i32;
-      for (ui32 i = width; i > 0; --i, sp += num_comps)
-        *dp++ = (si32)*sp;
+      if (bit_depth[comp_num] == 8)
+      {
+        for (ui32 i = width; i > 0; --i, sp += num_comps)
+          *dp++ = (si32)*sp;
+      }
+      else if (bit_depth[comp_num] < 8)
+      {
+        // read the desired precision from the MSBs
+        const int bits_to_shift = 8 - bit_depth[comp_num];
+        const int bit_mask = (1 << bit_depth[comp_num]) - 1;
+        for (int i = width; i > 0; --i, sp += num_comps)
+          *dp++ = (si32) (((*sp) >> bits_to_shift) & bit_mask);
+      }
+      else if (bit_depth[comp_num] > 8)
+      {
+        const int bits_to_shift = bit_depth[comp_num] - 8;
+        const int bit_mask = (1 << bit_depth[comp_num]) - 1;
+        for (int i = width; i > 0; --i, sp += num_comps)
+          *dp++ = (si32)(((*sp) << bits_to_shift) & bit_mask);
+      }
     }
-    else
+    else if(bytes_per_sample == 2)
     {
-      const ui16* sp = (ui16*)line_buffer + comp_num;
-      si32* dp = line->i32;
-      for (ui32 i = width; i > 0; --i, sp += num_comps)
-        *dp++ = (si32)*sp;
+      if (bit_depth[comp_num] == 16)
+      {
+        const ui16* sp = (ui16*)line_buffer + comp_num;
+        si32* dp = line->i32;
+        for (ui32 i = width; i > 0; --i, sp += num_comps)
+          *dp++ = (si32)*sp;
+      }
+      else if (bit_depth[comp_num] < 16)
+      {
+        // read the desired precision from the MSBs
+        const int bits_to_shift = 16 - bit_depth[comp_num];
+        const int bit_mask = (1 << bit_depth[comp_num]) - 1;
+        const ui16* sp = (ui16*)line_buffer + comp_num;
+        si32* dp = line->i32;
+        for (int i = width; i > 0; --i, sp += num_comps)
+          *dp++ = (si32)(((*sp) >> bits_to_shift) & bit_mask);
+      }
+      else if (bit_depth[comp_num] > 16)
+      {
+        const int bits_to_shift = bit_depth[comp_num] - 16;
+        const int bit_mask = (1 << bit_depth[comp_num]) - 1;
+        const ui16* sp = (ui16*)line_buffer + comp_num;
+        si32* dp = line->i32;
+        for (int i = width; i > 0; --i, sp += num_comps)
+          *dp++ = (si32)(((*sp) << bits_to_shift) & bit_mask);
+      }
+      
     }
 
     return width;
@@ -580,11 +640,17 @@ namespace ojph {
   void tif_out::open(char* filename)
   {
     // Error on known incompatilbe output formats
-    if (bit_depth != 8 && bit_depth != 16)
+    ui32 max_bitdepth = 0;
+    for (ui32 c = 0; c < num_components; c++)
     {
-      OJPH_ERROR(0x0300000C2, "TIFF IO is currently limited to files with "
-        "TIFFTAG_BITSPERSAMPLE=8 and TIFFTAG_BITSPERSAMPLE=16, the source "
-        "codestream has bit_depth=%d", filename, bit_depth);
+      if (bit_depth_of_data[c] > max_bitdepth)
+        max_bitdepth = bit_depth_of_data[c];
+    }
+    if (max_bitdepth > 16)
+    {
+      OJPH_WARN(0x0300000C2, "TIFF output is currently limited to files "
+        "with max_bitdepth = 16, the source codestream has max_bitdepth=%d"
+        ", the decoded data will be truncated to 16 bits", max_bitdepth);
     }
     if (num_components > 4)
     {
@@ -609,7 +675,7 @@ namespace ojph {
     TIFFSetField(tiff_handle, TIFFTAG_IMAGEWIDTH, width);
     TIFFSetField(tiff_handle, TIFFTAG_IMAGELENGTH, height);
 
-    TIFFSetField(tiff_handle, TIFFTAG_BITSPERSAMPLE, bit_depth);
+    TIFFSetField(tiff_handle, TIFFTAG_BITSPERSAMPLE, bytes_per_sample * 8);
     TIFFSetField(tiff_handle, TIFFTAG_SAMPLESPERPIXEL, num_components);
 
     planar_configuration = PLANARCONFIG_CONTIG;
@@ -651,16 +717,28 @@ namespace ojph {
 
   ////////////////////////////////////////////////////////////////////////////
   void tif_out::configure(ui32 width, ui32 height, ui32 num_components,
-    ui32 bit_depth)
+    ui32 *bit_depth)
   {
     assert(tiff_handle == NULL); //configure before opening
 
     this->width = width;
     this->height = height;
     this->num_components = num_components;
-    this->bit_depth = bit_depth;
+    ui32 max_bitdepth = 0;
+    for (ui32 c = 0; c < num_components; c++)
+    {
+      this->bit_depth_of_data[c] = bit_depth[c];
+      if (bit_depth[c] > max_bitdepth)
+        max_bitdepth = bit_depth[c];
+    }
 
-    bytes_per_sample = 1 + (bit_depth > 8 ? 1 : 0);
+    bytes_per_sample = (max_bitdepth + 7) / 8;  // round up
+    if (bytes_per_sample > 2)
+    {
+      // TIFF output is currently limited to files with max_bitdepth = 16, 
+      // the decoded data will be truncated to 16 bits
+      bytes_per_sample = 2;
+    }
     samples_per_line = num_components * width;
     bytes_per_line = bytes_per_sample * samples_per_line;
 
@@ -671,33 +749,101 @@ namespace ojph {
   {
     assert(tiff_handle);
     
-    if (bit_depth <= 8)
+    if (bytes_per_sample == 1)
+    {
+      int max_val = (1 << bit_depth_of_data[comp_num]) - 1;
+      const si32* sp = line->i32;
+      ui8* dp = buffer + comp_num;
+      if (bit_depth_of_data[comp_num] == 8)
       {
-        int max_val = (1 << bit_depth) - 1;
-        const si32* sp = line->i32;
-        ui8* dp = buffer + comp_num;
-        for (ui32 i = width; i > 0; --i, dp += num_components)
+        for (int i = width; i > 0; --i, dp += num_components)
         {
+          // clamp the decoded sample to the allowed range
           int val = *sp++;
           val = val >= 0 ? val : 0;
           val = val <= max_val ? val : max_val;
           *dp = (ui8)val;
         }
       }
-      else
+      else if (bit_depth_of_data[comp_num] < 8)
       {
-        int max_val = (1 << bit_depth) - 1;
-        const si32* sp = line->i32;
-        ui16* dp = (ui16*)buffer + comp_num;
-        for (ui32 i = width; i > 0; --i, dp += num_components)
+        const int bits_to_shift = 8 - bit_depth_of_data[comp_num];
+        const int bit_mask = (1 << bit_depth_of_data[comp_num]) - 1;
+        for (int i = width; i > 0; --i, dp += num_components)
         {
+          // clamp the decoded sample to the allowed range
+          int val = *sp++;
+          val = val >= 0 ? val : 0;
+          val = val <= max_val ? val : max_val;
+          // shift the decoded data so the data's MSB is aligned with the 8 bit MSB
+          *dp = (ui8)((val & bit_mask) << bits_to_shift);
+        }
+      }
+      else if (bit_depth_of_data[comp_num] > 8)
+      {
+        const int bits_to_shift = bit_depth_of_data[comp_num] - 8;
+        const int bit_mask = (1 << bit_depth_of_data[comp_num]) - 1;
+        for (int i = width; i > 0; --i, dp += num_components)
+        {
+          // clamp the decoded sample to the allowed range
+          int val = *sp++;
+          val = val >= 0 ? val : 0;
+          val = val <= max_val ? val : max_val;
+          // shift the decoded data so the data's MSB is aligned with the 8 bit MSB
+          *dp = (ui8)((val >> bits_to_shift) & bit_mask);
+        }
+      }
+      
+    }
+    else if(bytes_per_sample == 2)
+    {
+      int max_val = (1 << bit_depth_of_data[comp_num]) - 1;
+      const si32* sp = line->i32;
+      ui16* dp = (ui16*)buffer + comp_num;
+
+      if (bit_depth_of_data[comp_num] == 16)
+      {
+        for (int i = width; i > 0; --i, dp += num_components)
+        {
+          // clamp the decoded sample to the allowed range
           int val = *sp++;
           val = val >= 0 ? val : 0;
           val = val <= max_val ? val : max_val;
           *dp = (ui16)val;
         }
       }
+      else if (bit_depth_of_data[comp_num] < 16)
+      {
+        const int bits_to_shift = 16 - bit_depth_of_data[comp_num];
+        const int bit_mask = (1 << bit_depth_of_data[comp_num]) - 1;
+        for (int i = width; i > 0; --i, dp += num_components)
+        {
+          // clamp the decoded sample to the allowed range
+          int val = *sp++;
+          val = val >= 0 ? val : 0;
+          val = val <= max_val ? val : max_val;
+
+          // shift the decoded data so the data's MSB is aligned with the 16 bit MSB
+          *dp = (ui16)((val & bit_mask) << bits_to_shift);
+        }
+      }
+      else if (bit_depth_of_data[comp_num] > 16)
+      {
+        const int bits_to_shift = bit_depth_of_data[comp_num] - 16;
+        const int bit_mask = (1 << bit_depth_of_data[comp_num]) - 1;
+        for (int i = width; i > 0; --i, dp += num_components)
+        {
+          // clamp the decoded sample to the allowed range
+          int val = *sp++;
+          val = val >= 0 ? val : 0;
+          val = val <= max_val ? val : max_val;
+
+          // shift the decoded data so the data's MSB is aligned with the 16 bit MSB
+          *dp = (ui16)((val >> bits_to_shift) & bit_mask);
+        }
+      }
       
+    }
       // write scanline when the last component is reached 
       if (comp_num == num_components-1)
       {


### PR DESCRIPTION
### Adds support for reading the top X bits in a TIF file and compressing to J2C
For example, if `in.tif` is a 16 bit TIF file, this will read the top 10 MSBs in the 16bit data and compress it to J2C
`ojph_compress -i in.tif -o out.j2c -bit_depth 10,10,10`
Different bitdepths can be used for each component and also if the bitdepth value is larger than the input TIFs native bitdepth value, then the sample values are left shifted appropriately.  For example
`ojph_compress -i in.tif -o out.j2c -bit_depth 9,17,13`
### Adds support for decoding J2C to TIF when the component bitdepth is not multiple of 8
For example, if `10_12_13.j2c` has component bitdepths 10, 12, 13 then this command will store the decoded samples in the top 10, 12, and 13 MSBs respectively in a 16bit TIF
`ojph_expand -i 10_12_13.j2c -o out.tif`
If a component bitdepth is greater than 16, only the top 16bits of data will be stored in the output TIF file. 