### PR TITLE
make comment_exchange string const

### DIFF
--- a/src/core/codestream/ojph_params.cpp
+++ b/src/core/codestream/ojph_params.cpp
@@ -368,7 +368,7 @@ namespace ojph {
   ////////////////////////////////////////////////////////////////////////////
 
   //////////////////////////////////////////////////////////////////////////
-  void comment_exchange::set_string(char* str)
+  void comment_exchange::set_string(const char* str)
   { 
     size_t t = strlen(str);
     if (len > 65531)
@@ -380,7 +380,7 @@ namespace ojph {
   }
 
   //////////////////////////////////////////////////////////////////////////
-  void comment_exchange::set_data(char* data, ui16 len)
+  void comment_exchange::set_data(const char* data, ui16 len)
   { 
     if (len > 65531)
       OJPH_ERROR(0x000500C2, 

--- a/src/core/common/ojph_params.h
+++ b/src/core/common/ojph_params.h
@@ -176,12 +176,12 @@ namespace ojph {
   public:
     comment_exchange() : data(NULL), len(0), Rcom(0) {}
     OJPH_EXPORT
-    void set_string(char* str);
+    void set_string(const char* str);
     OJPH_EXPORT
-    void set_data(char* data, ui16 len);
+    void set_data(const char* data, ui16 len);
 
   private:
-    char* data;
+    const char* data;
     ui16 len;
     ui16 Rcom;
   };


### PR DESCRIPTION
The comment (string/data) is not modified, and can be `const`. This makes it easier to pass in something from C++ std::string.

This would be an API change, so OK if you'd prefer to drop it.