### PR TITLE
add accessors for tilepart division

### DIFF
--- a/src/core/codestream/ojph_codestream.cpp
+++ b/src/core/codestream/ojph_codestream.cpp
@@ -109,6 +109,20 @@ namespace ojph {
   }
 
   ////////////////////////////////////////////////////////////////////////////
+  bool codestream::is_tilepart_division_at_resolutions()
+  {
+    ui32 res = state->get_tilepart_div() & OJPH_TILEPART_RESOLUTIONS;
+    return res ? true : false;
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  bool codestream::is_tilepart_division_at_components()
+  {
+    ui32 comp = state->get_tilepart_div() & OJPH_TILEPART_COMPONENTS;
+    return comp ? true : false;
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
   void codestream::request_tlm_marker(bool needed)
   {
     state->request_tlm_marker(needed);

--- a/src/core/codestream/ojph_codestream_local.cpp
+++ b/src/core/codestream/ojph_codestream_local.cpp
@@ -68,7 +68,7 @@ namespace ojph {
       employ_color_transform = false;
       planar = -1;
       profile = OJPH_PN_UNDEFINED;
-      tilepart_div = OJPH_TILEPART_NODIVSIONS;
+      tilepart_div = OJPH_TILEPART_NO_DIVISIONS;
       need_tlm = false;
 
       cur_comp = 0;

--- a/src/core/codestream/ojph_params_local.h
+++ b/src/core/codestream/ojph_params_local.h
@@ -95,8 +95,8 @@ namespace ojph {
   const char OJPH_PN_STRING_IMF[] = "IMF";
 
   ////////////////////////////////////////////////////////////////////////////
-  enum OJPH_TILEPART_DIVISONS: ui32 {
-    OJPH_TILEPART_NODIVSIONS  = 0x0, // no divisions to tile parts
+  enum OJPH_TILEPART_DIVISIONS: ui32 {
+    OJPH_TILEPART_NO_DIVISIONS  = 0x0, // no divisions to tile parts
     OJPH_TILEPART_RESOLUTIONS = 0x1,
     OJPH_TILEPART_COMPONENTS  = 0x2,
     OJPH_TILEPART_LAYERS      = 0x4, // these are meaningless with HTJ2K

--- a/src/core/codestream/ojph_tile.cpp
+++ b/src/core/codestream/ojph_tile.cpp
@@ -412,7 +412,7 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     void tile::fill_tlm(param_tlm *tlm)
     {
-      if (tilepart_div == OJPH_TILEPART_NODIVSIONS) {
+      if (tilepart_div == OJPH_TILEPART_NO_DIVISIONS) {
         tlm->set_next_pair(sot.get_tile_index(), this->num_bytes);
       }
       else if (tilepart_div == OJPH_TILEPART_RESOLUTIONS)
@@ -471,7 +471,7 @@ namespace ojph {
         max_decompositions = ojph_max(max_decompositions,
           comps[c].get_num_decompositions());
 
-      if (tilepart_div == OJPH_TILEPART_NODIVSIONS)
+      if (tilepart_div == OJPH_TILEPART_NO_DIVISIONS)
       {
         //write tile header
         if (!sot.write(file, this->num_bytes))
@@ -487,7 +487,7 @@ namespace ojph {
       //sequence the writing of precincts according to progression order
       if (prog_order == OJPH_PO_LRCP || prog_order == OJPH_PO_RLCP)
       {
-        if (tilepart_div == OJPH_TILEPART_NODIVSIONS) 
+        if (tilepart_div == OJPH_TILEPART_NO_DIVISIONS)
         {
           for (ui32 r = 0; r <= max_decompositions; ++r)
             for (ui32 c = 0; c < num_comps; ++c)

--- a/src/core/common/ojph_codestream.h
+++ b/src/core/common/ojph_codestream.h
@@ -78,6 +78,11 @@ namespace ojph {
     void set_profile(const char* s);
     OJPH_EXPORT    
     void set_tilepart_divisions(bool at_resolutions, bool at_components);
+    OJPH_EXPORT
+    bool is_tilepart_division_at_resolutions();
+    OJPH_EXPORT
+    bool is_tilepart_division_at_components();
+
     OJPH_EXPORT    
     void request_tlm_marker(bool needed);
     OJPH_EXPORT


### PR DESCRIPTION
This exposes the current tilepart division setting. This avoids needing a shadow variable in the libheif plugin.

Also fixes a couple of typos in the applicable enumeration. I can split that out as a separate PR if preferred.
