### PR TITLE
include ojph_arch.h in ojph_codestream.h and ojph_params.h to compensate for OJPH_EXPORT definition

### DIFF
--- a/src/core/common/ojph_codestream.h
+++ b/src/core/common/ojph_codestream.h
@@ -41,6 +41,7 @@
 
 #include <cstdlib>
 
+#include "ojph_arch.h"
 #include "ojph_defs.h"
 
 namespace ojph {

--- a/src/core/common/ojph_params.h
+++ b/src/core/common/ojph_params.h
@@ -39,6 +39,7 @@
 #ifndef OJPH_PARAMS_H
 #define OJPH_PARAMS_H
 
+#include "ojph_arch.h"
 #include "ojph_base.h"
 
 namespace ojph {


### PR DESCRIPTION
These headers use `OJPH_EXPORT` but do not include the `ojph_arch.h` header that provides it. That potentially causes compile-time errors when using those headers, depending on what other headers are used and the order of inclusion.