### PR TITLE
Allow OpenJPH to be exported by cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,9 +149,15 @@ endif()
 
 include(GNUInstallDirs)
 install(TARGETS openjph
+  EXPORT openjph_targets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(EXPORT openjph_targets
+  FILE openjph_targets.cmake
+  DESTINATION lib/cmake/openjph
+)
 
 install(DIRECTORY src/core/common/
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openjph

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,15 +149,9 @@ endif()
 
 include(GNUInstallDirs)
 install(TARGETS openjph
-  EXPORT openjph_targets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
-
-install(EXPORT openjph_targets
-  FILE openjph_targets.cmake
-  DESTINATION lib/cmake/openjph
-)
 
 install(DIRECTORY src/core/common/
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openjph

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -38,8 +38,8 @@ if(EMSCRIPTEN)
   add_library(openjph ${SOURCES})
   add_library(openjphsimd ${SOURCES} ${CODESTREAM_WASM} ${CODING_WASM} ${TRANSFORM_WASM})
 
-  target_include_directories(openjph PUBLIC common)
-  target_include_directories(openjphsimd PUBLIC common)
+  target_include_directories(openjph PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}common> $<INSTALL_INTERFACE:include>)
+  target_include_directories(openjphsimd PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}common> $<INSTALL_INTERFACE:include>)
 
   target_compile_options(openjphsimd PRIVATE -DOJPH_ENABLE_WASM_SIMD -msimd128)
 
@@ -124,7 +124,7 @@ if (BUILD_SHARED_LIBS AND WIN32)
 endif()
 
 ## include library version/name
-target_include_directories(openjph PUBLIC common)
+target_include_directories(openjph PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/common> $<INSTALL_INTERFACE:include>)
 target_compile_definitions(openjph PUBLIC _FILE_OFFSET_BITS=64)
 
 if (MSVC)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -38,8 +38,8 @@ if(EMSCRIPTEN)
   add_library(openjph ${SOURCES})
   add_library(openjphsimd ${SOURCES} ${CODESTREAM_WASM} ${CODING_WASM} ${TRANSFORM_WASM})
 
-  target_include_directories(openjph PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}common> $<INSTALL_INTERFACE:include>)
-  target_include_directories(openjphsimd PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}common> $<INSTALL_INTERFACE:include>)
+  target_include_directories(openjph PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/common> $<INSTALL_INTERFACE:include>)
+  target_include_directories(openjphsimd PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/common> $<INSTALL_INTERFACE:include>)
 
   target_compile_options(openjphsimd PRIVATE -DOJPH_ENABLE_WASM_SIMD -msimd128)
 


### PR DESCRIPTION
In order to be exported by cmake (`INSTALL(EXPORT...)`), header directories need to be relative, but they need to be absolute when building.

See example: https://github.com/AcademySoftwareFoundation/openexr/blob/b2b882adb7c0ec1e0eeb235e3ddff6f3657a4f12/cmake/OpenEXRSetup.cmake#L301

Closes https://github.com/aous72/OpenJPH/issues/167
