### PR TITLE
Feature - dpx file input support for ojph_compress

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,13 @@ if( OJPH_ENABLE_TIFF_SUPPORT )
 endif() 
 ############################################################
 
+# enable DPX support
+if (MSVC)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D \"OJPH_ENABLE_DPX_SUPPORT\"")
+else()
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DOJPH_ENABLE_DPX_SUPPORT")
+endif()
+
 set(OJPH_EXPAND src/apps/ojph_expand/ojph_expand.cpp src/apps/others/ojph_img_io.cpp)
 set(OJPH_COMPRESS src/apps/ojph_compress/ojph_compress.cpp src/apps/others/ojph_img_io.cpp)
 set(OJPH_IMG_IO_SSE41 src/apps/others/ojph_img_io_sse41.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,14 @@ if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24.0")
   endif()
 endif()
 
+set(CMAKE_CXX_FLAGS_ASAN
+  "-fsanitize=address -fno-optimize-sibling-calls -fsanitize-address-use-after-scope -fno-omit-frame-pointer -g -O1"
+  CACHE STRING "Flags used by the C++ compiler during AddressSanitizer builds."
+  FORCE)
+
 if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
+  message( STATUS "To use AddressSanitizer, use \"cmake .. -DCMAKE_BUILD_TYPE=asan\"" )
 endif()
 message(STATUS "Building ${CMAKE_BUILD_TYPE}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,13 +224,6 @@ if( OJPH_ENABLE_TIFF_SUPPORT )
 endif() 
 ############################################################
 
-# enable DPX support
-if (MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D \"OJPH_ENABLE_DPX_SUPPORT\"")
-else()
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DOJPH_ENABLE_DPX_SUPPORT")
-endif()
-
 set(OJPH_EXPAND src/apps/ojph_expand/ojph_expand.cpp src/apps/others/ojph_img_io.cpp)
 set(OJPH_COMPRESS src/apps/ojph_compress/ojph_compress.cpp src/apps/others/ojph_img_io.cpp)
 set(OJPH_IMG_IO_SSE41 src/apps/others/ojph_img_io_sse41.cpp)

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,13 @@ RUN apt-get update
 # disable interactive install 
 ENV DEBIAN_FRONTEND noninteractive
 
+# install developement tools
 RUN apt-get -y install cmake
 RUN apt-get -y install g++
 RUN apt-get -y install libtiff-dev
+
+# install developement debugging tools
+RUN apt-get -y install valgrind
 
 # OpenJPH
 WORKDIR /usr/src/openjph/
@@ -25,4 +29,4 @@ WORKDIR /usr/src/openjph
 # docker build --rm -f Dockerfile -t openjph:latest .
 # step 2 - run docker image
 # docker run -it --rm openjph:latest
-# docker run -it --rm -v C:\\temp:/usr/src/openjph/build openjph:latest
+# docker run -it --rm -v C:\\temp:/tmp openjph:latest

--- a/src/apps/common/ojph_img_io.h
+++ b/src/apps/common/ojph_img_io.h
@@ -112,7 +112,7 @@ namespace ojph {
     void close() { if(fh) { fclose(fh); fh = NULL; } fname = NULL; }
     void set_planar(bool planar) { this->planar = planar; }
 
-    //size get_size() { assert(fh); return size(width, height); }
+    size get_size() { assert(fh); return size(width, height); }
     ui32 get_width() { assert(fh); return width; }
     ui32 get_height() { assert(fh); return height; }
     ui32 get_max_val() { assert(fh); return max_val; }
@@ -237,13 +237,13 @@ namespace ojph {
     {
       file_handle = NULL;
       fname = NULL;
+
       line_buffer = NULL;
       line_buffer_16bit_samples = NULL;
 
-      width = height = num_comps = 0;
-      //bytes_per_sample = 0;
+      width = height = 0;
+      num_comps = 0;
 
-      //bytes_per_line = 0;
       number_of_samples_per_line = 0;
 
       cur_line = 0;
@@ -276,7 +276,6 @@ namespace ojph {
 
     size get_size() { assert(file_handle); return size(width, height); }
     ui32 get_num_components() { assert(file_handle); return num_comps; }
-    //void set_bit_depth(ui32 num_bit_depths, ui32* bit_depth);
     ui32 get_bit_depth(ui32 comp_num)
     {
       assert(file_handle && comp_num < num_comps); return bit_depth[comp_num];
@@ -292,13 +291,12 @@ namespace ojph {
 
   private:
     FILE* file_handle;
-    //size_t bytes_per_line;
 
     const char* fname;
     void* line_buffer;
     ui32 width, height;
     ui32 num_comps;
-    //ui32 bytes_per_sample;
+
     ui32 cur_line;
     ui32 bit_depth[4];
     bool is_signed[4];

--- a/src/apps/common/ojph_img_io.h
+++ b/src/apps/common/ojph_img_io.h
@@ -229,7 +229,9 @@ namespace ojph {
   };
 #endif /* OJPH_ENABLE_TIFF_SUPPORT */
 
-#ifdef OJPH_ENABLE_DPX_SUPPORT
+  // A simple DPX file reader supporting commonly used 10bit and 16bit formats  
+  // DPX is an uncompressed file format used by the motion picture industry
+  // DPX is standardized by SMPTE ST 268-1:2014
   class dpx_in : public image_in_base
   {
   public:
@@ -330,7 +332,6 @@ namespace ojph {
     size_t number_of_32_bit_words_per_line;
 
   };
-#endif // OJPH_ENABLE_DPX_SUPPORT
 
   ////////////////////////////////////////////////////////////////////////////
   //

--- a/src/apps/common/ojph_img_io.h
+++ b/src/apps/common/ojph_img_io.h
@@ -229,6 +229,108 @@ namespace ojph {
   };
 #endif /* OJPH_ENABLE_TIFF_SUPPORT */
 
+#ifdef OJPH_ENABLE_DPX_SUPPORT
+  class dpx_in : public image_in_base
+  {
+  public:
+    dpx_in()
+    {
+      file_handle = NULL;
+      fname = NULL;
+      line_buffer = NULL;
+      line_buffer_16bit_samples = NULL;
+
+      width = height = num_comps = 0;
+      //bytes_per_sample = 0;
+
+      //bytes_per_line = 0;
+
+      cur_line = 0;
+
+      bit_depth[3] = bit_depth[2] = bit_depth[1] = bit_depth[0] = 0;
+      is_signed[3] = is_signed[2] = is_signed[1] = is_signed[0] = false;
+      subsampling[3] = subsampling[2] = point(1, 1);
+      subsampling[1] = subsampling[0] = point(1, 1);
+
+      is_byte_swapping_necessary = false;
+    }
+    virtual ~dpx_in()
+    {
+      close();
+      if (line_buffer)
+        free(line_buffer);
+      if (line_buffer_16bit_samples)
+        free(line_buffer_16bit_samples);
+    }
+
+    void open(const char* filename);
+    virtual ui32 read(const line_buf* line, ui32 comp_num);
+    void close() {
+      if (file_handle) {
+        fclose(file_handle);
+        file_handle = NULL;
+      }
+      fname = NULL;
+    }
+
+    size get_size() { assert(file_handle); return size(width, height); }
+    ui32 get_num_components() { assert(file_handle); return num_comps; }
+    //void set_bit_depth(ui32 num_bit_depths, ui32* bit_depth);
+    ui32 get_bit_depth(ui32 comp_num)
+    {
+      assert(file_handle && comp_num < num_comps); return bit_depth[comp_num];
+    }
+    bool get_is_signed(ui32 comp_num)
+    {
+      assert(file_handle && comp_num < num_comps); return is_signed[comp_num];
+    }
+    point get_comp_subsampling(ui32 comp_num)
+    {
+      assert(file_handle && comp_num < num_comps); return subsampling[comp_num];
+    }
+
+  private:
+    FILE* file_handle;
+    //size_t bytes_per_line;
+
+    const char* fname;
+    void* line_buffer;
+    ui32 width, height;
+    ui32 num_comps;
+    //ui32 bytes_per_sample;
+    ui32 cur_line;
+    ui32 bit_depth[4];
+    bool is_signed[4];
+    point subsampling[4];
+
+    ui16* line_buffer_16bit_samples;
+
+    // DPX specific members
+    bool is_byte_swapping_necessary;
+    // file info header
+    ui32 offset_to_image_data_in_bytes;
+    char version[8];
+    ui32 total_image_file_size_in_bytes;
+    // image information header
+    ui16 image_orientation;
+    ui16 number_of_image_elements;
+    ui32 pixels_per_line;
+    ui32 lines_per_image_element;
+    // image element 1
+    ui32 data_sign_for_image_element_1;
+    ui8 descriptor_for_image_element_1;
+    ui8 transfer_characteristic_for_image_element_1;
+    ui8 colormetric_specification_for_image_element_1;
+    ui8 bitdepth_for_image_element_1;
+    ui16 packing_for_image_element_1;
+    ui16 encoding_for_image_element_1;
+    ui32 offset_to_data_for_image_element_1;
+
+    size_t number_of_32_bit_words_per_line;
+
+  };
+#endif // OJPH_ENABLE_DPX_SUPPORT
+
   ////////////////////////////////////////////////////////////////////////////
   //
   //

--- a/src/apps/common/ojph_img_io.h
+++ b/src/apps/common/ojph_img_io.h
@@ -244,6 +244,7 @@ namespace ojph {
       //bytes_per_sample = 0;
 
       //bytes_per_line = 0;
+      number_of_samples_per_line = 0;
 
       cur_line = 0;
 
@@ -302,6 +303,8 @@ namespace ojph {
     ui32 bit_depth[4];
     bool is_signed[4];
     point subsampling[4];
+
+    ui32 number_of_samples_per_line;
 
     ui16* line_buffer_16bit_samples;
 

--- a/src/apps/ojph_compress/ojph_compress.cpp
+++ b/src/apps/ojph_compress/ojph_compress.cpp
@@ -911,8 +911,62 @@ int main(int argc, char * argv[]) {
         raw.open(input_filename);
         base = &raw;
       }
+#ifdef OJPH_ENABLE_DPX_SUPPORT
+      else if (is_matching(".dpx", v))
+      {
+      dpx.open(input_filename);
+      ojph::param_siz siz = codestream.access_siz();
+      siz.set_image_extent(ojph::point(image_offset.x + dpx.get_size().w,
+        image_offset.y + dpx.get_size().h));
+      ojph::ui32 num_comps = dpx.get_num_components();
+      siz.set_num_components(num_comps);
+      //if (num_bit_depths > 0)
+      //  dpx.set_bit_depth(num_bit_depths, bit_depth);
+      for (ojph::ui32 c = 0; c < num_comps; ++c)
+        siz.set_component(c, dpx.get_comp_subsampling(c),
+          dpx.get_bit_depth(c), dpx.get_is_signed(c));
+      siz.set_image_offset(image_offset);
+      siz.set_tile_size(tile_size);
+      siz.set_tile_offset(tile_offset);
+
+      ojph::param_cod cod = codestream.access_cod();
+      cod.set_num_decomposition(num_decompositions);
+      cod.set_block_dims(block_size.w, block_size.h);
+      if (num_precincts != -1)
+        cod.set_precinct_size(num_precincts, precinct_size);
+      cod.set_progression_order(prog_order);
+      if (employ_color_transform == -1 && num_comps >= 3)
+        cod.set_color_transform(true);
       else
-#ifdef OJPH_ENABLE_TIFF_SUPPORT
+        cod.set_color_transform(employ_color_transform == 1);
+      cod.set_reversible(reversible);
+      if (!reversible && quantization_step != -1)
+        codestream.access_qcd().set_irrev_quant(quantization_step);
+      codestream.set_planar(false);
+      if (profile_string[0] != '\0')
+        codestream.set_profile(profile_string);
+      codestream.set_tilepart_divisions(tileparts_at_resolutions,
+        tileparts_at_components);
+      codestream.request_tlm_marker(tlm_marker);
+
+      if (dims.w != 0 || dims.h != 0)
+        OJPH_WARN(0x01000071,
+          "-dims option is not needed and was not used\n");
+      if (num_components != 0)
+        OJPH_WARN(0x01000072,
+          "-num_comps is not needed and was not used\n");
+      if (is_signed[0] != -1)
+        OJPH_WARN(0x01000073,
+          "-signed is not needed and was not used\n");
+      if (comp_downsampling[0].x != 0 || comp_downsampling[0].y != 0)
+        OJPH_WARN(0x01000075,
+          "-downsamp is not needed and was not used\n");
+
+      base = &dpx;
+      }
+#endif // !OJPH_ENABLE_DPX_SUPPORT
+      else
+#if defined( OJPH_ENABLE_TIFF_SUPPORT) && defined( OJPH_ENABLE_DPX_SUPPORT)
         OJPH_ERROR(0x01000041,
           "unknown input file extension; only pgm, ppm, dpx, tif(f),"
           " or raw(yuv) are supported\n");

--- a/src/apps/ojph_compress/ojph_compress.cpp
+++ b/src/apps/ojph_compress/ojph_compress.cpp
@@ -614,12 +614,11 @@ int main(int argc, char * argv[]) {
     ojph::ppm_in ppm;
     ojph::yuv_in yuv;
     ojph::raw_in raw;
+    ojph::dpx_in dpx;
 #ifdef OJPH_ENABLE_TIFF_SUPPORT
     ojph::tif_in tif;
 #endif // !OJPH_ENABLE_TIFF_SUPPORT
-#ifdef OJPH_ENABLE_DPX_SUPPORT
-    ojph::dpx_in dpx;
-#endif // OJPH_ENABLE_DPX_SUPPORT
+
     ojph::image_in_base *base = NULL;
     if (input_filename == NULL)
       OJPH_ERROR(0x01000007, "please specify an input file name using"
@@ -916,7 +915,6 @@ int main(int argc, char * argv[]) {
         raw.open(input_filename);
         base = &raw;
       }
-#ifdef OJPH_ENABLE_DPX_SUPPORT
       else if (is_matching(".dpx", v))
       {
       dpx.open(input_filename);
@@ -969,25 +967,16 @@ int main(int argc, char * argv[]) {
 
       base = &dpx;
       }
-#endif // !OJPH_ENABLE_DPX_SUPPORT
       else
-#if defined( OJPH_ENABLE_TIFF_SUPPORT) && defined( OJPH_ENABLE_DPX_SUPPORT)
+#if defined( OJPH_ENABLE_TIFF_SUPPORT)
         OJPH_ERROR(0x01000041,
           "unknown input file extension; only pgm, ppm, dpx, tif(f),"
           " or raw(yuv) are supported\n");
-#elif defined( OJPH_ENABLE_TIFF_SUPPORT)
-      OJPH_ERROR(0x01000041,
-      "unknown input file extension; only pgm, ppm, tif(f),"
-      " or raw(yuv) are supported\n");
-#elif defined( OJPH_ENABLE_DPX_SUPPORT)
-      OJPH_ERROR(0x01000041,
-      "unknown input file extension; only pgm, ppm, dpx,"
-      " or raw(yuv) are supported\n");
 #else
         OJPH_ERROR(0x01000041,
-          "unknown input file extension; only pgm, ppm, and raw(yuv))"
-          " are supported\n");
-#endif // !OJPH_ENABLE_TIFF_SUPPORT !OJPH_ENABLE_DPX_SUPPORT
+          "unknown input file extension; only pgm, ppm, dpx,"
+          " or raw(yuv) are supported\n");
+#endif // !OJPH_ENABLE_TIFF_SUPPORT 
     }
     else
       OJPH_ERROR(0x01000051,

--- a/src/apps/others/ojph_img_io.cpp
+++ b/src/apps/others/ojph_img_io.cpp
@@ -1445,8 +1445,17 @@ namespace ojph {
 #ifdef OJPH_ENABLE_DPX_SUPPORT  
   ////////////////////////////////////////////////////////////////////////////
 
-#define DPX_SWAP_BYTES_UINT32(x) ( (((x) & 0xff000000) >> 24) | (((x) & 0x00ff0000) >> 8) | (((x) & 0x0000ff00) << 8) | (((x) & 0x000000ff) << 24) )
-#define DPX_SWAP_BYTES_UINT16(x) ( (((x) & 0xff00)     >>  8) | (((x) & 0x00ff)     << 8) )
+  ui32 DPX_SWAP_BYTES_UINT32(ui32 x)
+  {
+    return (((x) & 0xff000000) >> 24) | (((x) & 0x00ff0000) >> 8) | (((x) & 0x0000ff00) << 8) | (((x) & 0x000000ff) << 24);
+  }
+
+  ui16 DPX_SWAP_BYTES_UINT16(ui16 x)
+  {
+    const ui16 most  = (ui16) ((x & 0xff00) >> 8);
+    const ui16 least = (ui16) ((x & 0x00ff) << 8);
+    return most | least;
+  }
 
   void dpx_in::open(const char* filename)
   {
@@ -1705,15 +1714,15 @@ namespace ojph {
         for (ui32 i = 0; i < number_of_samples_per_line; i += 3)
         {
           // R
-          line_buffer_16bit_samples[i + 0] = (line_buffer_ptr[word_index] & 0xFFC00000) >> 22;
+          line_buffer_16bit_samples[i + 0] = (ui16) ((line_buffer_ptr[word_index] & 0xFFC00000) >> 22);
           // G
-          line_buffer_16bit_samples[i + 1] = (line_buffer_ptr[word_index] & 0x003FF000) >> 12;
+          line_buffer_16bit_samples[i + 1] = (ui16) ((line_buffer_ptr[word_index] & 0x003FF000) >> 12);
           // B
-          line_buffer_16bit_samples[i + 2] = (line_buffer_ptr[word_index] & 0x00000FFC) >> 2;
+          line_buffer_16bit_samples[i + 2] = (ui16) ((line_buffer_ptr[word_index] & 0x00000FFC) >>  2);
           word_index++;
         }
       }
-      if (16 == bitdepth_for_image_element_1 && 3 == num_comps)
+      else if (16 == bitdepth_for_image_element_1 && 3 == num_comps)
       {
         ui16* line_buffer_ptr = (ui16*)line_buffer;
         for (ui32 i = 0; i < number_of_samples_per_line; i++)
@@ -1723,7 +1732,8 @@ namespace ojph {
       }
       else
       {
-        OJPH_ERROR(0x0300000B2, "file %s uses DPX image formats that are not yet supported by this software", fname);
+        OJPH_ERROR(0x0300000B2, "file %s uses DPX image formats that are not yet supported by this software\n bitdepth_for_image_element_1 = %d\n num_comps=%d\npacking_for_image_element_1=%d\n descriptor_for_image_element_1=%d", 
+          fname, bitdepth_for_image_element_1, num_comps, packing_for_image_element_1, descriptor_for_image_element_1);
       }
       
       cur_line++;

--- a/src/apps/others/ojph_img_io.cpp
+++ b/src/apps/others/ojph_img_io.cpp
@@ -1198,4 +1198,291 @@ namespace ojph {
 
     return w;
   }
-}
+
+
+  ////////////////////////////////////////////////////////////////////////////
+  //
+  //
+  //
+  //
+  //
+  ////////////////////////////////////////////////////////////////////////////
+#ifdef OJPH_ENABLE_DPX_SUPPORT  
+  ////////////////////////////////////////////////////////////////////////////
+
+#define DPX_SWAP_BYTES_UINT32(x) ( (((x) & 0xff000000) >> 24) | (((x) & 0x00ff0000) >> 8) | (((x) & 0x0000ff00) << 8) | (((x) & 0x000000ff) << 24) )
+#define DPX_SWAP_BYTES_UINT16(x) ( (((x) & 0xff00)     >>  8) | (((x) & 0x00ff)     << 8) )
+
+  void dpx_in::open(const char* filename)
+  {
+    assert(file_handle == 0);
+    file_handle = fopen(filename, "rb");
+    if (0 == file_handle)
+      OJPH_ERROR(0x0300000B1, "Unable to open file %s", filename);
+    fname = filename;
+
+    // read magic number
+    uint32_t magic_number;
+    if (fread(&magic_number, sizeof(uint32_t), 1, file_handle) != 1)
+    {
+      close();
+      OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
+    }
+
+    // check magic number
+    const uint32_t dpx_magic_number = 0x53445058;
+    if (dpx_magic_number == magic_number)
+    {
+      // magic number is a match - no byte swapping necessary
+      is_byte_swapping_necessary = false;
+    }
+    else if (dpx_magic_number == DPX_SWAP_BYTES_UINT32(magic_number))
+    {
+      // magic number is a match after bytes swapping - the data read from this file needs byte swapping
+      is_byte_swapping_necessary = true;
+    }
+    else
+    {
+      close();
+      OJPH_ERROR(0x0300000B2, "Error reading file %s - this does not appear to be a valid DPX file.  It has magic number = 0x%08X.  The magic number of a DPX file is 0x%08X.", 
+        filename, magic_number, dpx_magic_number );
+    }
+
+    // read offset to data
+    if (fread(&offset_to_image_data_in_bytes, sizeof(uint32_t), 1, file_handle) != 1)
+    {
+      close();
+      OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
+    }
+    if (is_byte_swapping_necessary)
+      offset_to_image_data_in_bytes = DPX_SWAP_BYTES_UINT32(offset_to_image_data_in_bytes);
+    // read version
+    if (fread(version, sizeof(uint8_t), 8, file_handle) != 8)
+    {
+      close();
+      OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
+    }
+    // read image file size in bytes
+    if (fread(&total_image_file_size_in_bytes, sizeof(uint32_t), 1, file_handle) != 1)
+    {
+      close();
+      OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
+    }
+    if (is_byte_swapping_necessary)
+      total_image_file_size_in_bytes = DPX_SWAP_BYTES_UINT32(total_image_file_size_in_bytes);
+    
+    // seek to image info header
+    if (fseek(file_handle,768, SEEK_SET) != 0)
+    {
+      close();
+      OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
+    }
+    // read image_orientation
+    if (fread(&image_orientation, sizeof(uint16_t), 1, file_handle) != 1)
+    {
+      close();
+      OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
+    }
+    if (is_byte_swapping_necessary)
+      image_orientation = DPX_SWAP_BYTES_UINT16(image_orientation);
+    // read number of image elements
+    if (fread(&number_of_image_elements, sizeof(uint16_t), 1, file_handle) != 1)
+    {
+      close();
+      OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
+    }
+    if (is_byte_swapping_necessary)
+      number_of_image_elements = DPX_SWAP_BYTES_UINT16(number_of_image_elements);
+    // read pixels per line
+    if (fread(&pixels_per_line, sizeof(uint32_t), 1, file_handle) != 1)
+    {
+      close();
+      OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
+    }
+    if (is_byte_swapping_necessary)
+      pixels_per_line = DPX_SWAP_BYTES_UINT32(pixels_per_line);
+
+    // read lines per image element
+    if (fread(&lines_per_image_element, sizeof(uint32_t), 1, file_handle) != 1)
+    {
+      close();
+      OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
+    }
+    if (is_byte_swapping_necessary)
+      lines_per_image_element = DPX_SWAP_BYTES_UINT32(lines_per_image_element);
+
+    // seek to data structure for image element 1
+    if (fseek(file_handle, 780, SEEK_SET) != 0)
+    {
+      close();
+      OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
+    }
+    // read data sign for image element
+    if (fread(&data_sign_for_image_element_1, sizeof(uint32_t), 1, file_handle) != 1)
+    {
+      close();
+      OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
+    }
+    if (is_byte_swapping_necessary)
+      data_sign_for_image_element_1 = DPX_SWAP_BYTES_UINT32(data_sign_for_image_element_1);
+    // seek to core data elements in image element 1
+    if (fseek(file_handle, 800, SEEK_SET) != 0)
+    {
+      close();
+      OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
+    }
+    // read descriptor
+    if (fread(&descriptor_for_image_element_1, sizeof(uint8_t), 1, file_handle) != 1)
+    {
+      close();
+      OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
+    }
+    // read transfer characteristic
+    if (fread(&transfer_characteristic_for_image_element_1, sizeof(uint8_t), 1, file_handle) != 1)
+    {
+      close();
+      OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
+    }
+    // read colorimetric specification
+    if (fread(&colormetric_specification_for_image_element_1, sizeof(uint8_t), 1, file_handle) != 1)
+    {
+      close();
+      OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
+    }
+    // read bit depth
+    if (fread(&bitdepth_for_image_element_1, sizeof(uint8_t), 1, file_handle) != 1)
+    {
+      close();
+      OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
+    }
+    // read packing
+    if (fread(&packing_for_image_element_1, sizeof(uint16_t), 1, file_handle) != 1)
+    {
+      close();
+      OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
+    }
+    if (is_byte_swapping_necessary)
+      packing_for_image_element_1 = DPX_SWAP_BYTES_UINT16(packing_for_image_element_1);
+    // read encoding
+    if (fread(&encoding_for_image_element_1, sizeof(uint16_t), 1, file_handle) != 1)
+    {
+      close();
+      OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
+    }
+    if (is_byte_swapping_necessary)
+      encoding_for_image_element_1 = DPX_SWAP_BYTES_UINT16(encoding_for_image_element_1);
+    // read offset to data
+    if (fread(&offset_to_data_for_image_element_1, sizeof(uint32_t), 1, file_handle) != 1)
+    {
+      close();
+      OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
+    }
+    if (is_byte_swapping_necessary)
+      offset_to_data_for_image_element_1 = DPX_SWAP_BYTES_UINT32(offset_to_data_for_image_element_1);
+
+    // set to starting point of image data
+    if (fseek(file_handle, offset_to_image_data_in_bytes, SEEK_SET) != 0)
+    {
+      close();
+      OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
+    }
+
+    // set ojph properties
+    width = pixels_per_line;
+    height = lines_per_image_element;
+    num_comps = 3;  // not that descriptor field can indicate 1, 3, or 4 components
+    for ( ojph::ui32 c = 0; c < get_num_components(); c++)
+    {
+      bit_depth[c] = bitdepth_for_image_element_1;
+      is_signed[c] = false;
+      subsampling[c] = point(1,1);
+    }
+    //bytes_per_sample = (bitdepth_for_image_element_1 + 7) / 8;
+    //bytes_per_line = bytes_per_sample * width * num_comps;
+
+    // handle DPX image data packing in file 
+    ui32 number_of_samples_per_32_bit_word = 32 / bitdepth_for_image_element_1;
+    number_of_32_bit_words_per_line = (width * num_comps + (number_of_samples_per_32_bit_word - 1)) / number_of_samples_per_32_bit_word;
+
+    cur_line = 0;
+
+    // allocate linebuffer to hold a line of image data from the file
+    line_buffer = malloc(number_of_32_bit_words_per_line * sizeof(ui32) );
+    if (NULL == line_buffer)
+      OJPH_ERROR(0x0300000B2, "Unable to allocate %d bytes for line_buffer[] "
+        "for file %s", number_of_32_bit_words_per_line * sizeof(ui32), filename);
+
+    // allocate line_buffer_16bit_samples to hold a line of image data in memory
+    line_buffer_16bit_samples = (ui16*) malloc(width * num_comps * sizeof(ui16));
+    if (NULL == line_buffer_16bit_samples)
+      OJPH_ERROR(0x0300000B2, "Unable to allocate %d bytes for line_buffer_16bit_samples[] "
+        "for file %s", width * num_comps * sizeof(ui16), filename);
+
+
+    cur_line = 0;
+
+    return;
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  ui32 dpx_in::read(const line_buf* line, ui32 comp_num)
+  {
+    assert(file_handle != 0 && comp_num < num_comps);
+    assert((ui32)line->size >= width);
+
+    //printf("cur_line = %d comp_num = %d\n", cur_line, comp_num);
+
+    // read from file if trying to read the first component
+    if (0 == comp_num)
+    {
+      if (fread(line_buffer, sizeof(uint32_t), number_of_32_bit_words_per_line, file_handle) != number_of_32_bit_words_per_line)
+      {
+        close();
+        OJPH_ERROR(0x0300000B2, "Error reading file %s", fname);
+      }
+
+      if (true == is_byte_swapping_necessary)
+      {
+        ui32 *line_buffer_ptr = (ui32*)line_buffer;
+        for (size_t i = 0; i < number_of_32_bit_words_per_line; i++)
+        {
+          line_buffer_ptr[i] = DPX_SWAP_BYTES_UINT32(line_buffer_ptr[i]);
+        }
+      }
+
+      // extract samples from 32bit words from file read into RGB ordered buffer
+      ui32 word_index = 0;
+      if (10 == bitdepth_for_image_element_1 && 3 == num_comps && packing_for_image_element_1 == 1)
+      {
+        ui32* line_buffer_ptr = (ui32*)line_buffer;
+        for (ui32 i = 0; i < width*num_comps; i += 3)
+        {
+          // R
+          line_buffer_16bit_samples[i + 0] = (line_buffer_ptr[word_index] & 0xFFC00000) >> 22;
+          // G
+          line_buffer_16bit_samples[i + 1] = (line_buffer_ptr[word_index] & 0x003FF000) >> 12;
+          // B
+          line_buffer_16bit_samples[i + 2] = (line_buffer_ptr[word_index] & 0x00000FFC) >>  2;
+          word_index++;
+        }
+      }
+      else
+      {
+        OJPH_ERROR(0x0300000B2, "file %s uses DPX image formats that are not yet supported by this software", fname);
+      }
+      
+      cur_line++;
+    }
+
+    // copy sample data from the unpacked line buffer into a single-component buffer to be used by the openjph core
+    const ui16* sp = (ui16*)line_buffer_16bit_samples + comp_num;
+    si32* dp = line->i32;
+    for (ui32 i = width; i > 0; --i, sp += num_comps)
+      *dp++ = (si32)*sp;
+
+    return width;
+  }
+
+#endif /* OJPH_ENABLE_DPX_SUPPORT */
+
+} 

--- a/src/apps/others/ojph_img_io.cpp
+++ b/src/apps/others/ojph_img_io.cpp
@@ -1442,7 +1442,7 @@ namespace ojph {
   //
   //
   ////////////////////////////////////////////////////////////////////////////
-#ifdef OJPH_ENABLE_DPX_SUPPORT  
+  
   ////////////////////////////////////////////////////////////////////////////
 
   ui32 DPX_SWAP_BYTES_UINT32(ui32 x)
@@ -1754,7 +1754,5 @@ namespace ojph {
 
     return width;
   }
-
-#endif /* OJPH_ENABLE_DPX_SUPPORT */
 
 } 

--- a/src/apps/others/ojph_img_io.cpp
+++ b/src/apps/others/ojph_img_io.cpp
@@ -1521,6 +1521,7 @@ namespace ojph {
       close();
       OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
     }
+
     // read image_orientation
     if (fread(&image_orientation, sizeof(uint16_t), 1, file_handle) != 1)
     {
@@ -1529,6 +1530,7 @@ namespace ojph {
     }
     if (is_byte_swapping_necessary)
       image_orientation = DPX_SWAP_BYTES_UINT16(image_orientation);
+
     // read number of image elements
     if (fread(&number_of_image_elements, sizeof(uint16_t), 1, file_handle) != 1)
     {
@@ -1537,6 +1539,7 @@ namespace ojph {
     }
     if (is_byte_swapping_necessary)
       number_of_image_elements = DPX_SWAP_BYTES_UINT16(number_of_image_elements);
+
     // read pixels per line
     if (fread(&pixels_per_line, sizeof(uint32_t), 1, file_handle) != 1)
     {
@@ -1561,6 +1564,7 @@ namespace ojph {
       close();
       OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
     }
+
     // read data sign for image element
     if (fread(&data_sign_for_image_element_1, sizeof(uint32_t), 1, file_handle) != 1)
     {
@@ -1569,36 +1573,42 @@ namespace ojph {
     }
     if (is_byte_swapping_necessary)
       data_sign_for_image_element_1 = DPX_SWAP_BYTES_UINT32(data_sign_for_image_element_1);
+
     // seek to core data elements in image element 1
     if (fseek(file_handle, 800, SEEK_SET) != 0)
     {
       close();
       OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
     }
+
     // read descriptor
     if (fread(&descriptor_for_image_element_1, sizeof(uint8_t), 1, file_handle) != 1)
     {
       close();
       OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
     }
+
     // read transfer characteristic
     if (fread(&transfer_characteristic_for_image_element_1, sizeof(uint8_t), 1, file_handle) != 1)
     {
       close();
       OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
     }
+
     // read colorimetric specification
     if (fread(&colormetric_specification_for_image_element_1, sizeof(uint8_t), 1, file_handle) != 1)
     {
       close();
       OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
     }
+
     // read bit depth
     if (fread(&bitdepth_for_image_element_1, sizeof(uint8_t), 1, file_handle) != 1)
     {
       close();
       OJPH_ERROR(0x0300000B2, "Error reading file %s", filename);
     }
+
     // read packing
     if (fread(&packing_for_image_element_1, sizeof(uint16_t), 1, file_handle) != 1)
     {
@@ -1607,6 +1617,7 @@ namespace ojph {
     }
     if (is_byte_swapping_necessary)
       packing_for_image_element_1 = DPX_SWAP_BYTES_UINT16(packing_for_image_element_1);
+
     // read encoding
     if (fread(&encoding_for_image_element_1, sizeof(uint16_t), 1, file_handle) != 1)
     {
@@ -1615,6 +1626,7 @@ namespace ojph {
     }
     if (is_byte_swapping_necessary)
       encoding_for_image_element_1 = DPX_SWAP_BYTES_UINT16(encoding_for_image_element_1);
+      
     // read offset to data
     if (fread(&offset_to_data_for_image_element_1, sizeof(uint32_t), 1, file_handle) != 1)
     {
@@ -1634,15 +1646,13 @@ namespace ojph {
     // set ojph properties
     width = pixels_per_line;
     height = lines_per_image_element;
-    num_comps = 3;  // not that descriptor field can indicate 1, 3, or 4 components
+    num_comps = 3;  // note that descriptor field can indicate 1, 3, or 4 components
     for ( ojph::ui32 c = 0; c < get_num_components(); c++)
     {
       bit_depth[c] = bitdepth_for_image_element_1;
       is_signed[c] = false;
       subsampling[c] = point(1,1);
     }
-    //bytes_per_sample = (bitdepth_for_image_element_1 + 7) / 8;
-    //bytes_per_line = bytes_per_sample * width * num_comps;
 
     // handle DPX image data packing in file 
     ui32 number_of_samples_per_32_bit_word = 32 / bitdepth_for_image_element_1;
@@ -1663,7 +1673,6 @@ namespace ojph {
       OJPH_ERROR(0x0300000B2, "Unable to allocate %d bytes for line_buffer_16bit_samples[] "
         "for file %s", width * num_comps * sizeof(ui16), filename);
 
-
     cur_line = 0;
 
     return;
@@ -1674,8 +1683,6 @@ namespace ojph {
   {
     assert(file_handle != 0 && comp_num < num_comps);
     assert((ui32)line->size >= width);
-
-    //printf("cur_line = %d comp_num = %d\n", cur_line, comp_num);
 
     // read from file if trying to read the first component
     if (0 == comp_num)


### PR DESCRIPTION
This PR add DPX file read support to ojph_compress

DPX (SMPTE ST268) is a common file format used in the motion picture to store uncompressed 10bit or 16bit RGB data.

Motion Picture film scanners typically output DPX files.  Some workflows also use DPX as a final format for color graded finished video masters.  The most common DPX file variant stores three 10 bit samples (RGB) in a single 32-bit word.

Lossless compression of DPX film scans and video masters is a good application for HTJ2K.