### PR TITLE
Supporting differing components in QCD

### DIFF
--- a/src/apps/ojph_compress/ojph_compress.cpp
+++ b/src/apps/ojph_compress/ojph_compress.cpp
@@ -842,11 +842,11 @@ int main(int argc, char * argv[]) {
           // Of course for .pfm images all components should have the same
           // bit depth and signedness.
           if (all_the_same)
-            nlt.set_nonlinearity(ojph::param_nlt::ALL_COMPS, 
+            nlt.set_nonlinear_transform(ojph::param_nlt::ALL_COMPS, 
               ojph::param_nlt::OJPH_NLT_BINARY_COMPLEMENT_NLT);
           else
             for (ojph::ui32 c = 0; c < num_comps; ++c)
-              nlt.set_nonlinearity(c, 
+              nlt.set_nonlinear_transform(c, 
                 ojph::param_nlt::OJPH_NLT_BINARY_COMPLEMENT_NLT);
         }
         else

--- a/src/apps/ojph_compress/ojph_compress.cpp
+++ b/src/apps/ojph_compress/ojph_compress.cpp
@@ -834,11 +834,20 @@ int main(int argc, char * argv[]) {
 
         ojph::param_nlt nlt = codestream.access_nlt();
         if (reversible) {
+          // Note: Even if only ALL_COMPS is set to 
+          // OJPH_NLT_BINARY_COMPLEMENT_NLT, the library can decide if
+          // one ALL_COMPS NLT marker segment is needed, or multiple 
+          // per component NLT marker segments are needed (when the components
+          // have different bit depths or signedness).
+          // Of course for .pfm images all components should have the same
+          // bit depth and signedness.
           if (all_the_same)
-            nlt.set_type3_transformation(ojph::param_nlt::ALL_COMPS, true);
+            nlt.set_nonlinearity(ojph::param_nlt::ALL_COMPS, 
+              ojph::param_nlt::OJPH_NLT_BINARY_COMPLEMENT_NLT);
           else
             for (ojph::ui32 c = 0; c < num_comps; ++c)
-              nlt.set_type3_transformation(c, true);
+              nlt.set_nonlinearity(c, 
+                ojph::param_nlt::OJPH_NLT_BINARY_COMPLEMENT_NLT);
         }
         else
           OJPH_ERROR(0x01000093, "We currently support lossless only for "

--- a/src/apps/ojph_expand/ojph_expand.cpp
+++ b/src/apps/ojph_expand/ojph_expand.cpp
@@ -269,6 +269,12 @@ int main(int argc, char *argv[]) {
       }
       else if (is_matching(".pfm", v))
       {
+        OJPH_INFO(0x02000011, "Note: The .pfm implementation is "
+          "experimental. It is developed for me the test NLT marker segments. "
+          "For this reason, I am restricting it to images that employ the "
+          "NLT marker segment, with the assumption that original values are "
+          "floating-point numbers.");
+
         codestream.set_planar(false);
         ojph::param_siz siz = codestream.access_siz();
         ojph::param_cod cod = codestream.access_cod();
@@ -294,8 +300,10 @@ int main(int argc, char *argv[]) {
         for (ojph::ui32 c = 0; c < siz.get_num_components(); ++c) {
           ojph::ui8 bd = 0;
           bool is = true;
-          bool result = nlt.get_type3_transformation(c, bd, is);
-          if (result == false)
+          ojph::ui8 nl_type;
+          bool result = nlt.get_nonlinearity(c, bd, is, nl_type);
+          if (result == false || 
+              nl_type != ojph::param_nlt::OJPH_NLT_BINARY_COMPLEMENT_NLT)
             OJPH_ERROR(0x0200000E,
               "This codestream is not supported; it does not have an "
               "NLT segment marker for this component (or no default NLT "

--- a/src/apps/ojph_expand/ojph_expand.cpp
+++ b/src/apps/ojph_expand/ojph_expand.cpp
@@ -301,7 +301,7 @@ int main(int argc, char *argv[]) {
           ojph::ui8 bd = 0;
           bool is = true;
           ojph::ui8 nl_type;
-          bool result = nlt.get_nonlinearity(c, bd, is, nl_type);
+          bool result = nlt.get_nonlinear_transform(c, bd, is, nl_type);
           if (result == false || 
               nl_type != ojph::param_nlt::OJPH_NLT_BINARY_COMPLEMENT_NLT)
             OJPH_ERROR(0x0200000E,

--- a/src/core/codestream/ojph_codeblock.cpp
+++ b/src/core/codestream/ojph_codeblock.cpp
@@ -54,17 +54,14 @@ namespace ojph {
 
     //////////////////////////////////////////////////////////////////////////
     void codeblock::pre_alloc(codestream *codestream, ui32 comp_num,
-                              const size& nominal)
+                              const size& nominal, ui32 precision)
     {
       mem_fixed_allocator* allocator = codestream->get_allocator();
 
       assert(byte_alignment / sizeof(ui32) > 1);
       const ui32 f = byte_alignment / sizeof(ui32) - 1;
       ui32 stride = (nominal.w + f) & ~f; // a multiple of 8
-
-      const param_siz* sz = codestream->get_siz();
-      const param_cod* cd = codestream->get_cod(comp_num);
-      ui32 precision = cd->propose_precision(sz, comp_num);
+      
       if (precision <= 32)
         allocator->pre_alloc_data<ui32>(nominal.h * (size_t)stride, 0);
       else
@@ -76,7 +73,8 @@ namespace ojph {
                                    subband *parent, const size& nominal,
                                    const size& cb_size,
                                    coded_cb_header* coded_cb,
-                                   ui32 K_max, int line_offset)
+                                   ui32 K_max, int line_offset,
+                                   ui32 precision)
     {
       mem_fixed_allocator* allocator = codestream->get_allocator();
 
@@ -84,16 +82,12 @@ namespace ojph {
       this->stride = (nominal.w + f) & ~f; // a multiple of 8
       this->buf_size = this->stride * nominal.h;
 
-      ui32 comp_num = parent->get_parent()->get_comp_num();
-      const param_siz* sz = codestream->get_siz();
-      const param_cod* cd = codestream->get_cod(comp_num);
-      ui32 bit_depth = cd->propose_precision(sz, comp_num);
-      if (bit_depth <= 32) {
-        precision = BUF32;
+      if (precision <= 32) {
+        this->precision = BUF32;
         this->buf32 = allocator->post_alloc_data<ui32>(this->buf_size, 0);
       }
       else {
-        precision = BUF64;
+        this->precision = BUF64;
         this->buf64 = allocator->post_alloc_data<ui64>(this->buf_size, 0);
       }
 

--- a/src/core/codestream/ojph_codeblock.cpp
+++ b/src/core/codestream/ojph_codeblock.cpp
@@ -53,8 +53,8 @@ namespace ojph {
   {
 
     //////////////////////////////////////////////////////////////////////////
-    void codeblock::pre_alloc(codestream *codestream, ui32 comp_num,
-                              const size& nominal, ui32 precision)
+    void codeblock::pre_alloc(codestream *codestream, const size& nominal, 
+                              ui32 precision)
     {
       mem_fixed_allocator* allocator = codestream->get_allocator();
 

--- a/src/core/codestream/ojph_codeblock.h
+++ b/src/core/codestream/ojph_codeblock.h
@@ -71,8 +71,8 @@ namespace ojph {
       };
 
     public:
-      static void pre_alloc(codestream *codestream, ui32 comp_num, 
-                            const size& nominal, ui32 precision);
+      static void pre_alloc(codestream *codestream, const size& nominal, 
+                            ui32 precision);
       void finalize_alloc(codestream *codestream, subband* parent,
                           const size& nominal, const size& cb_size,
                           coded_cb_header* coded_cb,

--- a/src/core/codestream/ojph_codeblock.h
+++ b/src/core/codestream/ojph_codeblock.h
@@ -72,11 +72,11 @@ namespace ojph {
 
     public:
       static void pre_alloc(codestream *codestream, ui32 comp_num, 
-                            const size& nominal);
+                            const size& nominal, ui32 precision);
       void finalize_alloc(codestream *codestream, subband* parent,
                           const size& nominal, const size& cb_size,
                           coded_cb_header* coded_cb,
-                          ui32 K_max, int tbx0);
+                          ui32 K_max, int tbx0, ui32 precision);
       void push(line_buf *line);
       void encode(mem_elastic_allocator *elastic);
       void recreate(const size& cb_size, coded_cb_header* coded_cb);

--- a/src/core/codestream/ojph_codestream_local.cpp
+++ b/src/core/codestream/ojph_codestream_local.cpp
@@ -776,7 +776,7 @@ namespace ojph {
         }
         else if (marker_idx == 6)
         {
-          param_qcd* p = qcd.add_qcc_object();
+          param_qcd* p = qcd.add_qcc_object(param_qcd::OJPH_QCD_UNKNOWN); 
           p->read_qcc(file, siz.get_num_components());
           if (p->get_comp_idx() >= siz.get_num_components())
             OJPH_ERROR(0x00030054, "The codestream carries a QCC narker "

--- a/src/core/codestream/ojph_codestream_local.cpp
+++ b/src/core/codestream/ojph_codestream_local.cpp
@@ -79,8 +79,6 @@ namespace ojph {
 
       precinct_scratch_needed_bytes = 0;
 
-      used_qcc_fields = 0;
-      qcc = qcc_store;
       used_coc_fields = 0;
       coc = coc_store;
 
@@ -100,8 +98,6 @@ namespace ojph {
     ////////////////////////////////////////////////////////////////////////////
     codestream::~codestream()
     {
-      if (qcc_store != qcc)
-        delete[] qcc;
       if (allocator)
         delete allocator;
       if (elastic_alloc)
@@ -633,6 +629,9 @@ namespace ojph {
       if (!qcd.write(file))
         OJPH_ERROR(0x00030026, "Error writing to file");
 
+      if (!qcd.write_qcc(file, num_comps))
+        OJPH_ERROR(0x0003002D, "Error writing to file");
+
       if (!nlt.write(file))
         OJPH_ERROR(0x00030027, "Error writing to file");
 
@@ -766,9 +765,7 @@ namespace ojph {
           ui32 num_comps = siz.get_num_components();
           if (coc == coc_store && 
               num_comps * sizeof(param_cod) > sizeof(coc_store))
-          {
             coc = new param_cod[num_comps];
-          }
           coc[used_coc_fields++].read(
             file, param_cod::COC_MAIN, num_comps, &cod);
         }
@@ -779,13 +776,18 @@ namespace ojph {
         }
         else if (marker_idx == 6)
         {
-          ui32 num_comps = siz.get_num_components();
-          if (qcc == qcc_store && 
-              num_comps * sizeof(param_qcc) > sizeof(qcc_store))
-          {
-            qcc = new param_qcc[num_comps];
-          }
-          qcc[used_qcc_fields++].read(file, num_comps);
+          param_qcd* p = qcd.add_qcc_object();
+          p->read_qcc(file, siz.get_num_components());
+          if (p->get_comp_idx() >= siz.get_num_components())
+            OJPH_ERROR(0x00030054, "The codestream carries a QCC narker "
+              "segment for a component indexed by %d, which is more than the "
+              "allowed index number, since the codestream has %d components", 
+              p->get_comp_idx(), num_comps);
+          param_qcd *q = qcd.get_qcc(p->get_comp_idx());
+          if (p != q && p->get_comp_idx() == q->get_comp_idx())
+            OJPH_ERROR(0x00030055, "The codestream has two QCC marker "
+              "segments for one component of index %d", 
+              p->get_comp_idx());
         }
         else if (marker_idx == 7)
           skip_marker(file, "RGN", "RGN is not supported yet",

--- a/src/core/codestream/ojph_codestream_local.h
+++ b/src/core/codestream/ojph_codestream_local.h
@@ -86,14 +86,8 @@ namespace ojph {
       { return &cod; }
       const param_cod* get_cod(ui32 comp_num) //return internal cod
       { return cod.get_cod(comp_num); }
-      param_qcd* access_qcd(ui32 comp_num)
-      { 
-        if (used_qcc_fields > 0)
-          for (int v = 0; v < used_qcc_fields; ++v)
-            if (qcc[v].get_comp_num() == comp_num)
-              return qcc + v;
-        return &qcd; 
-      }
+      const param_qcd* access_qcd()
+      { return &qcd; }
       const param_dfs* access_dfs()
       { if (dfs.exists()) return &dfs; else return NULL; }
       const param_nlt* get_nlt()
@@ -166,9 +160,6 @@ namespace ojph {
       param_nlt nlt;         // non-linearity point transformation
 
     private: // this is to handle qcc and coc
-      int used_qcc_fields;
-      param_qcc *qcc;         // quantization component
-      param_qcc qcc_store[4]; // we allocate 4, we allocate more if needed
       int used_coc_fields;
       param_cod *coc;         // coding style component
       param_cod coc_store[4]; // we allocate 4, we allocate more if needed
@@ -178,8 +169,6 @@ namespace ojph {
       param_atk* atk;        // a pointer to atk
       param_atk atk_store[3];// 0 and 1 are for DWT from Part 1, 2 onward are
                              // for arbitrary transformation kernels
-
-
     private:
       mem_fixed_allocator *allocator;
       mem_elastic_allocator *elastic_alloc;

--- a/src/core/codestream/ojph_codestream_local.h
+++ b/src/core/codestream/ojph_codestream_local.h
@@ -84,8 +84,8 @@ namespace ojph {
       { return ojph::param_cod(&cod); }
       const param_cod* get_cod()              //return internal cod
       { return &cod; }
-      const param_cod* get_cod(ui32 comp_num) //return internal cod
-      { return cod.get_cod(comp_num); }
+      const param_cod* get_coc(ui32 comp_num) //return internal cod
+      { return cod.get_coc(comp_num); }
       const param_qcd* access_qcd()
       { return &qcd; }
       const param_dfs* access_dfs()

--- a/src/core/codestream/ojph_params.cpp
+++ b/src/core/codestream/ojph_params.cpp
@@ -1643,12 +1643,9 @@ namespace ojph {
             param_nlt* p = get_nlt_object(c);
             if (p == NULL || !p->enabled)
             { // captured by ALL_COMPS
-              if (p)
-                p->enabled = true;
-              else {
+              if (p == NULL)
                 p = add_object(c);
-                p->Cnlt = c;
-              }
+              p->enabled = true;                
               p->Tnlt = nonlinearity::OJPH_NLT_BINARY_COMPLEMENT_NLT;
               p->BDnlt = (ui8)(siz.get_bit_depth(c) - 1);
               p->BDnlt = (ui8)(p->BDnlt | (siz.is_signed(c) ? 0x80 : 0));
@@ -1696,8 +1693,9 @@ namespace ojph {
     param_nlt::get_nonlinear_transform(ui32 comp_num, ui8& bit_depth, 
                                        bool& is_signed, ui8& nl_type) const
     {
+      assert(Cnlt == special_comp_num::ALL_COMPS);
       const param_nlt* p = get_nlt_object(comp_num);
-      p = p ? p : this;
+      p = (p && p->enabled) ? p : this;
       if (p->enabled)
       {
         bit_depth = (ui8)((p->BDnlt & 0x7F) + 1);
@@ -1780,7 +1778,8 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     param_nlt* param_nlt::add_object(ui32 comp_num)
     {
-      assert(Cnlt != comp_num);
+      assert(comp_num != special_comp_num::ALL_COMPS);
+      assert(Cnlt == special_comp_num::ALL_COMPS);
       param_nlt* p = this;
       while (p->next != NULL) {
         assert(p->Cnlt != comp_num);

--- a/src/core/codestream/ojph_params.cpp
+++ b/src/core/codestream/ojph_params.cpp
@@ -364,6 +364,12 @@ namespace ojph {
     state->set_delta(delta);
   }
 
+  //////////////////////////////////////////////////////////////////////////
+  void param_qcd::set_irrev_quant(ui32 comp_idx, float delta)
+  {
+    state->set_delta(comp_idx, delta);
+  }
+
   ////////////////////////////////////////////////////////////////////////////
   //
   //
@@ -373,16 +379,16 @@ namespace ojph {
   ////////////////////////////////////////////////////////////////////////////
 
   ////////////////////////////////////////////////////////////////////////////
-  void param_nlt::set_nonlinearity(ui32 comp_num, nonlinearity type)
+  void param_nlt::set_nonlinearity(ui32 comp_num, ui8 nl_type)
   {
-    state->set_nonlinearity(comp_num, type);
+    state->set_nonlinearity(comp_num, nl_type);
   }
 
   ////////////////////////////////////////////////////////////////////////////
   bool param_nlt::get_nonlinearity(ui32 comp_num, ui8& bit_depth, 
-                                   bool& is_signed, nonlinearity& type) const
+                                   bool& is_signed, ui8& nl_type) const
   {
-    return state->get_nonlinearity(comp_num, bit_depth, is_signed, type);
+    return state->get_nonlinearity(comp_num, bit_depth, is_signed, nl_type);
   }
 
   ////////////////////////////////////////////////////////////////////////////
@@ -777,32 +783,6 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
 
     //////////////////////////////////////////////////////////////////////////
-    ui32 
-    param_cod::propose_precision(const param_siz* siz, ui32 comp_num) const
-    {
-      if (atk->is_reversible() == false)
-        return 32;
-      else
-      {
-        ui32 bit_depth = 0;
-        if (comp_num < 3 && is_employing_color_transform())
-        {
-          for (ui32 c = 0; c < 3; ++c)
-            bit_depth = ojph_max(bit_depth, siz->get_bit_depth(c));
-          ++bit_depth; // colour transform needs one extra bit
-        }
-        else
-          bit_depth = siz->get_bit_depth(comp_num);
-
-        // 3 or 4 is how many extra bits are needed for the HH band at the 
-        // bottom most level of decomposition. 
-        bit_depth += get_num_decompositions() > 5 ? 4 : 3; 
-
-        return bit_depth;
-      }
-    }
-
-    //////////////////////////////////////////////////////////////////////////
     bool param_cod::write(outfile_base *file)
     {
       assert(type == COD_MAIN);
@@ -954,29 +934,132 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     void param_qcd::check_validity(const param_siz& siz, const param_cod& cod)
     {
+      ui32 num_comp = siz.get_num_components();
+
+      // first check that all the component captured by QCD have the same
+      // bit_depth and signedness
+      bool all_same = true;
+      bool other_comps_exist = false;
+      ui32 bit_depth = 0;
+      bool is_signed = false;
+      ui32 first_comp = 0xFFFF; // an impossible component
+      for (ui32 c = 0; c < num_comp && all_same; ++c)
+      {
+        if (get_qcc(c) == this) // no qcc defined for component c
+        {
+          if (bit_depth == 0) // first component captured by QCD
+          {
+            bit_depth = siz.get_bit_depth(c);
+            is_signed = siz.is_signed(c);
+            first_comp = c;
+          }
+          else
+          {
+            all_same = all_same && (bit_depth == siz.get_bit_depth(c));
+            all_same = all_same && (is_signed == siz.is_signed(c));
+          }
+        }
+        else
+          other_comps_exist = true;
+      }
+      first_comp = first_comp != 0xFFFF ? first_comp : 0;
+
+      // configure QCD according COD
+      bool employing_color_transform = cod.is_employing_color_transform();
       ui32 num_decomps = cod.get_num_decompositions();
       num_subbands = 1 + 3 * num_decomps;
       if (cod.get_wavelet_kern() == param_cod::DWT_REV53)
       {
-        ui32 bit_depth = 0;
-        for (ui32 i = 0; i < siz.get_num_components(); ++i)
-          bit_depth = ojph_max(bit_depth, siz.get_bit_depth(i));
+        ui32 bit_depth = siz.get_bit_depth(first_comp);
         set_rev_quant(num_decomps, bit_depth,
-          cod.is_employing_color_transform());
+          first_comp < 3 ? employing_color_transform : false);
       }
       else if (cod.get_wavelet_kern() == param_cod::DWT_IRV97)
       {
         if (base_delta == -1.0f) {
-          ui32 bit_depth = 0;
-          for (ui32 i = 0; i < siz.get_num_components(); ++i)
-            bit_depth =
-            ojph_max(bit_depth, siz.get_bit_depth(i) + siz.is_signed(i));
+          ui32 bit_depth = siz.get_bit_depth(first_comp);
           base_delta = 1.0f / (float)(1 << bit_depth);
         }
         set_irrev_quant(num_decomps);
       }
       else
         assert(0);
+
+      // if not all the same and captured by QCD, the create QCC for them
+      if (!all_same && bit_depth != 0)
+      {
+        for (ui32 c = 0; c < num_comp; ++c)
+        {
+          param_qcd *qp = get_qcc(c);
+          if (qp == NULL) {
+            qp = this->add_qcc_object();
+            qp->enabled = true;
+            qp->top_qcd = this;
+            qp->comp_idx = c;
+          }
+          const param_cod *cp = cod.get_cod(c);
+          ui32 num_decomps = cp->get_num_decompositions();
+          qp->num_subbands = 1 + 3 * num_decomps;
+          if (cp->get_wavelet_kern() == param_cod::DWT_REV53)
+          {
+            ui32 bit_depth = siz.get_bit_depth(c);
+            qp->set_rev_quant(num_decomps, bit_depth,
+              c < 3 ? employing_color_transform : false);
+          }
+          else if (cp->get_wavelet_kern() == param_cod::DWT_IRV97)
+          {
+            if (qp->base_delta == -1.0f) {
+              ui32 bit_depth = siz.get_bit_depth(c);
+              qp->base_delta = 1.0f / (float)(1 << bit_depth);
+            }
+            qp->set_irrev_quant(num_decomps);
+          }
+          else
+            assert(0);
+        }
+      }
+      else if (other_comps_exist)
+      {
+        for (ui32 c = 0; c < num_comp; ++c)
+        {
+          param_qcd *qp = get_qcc(c);
+          if (qp == this)
+            continue;
+          const param_cod *cp = cod.get_cod(c);
+          ui32 num_decomps = cp->get_num_decompositions();
+          qp->num_subbands = 1 + 3 * num_decomps;
+          if (cp->get_wavelet_kern() == param_cod::DWT_REV53)
+          {
+            ui32 bit_depth = siz.get_bit_depth(c);
+            qp->set_rev_quant(num_decomps, bit_depth,
+              c < 3 ? employing_color_transform : false);
+          }
+          else if (cp->get_wavelet_kern() == param_cod::DWT_IRV97)
+          {
+            if (qp->base_delta == -1.0f) {
+              ui32 bit_depth = siz.get_bit_depth(c);
+              qp->base_delta = 1.0f / (float)(1 << bit_depth);
+            }
+            qp->set_irrev_quant(num_decomps);
+          }
+          else
+            assert(0);
+        }
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void param_qcd::set_delta(ui32 comp_idx, float delta)
+    {
+      assert(type == QCD_MAIN);
+      param_qcd *p = get_qcc(comp_idx);
+      if (p == NULL) {
+        p = add_qcc_object();
+        p->enabled = true;
+        p->top_qcd = this;
+        p->comp_idx = comp_idx;
+      }
+      p->set_delta(delta);
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -988,19 +1071,19 @@ namespace ojph {
       int s = 0;
       double bibo_l = bibo_gains::get_bibo_gain_l(num_decomps, true);
       ui32 X = (ui32) ceil(log(bibo_l * bibo_l) / M_LN2);
-      u8_SPqcd[s++] = (ui8)(B + X);
+      SPqcd.u8[s++] = (ui8)(B + X);
       ui32 max_B_plus_X = (ui32)(B + X);
       for (ui32 d = num_decomps; d > 0; --d)
       {
         double bibo_l = bibo_gains::get_bibo_gain_l(d, true);
         double bibo_h = bibo_gains::get_bibo_gain_h(d - 1, true);
         X = (ui32) ceil(log(bibo_h * bibo_l) / M_LN2);
-        u8_SPqcd[s++] = (ui8)(B + X);
+        SPqcd.u8[s++] = (ui8)(B + X);
         max_B_plus_X = ojph_max(max_B_plus_X, B + X);
-        u8_SPqcd[s++] = (ui8)(B + X);
+        SPqcd.u8[s++] = (ui8)(B + X);
         max_B_plus_X = ojph_max(max_B_plus_X, B + X);
         X = (ui32) ceil(log(bibo_h * bibo_h) / M_LN2);
-        u8_SPqcd[s++] = (ui8)(B + X);
+        SPqcd.u8[s++] = (ui8)(B + X);
         max_B_plus_X = ojph_max(max_B_plus_X, B + X);
       }
 
@@ -1013,15 +1096,15 @@ namespace ojph {
       int guard_bits = ojph_max(1, (si32)max_B_plus_X - 31);
       Sqcd = (ui8)(guard_bits << 5);
       s = 0;
-      u8_SPqcd[s] = encode_SPqcd((ui8)(u8_SPqcd[s] - guard_bits));
+      SPqcd.u8[s] = encode_SPqcd((ui8)(SPqcd.u8[s] - guard_bits));
       s++;
       for (ui32 d = num_decomps; d > 0; --d)
       {
-        u8_SPqcd[s] = encode_SPqcd((ui8)(u8_SPqcd[s] - guard_bits));
+        SPqcd.u8[s] = encode_SPqcd((ui8)(SPqcd.u8[s] - guard_bits));
         s++;
-        u8_SPqcd[s] = encode_SPqcd((ui8)(u8_SPqcd[s] - guard_bits));
+        SPqcd.u8[s] = encode_SPqcd((ui8)(SPqcd.u8[s] - guard_bits));
         s++;
-        u8_SPqcd[s] = encode_SPqcd((ui8)(u8_SPqcd[s] - guard_bits));
+        SPqcd.u8[s] = encode_SPqcd((ui8)(SPqcd.u8[s] - guard_bits));
         s++;
       }
     }
@@ -1041,7 +1124,7 @@ namespace ojph {
       // but that should not happen in reality
       mantissa = (int)round(delta_b * (float)(1<<11)) - (1<<11);
       mantissa = mantissa < (1<<11) ? mantissa : 0x7FF;
-      u16_SPqcd[s++] = (ui16)((exp << 11) | mantissa);
+      SPqcd.u16[s++] = (ui16)((exp << 11) | mantissa);
       for (ui32 d = num_decomps; d > 0; --d)
       {
         float gain_l = sqrt_energy_gains::get_gain_l(d, false);
@@ -1054,8 +1137,8 @@ namespace ojph {
         { exp++; delta_b *= 2.0f; }
         mantissa = (int)round(delta_b * (float)(1<<11)) - (1<<11);
         mantissa = mantissa < (1<<11) ? mantissa : 0x7FF;
-        u16_SPqcd[s++] = (ui16)((exp << 11) | mantissa);
-        u16_SPqcd[s++] = (ui16)((exp << 11) | mantissa);
+        SPqcd.u16[s++] = (ui16)((exp << 11) | mantissa);
+        SPqcd.u16[s++] = (ui16)((exp << 11) | mantissa);
 
         delta_b = base_delta / (gain_h * gain_h);
 
@@ -1064,7 +1147,7 @@ namespace ojph {
         { exp++; delta_b *= 2.0f; }
         mantissa = (int)round(delta_b * (float)(1<<11)) - (1<<11);
         mantissa = mantissa < (1<<11) ? mantissa : 0x7FF;
-        u16_SPqcd[s++] = (ui16)((exp << 11) | mantissa);
+        SPqcd.u16[s++] = (ui16)((exp << 11) | mantissa);
       }
     }
 
@@ -1079,7 +1162,7 @@ namespace ojph {
       int irrev = Sqcd & 0x1F;
       if (irrev == 0) //reversible
         for (ui32 i = 0; i < num_subbands; ++i) {
-          ui32 t = decode_SPqcd(u8_SPqcd[i]);
+          ui32 t = decode_SPqcd(SPqcd.u8[i]);
           t += get_num_guard_bits() - 1u;
           B = ojph_max(B, t);
         }
@@ -1087,7 +1170,7 @@ namespace ojph {
         for (ui32 i = 0; i < num_subbands; ++i)
         {
           ui32 nb = num_decomps - (i ? (i - 1) / 3 : 0); //decompsition level
-          B = ojph_max(B, (u16_SPqcd[i] >> 11) + get_num_guard_bits() - nb);
+          B = ojph_max(B, (SPqcd.u16[i] >> 11) + get_num_guard_bits() - nb);
         }
       else
         assert(0);
@@ -1096,7 +1179,7 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    float param_qcd::irrev_get_delta(const param_dfs* dfs, 
+    float param_qcd::get_irrev_delta(const param_dfs* dfs, 
                                      ui32 num_decompositions,
                                      ui32 resolution, ui32 subband) const
     {
@@ -1117,12 +1200,32 @@ namespace ojph {
           idx + 1, num_subbands, num_subbands - 1);
         idx = num_subbands - 1;
       }
-      int eps = u16_SPqcd[idx] >> 11;
+      int eps = SPqcd.u16[idx] >> 11;
       float mantissa;
-      mantissa = (float)((u16_SPqcd[idx] & 0x7FF) | 0x800) * arr[subband];
+      mantissa = (float)((SPqcd.u16[idx] & 0x7FF) | 0x800) * arr[subband];
       mantissa /= (float)(1 << 11);
       mantissa /= (float)(1u << eps);
       return mantissa;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    ui32 param_qcd::propose_precision(const param_cod* cod) const
+    {
+      ui32 comp_idx = cod->get_comp_num();
+      ui32 precision = 0;
+      const param_cod *main = 
+        cod->get_cod(param_cod::OJPH_COD_DEFAULT);
+      if (main->is_employing_color_transform() && comp_idx < 3)
+      {
+        for (ui32 i = 0; i < 3; ++i) {
+          const param_qcd* p = this->get_qcc(i);
+          precision = ojph_max(precision, p->get_largest_Kmax());
+        }
+      }
+      else {
+        precision = get_largest_Kmax();
+      }
+      return precision;
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -1135,7 +1238,6 @@ namespace ojph {
     ui32 param_qcd::get_Kmax(const param_dfs* dfs, ui32 num_decompositions,
                              ui32 resolution, ui32 subband) const
     {
-      ui32 num_bits = get_num_guard_bits();
       ui32 idx;
       if (dfs != NULL && dfs->exists())
         idx = dfs->get_subband_idx(num_decompositions, resolution, subband);
@@ -1152,19 +1254,47 @@ namespace ojph {
       }
 
       int irrev = Sqcd & 0x1F;
+      ui32 num_bits = 0;
       if (irrev == 0) // reversible; this is (10.22) from the J2K book
       {
-        num_bits += decode_SPqcd(u8_SPqcd[idx]);
+        num_bits = decode_SPqcd(SPqcd.u8[idx]);
         num_bits = num_bits == 0 ? 0 : num_bits - 1;
       }
       else if (irrev == 1)
         assert(0);
       else if (irrev == 2) //scalar expounded
-        num_bits += (u16_SPqcd[idx] >> 11) - 1;
+        num_bits = (SPqcd.u16[idx] >> 11) - 1;
       else
         assert(0);
 
-      return num_bits;
+      return num_bits + get_num_guard_bits();
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    ui32 param_qcd::get_largest_Kmax() const
+    {
+      int irrev = Sqcd & 0x1F;
+      ui32 num_bits = 0;
+      if (irrev == 0) // reversible; this is (10.22) from the J2K book
+      {
+        for (ui32 i = 0; i < num_subbands; ++i) {
+          ui32 t = decode_SPqcd(SPqcd.u8[i]);
+          num_bits = ojph_max(num_bits, t == 0 ? 0 : t - 1);
+        }
+      }
+      else if (irrev == 1)
+        assert(0);
+      else if (irrev == 2) //scalar expounded
+      {
+        for (ui32 i = 0; i < num_subbands; ++i) {
+          ui32 t = (SPqcd.u16[i] >> 11) - 1;
+          num_bits = ojph_max(num_bits, t);
+        }
+      }
+      else
+        assert(0);
+      
+      return num_bits + get_num_guard_bits();        
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -1195,21 +1325,86 @@ namespace ojph {
       if (irrev == 0)
         for (ui32 i = 0; i < num_subbands; ++i)
         {
-          *(ui8*)buf = u8_SPqcd[i];
+          *(ui8*)buf = SPqcd.u8[i];
           result &= file->write(&buf, 1) == 1;
         }
       else if (irrev == 2)
         for (ui32 i = 0; i < num_subbands; ++i)
         {
-          *(ui16*)buf = swap_byte(u16_SPqcd[i]);
+          *(ui16*)buf = swap_byte(SPqcd.u16[i]);
           result &= file->write(&buf, 2) == 2;
         }
       else
         assert(0);
 
+      return result;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    bool param_qcd::write_qcc(outfile_base *file, ui32 num_comps)
+    {
+      bool result = true;
+      param_qcd *p = this->next;
+      while (p)
+      {
+        result &= p->internal_write_qcc(file, num_comps);
+        p = p->next;
+      }
+      return result;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    bool param_qcd::internal_write_qcc(outfile_base *file, ui32 num_comps)
+    {
+      int irrev = Sqcd & 0x1F;
+
+      //marker size excluding header
+      Lqcd = 4 + (num_comps < 257 ? 0 : 1);
+      if (irrev == 0)
+        Lqcd = (ui16)(Lqcd + num_subbands);
+      else if (irrev == 2)
+        Lqcd = (ui16)(Lqcd + 2 * num_subbands);
+      else
+        assert(0);
+
+      char buf[4];
+      bool result = true;
+
+      *(ui16*)buf = JP2K_MARKER::QCC;
+      *(ui16*)buf = swap_byte(*(ui16*)buf);
+      result &= file->write(&buf, 2) == 2;
+      *(ui16*)buf = swap_byte(Lqcd);
+      result &= file->write(&buf, 2) == 2;
+      if (num_comps < 257)
+      {
+        *(ui8*)buf = (ui8)comp_idx;
+        result &= file->write(&buf, 1) == 1;
+      }
+      else
+      {
+        *(ui16*)buf = swap_byte(comp_idx);
+        result &= file->write(&buf, 2) == 2;
+      }
+      *(ui8*)buf = Sqcd;
+      result &= file->write(&buf, 1) == 1;
+      if (irrev == 0)
+        for (ui32 i = 0; i < num_subbands; ++i)
+        {
+          *(ui8*)buf = SPqcd.u8[i];
+          result &= file->write(&buf, 1) == 1;
+        }
+      else if (irrev == 2)
+        for (ui32 i = 0; i < num_subbands; ++i)
+        {
+          *(ui16*)buf = swap_byte(SPqcd.u16[i]);
+          result &= file->write(&buf, 2) == 2;
+        }
+      else
+        assert(0);
 
       return result;
     }
+
     //////////////////////////////////////////////////////////////////////////
     void param_qcd::read(infile_base *file)
     {
@@ -1224,7 +1419,7 @@ namespace ojph {
         if (Lqcd != 3 + num_subbands)
           OJPH_ERROR(0x00050083, "wrong Lqcd value in QCD marker");
         for (ui32 i = 0; i < num_subbands; ++i)
-          if (file->read(&u8_SPqcd[i], 1) != 1)
+          if (file->read(&SPqcd.u8[i], 1) != 1)
             OJPH_ERROR(0x00050084, "error reading QCD marker");
       }
       else if ((Sqcd & 0x1F) == 1)
@@ -1242,9 +1437,9 @@ namespace ojph {
           OJPH_ERROR(0x00050086, "wrong Lqcd value in QCD marker");
         for (ui32 i = 0; i < num_subbands; ++i)
         {
-          if (file->read(&u16_SPqcd[i], 2) != 2)
+          if (file->read(&SPqcd.u16[i], 2) != 2)
             OJPH_ERROR(0x00050087, "error reading QCD marker");
-          u16_SPqcd[i] = swap_byte(u16_SPqcd[i]);
+          SPqcd.u16[i] = swap_byte(SPqcd.u16[i]);
         }
       }
       else
@@ -1252,15 +1447,7 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    //
-    //
-    //
-    //
-    //
-    //////////////////////////////////////////////////////////////////////////
-
-    //////////////////////////////////////////////////////////////////////////
-    void param_qcc::read(infile_base *file, ui32 num_comps)
+    void param_qcd::read_qcc(infile_base *file, ui32 num_comps)
     {
       if (file->read(&Lqcd, 2) != 2)
         OJPH_ERROR(0x000500A1, "error reading QCC marker");
@@ -1287,7 +1474,7 @@ namespace ojph {
         if (Lqcd != offset + num_subbands)
           OJPH_ERROR(0x000500A5, "wrong Lqcd value in QCC marker");
         for (ui32 i = 0; i < num_subbands; ++i)
-          if (file->read(&u8_SPqcd[i], 1) != 1)
+          if (file->read(&SPqcd.u8[i], 1) != 1)
             OJPH_ERROR(0x000500A6, "error reading QCC marker");
       }
       else if ((Sqcd & 0x1F) == 1)
@@ -1305,13 +1492,46 @@ namespace ojph {
           OJPH_ERROR(0x000500A8, "wrong Lqcc value in QCC marker");
         for (ui32 i = 0; i < num_subbands; ++i)
         {
-          if (file->read(&u16_SPqcd[i], 2) != 2)
+          if (file->read(&SPqcd.u16[i], 2) != 2)
             OJPH_ERROR(0x000500A9, "error reading QCC marker");
-          u16_SPqcd[i] = swap_byte(u16_SPqcd[i]);
+          SPqcd.u16[i] = swap_byte(SPqcd.u16[i]);
         }
       }
       else
         OJPH_ERROR(0x000500AA, "wrong Sqcc value in QCC marker");
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    param_qcd* param_qcd::get_qcc(ui32 comp_idx) 
+    { 
+      // cast object to constant
+      const param_qcd* const_p = const_cast<const param_qcd*>(this);
+      // call using the constant object, then cast to non-const
+      return const_cast<param_qcd*>(const_p->get_qcc(comp_idx));
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    const param_qcd* param_qcd::get_qcc(ui32 comp_idx) const
+    {
+      param_qcd* p = this->top_qcd;
+      while (p && p->comp_idx != comp_idx)
+        p = p->next;
+      return p ? p : this->top_qcd;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    param_qcd* param_qcd::add_qcc_object()
+    {
+      param_qcd *p = this;
+      while (p->next != NULL)
+        p = p->next;
+      p->next = new param_qcd;
+      p = p->next;
+
+      p->type = QCC_MAIN;
+      p->next = NULL;
+      p->top_qcd = this;
+      return p;
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -1328,115 +1548,107 @@ namespace ojph {
       if (is_any_enabled() == false)
         return;
 
-      bool all_same = true;
-      ui32 num_comps = siz.get_num_components();
+      if (this->enabled && this->Tnlt == nonlinearity::OJPH_NLT_NO_NLT)
+        this->enabled = false;
 
-      // first stage; find out if all components captured by the default
-      // entry (ALL_COMPS) has the same bit_depth/signedness,
-      // while doing this, set the BDnlt for components not captured by the
-      // default entry (ALL_COMPS)
-      ui32 bit_depth = 0;      // unknown yet
-      bool is_signed = false;  // unknown yet
-      for (ui32 c = 0; c < num_comps; ++c)
+      if (this->enabled && 
+          this->Tnlt == nonlinearity::OJPH_NLT_BINARY_COMPLEMENT_NLT)
       {
-        param_nlt* p = get_comp_object(c);
-        if (p == NULL || !p->enabled) // comp is not in list or not enabled
-        {
-          if (bit_depth == 0)
-          { // this is the first component which has not type 3 nlt definition
-            bit_depth = siz.get_bit_depth(c);
-            is_signed = siz.is_signed(c);
+        bool all_same = true;
+        ui32 num_comps = siz.get_num_components();
+
+        // first stage; find out if all components captured by the default
+        // entry (ALL_COMPS) has the same bit_depth/signedness,
+        // while doing this, set the BDnlt for components not captured by the
+        // default entry (ALL_COMPS)
+        ui32 bit_depth = 0;      // unknown yet
+        bool is_signed = false;  // unknown yet
+        for (ui32 c = 0; c < num_comps; ++c)
+        { // captured by ALL_COMPS
+          param_nlt* p = get_nlt_object(c);
+          if (p == NULL || !p->enabled) 
+          {
+            if (bit_depth != 0)
+            { 
+              // we have seen an undefined component previously
+              all_same = all_same && (bit_depth == siz.get_bit_depth(c));
+              all_same = all_same && (is_signed == siz.is_signed(c));
+            }
+            else
+            { 
+              // this is the first component which has not type 3 nlt definition
+              bit_depth = siz.get_bit_depth(c);
+              is_signed = siz.is_signed(c);
+            }
           }
           else
-          { // we have seen an undefined component previously
-            all_same = all_same && (bit_depth == siz.get_bit_depth(c));
-            all_same = all_same && (is_signed == siz.is_signed(c));
+          { // can be type 0 or type 3
+            p->BDnlt = (ui8)(siz.get_bit_depth(c) - 1);
+            p->BDnlt = (ui8)(p->BDnlt | (siz.is_signed(c) ? 0x80 : 0));
           }
         }
-        else
-        {
-          p->BDnlt = (ui8)(siz.get_bit_depth(c) - 1);
-          p->BDnlt = (ui8)(p->BDnlt | (siz.is_signed(c) ? 0x80 : 0));
+
+        if (all_same && bit_depth != 0) 
+        { // all the same, and some components are captured by ALL_COMPS
+          this->BDnlt = (ui8)(bit_depth - 1);
+          this->BDnlt = (ui8)(this->BDnlt | (is_signed ? 0x80 : 0));
         }
-      }
-
-      // If the default entry is enabled/used, then if the components captured
-      // by it are not the same, we need to create entries for these 
-      // components
-      if (this->enabled)
-      {
-        if (bit_depth != 0) // default captures some components
-        {
-          // captures at least one of the componets in the default entry
-          this->BDnlt = (ui8)((bit_depth - 1) | (is_signed ? 0x80 : (ui8)0));
-
-          if (!all_same)
+        else if (!all_same)
+        { // have different settings or no component is captured by ALL_COMPS
+          this->enabled = false;
+          for (ui32 c = 0; c < num_comps; ++c)
           {
-            // We cannot use the default for all components in it, so we 
-            // will keep the first one, and we will also define other
-            // components on their own.
-
-            for (ui32 c = 0; c < num_comps; ++c)
-            {
-              ui32 bd = siz.get_bit_depth(c);
-              bool is = siz.is_signed(c);
-              if (bd != bit_depth || is != is_signed)
-              { 
-                // this component has different bit_depth/signedness than the
-                // default (ALL_COMPS) entry
-                param_nlt* p = get_comp_object(c);
-                if (p == NULL || !p->enabled)
-                {
-                  // this component is captured by the default (ALL_COMPS)
-                  // entry (because it is either not in the list, or 
-                  // not enabled
-                  if (p == NULL)
-                    p = add_object(c);
-                  p->enabled = true;
-                  p->BDnlt = (ui8)((bd - 1) | (is ? 0x80 : 0));
-                }
+            param_nlt* p = get_nlt_object(c);
+            if (p == NULL || !p->enabled)
+            { // captured by ALL_COMPS
+              if (p)
+                p->enabled = true;
+              else {
+                p = add_object(c);
+                p->Cnlt = c;
               }
+              p->Tnlt = nonlinearity::OJPH_NLT_BINARY_COMPLEMENT_NLT;
+              p->BDnlt = (ui8)(siz.get_bit_depth(c) - 1);
+              p->BDnlt = (ui8)(p->BDnlt | (siz.is_signed(c) ? 0x80 : 0));
             }
           }
         }
-        else
-          this->enabled = false;
       }
 
-      trim_non_existing_components(num_comps);
+      trim_non_existing_components(siz.get_num_components());
 
       if (is_any_enabled() == true)
         siz.set_Rsiz_flag(param_siz::RSIZ_EXT_FLAG | param_siz::RSIZ_NLT_FLAG);
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void param_nlt::set_nonlinearity(ui32 comp_num, nonlinearity type)
+    void param_nlt::set_nonlinearity(ui32 comp_num, ui8 nl_type)
     {
-      if (type != ojph::param_nlt::OJPH_NLT_NO_NLT && 
-          type != ojph::param_nlt::OJPH_NLT_BINARY_COMPLEMENT_NLT)
-      OJPH_ERROR(0x00050171, "Nonliearity other than types 0 "
-        "(No Nonlinearity) and 3 (Binary Binary Complement to Sign Magnitude "
-        "Conversion) is not supported yet");
-      param_nlt* p = get_comp_object(comp_num);
+      if (nl_type != ojph::param_nlt::OJPH_NLT_NO_NLT && 
+          nl_type != ojph::param_nlt::OJPH_NLT_BINARY_COMPLEMENT_NLT)
+      OJPH_ERROR(0x00050171, "Nonliearities other than type 0 "
+        "(No Nonlinearity) or type  3 (Binary Binary Complement to Sign "
+        "Magnitude Conversion) are not supported yet");
+      param_nlt* p = get_nlt_object(comp_num);
       if (p == NULL)
         p = add_object(comp_num);
-      p->Tnlt = type;
+      p->Tnlt = nl_type;
       p->enabled = true;
     }
 
     //////////////////////////////////////////////////////////////////////////
     bool
     param_nlt::get_nonlinearity(ui32 comp_num, ui8& bit_depth, bool& is_signed, 
-                                nonlinearity& type) const
+                                ui8& nl_type) const
     {
-      const param_nlt* p = get_comp_object(comp_num);
+      const param_nlt* p = get_nlt_object(comp_num);
       p = p ? p : this;
       if (p->enabled)
       {
         bit_depth = (ui8)((p->BDnlt & 0x7F) + 1);
         bit_depth = bit_depth <= 38 ? bit_depth : 38;
         is_signed = (p->BDnlt & 0x80) == 0x80;
-        type = (nonlinearity)p->Tnlt;
+        nl_type = (nonlinearity)p->Tnlt;
         return true;
       }
       return false;
@@ -1479,33 +1691,30 @@ namespace ojph {
         OJPH_ERROR(0x00050141, "error reading NLT marker segment");
 
       ui16 length = swap_byte(*(ui16*)buf);
-      if (length != 6 || buf[5] != 3) // wrong length or type
+      if (length != 6 || buf[5] != 3 || buf[5] != 0) // wrong length or type
         OJPH_ERROR(0x00050142, "Unsupported NLT type %d\n", buf[5]);
 
       ui16 comp = swap_byte(*(ui16*)(buf + 2));
-      param_nlt* p = this;
-      if (comp != special_comp_num::ALL_COMPS)
-      {
-        p = get_comp_object(comp);
-        if (p == NULL)
-          p = add_object(comp);
-      }
+      param_nlt* p = get_nlt_object(comp);
+      if (p == NULL)
+        p = add_object(comp);
       p->enabled = true;
       p->Cnlt = comp;
       p->BDnlt = buf[4];
+      p->Tnlt = buf[5];
     }
 
     //////////////////////////////////////////////////////////////////////////
-    param_nlt* param_nlt::get_comp_object(ui32 comp_num) 
+    param_nlt* param_nlt::get_nlt_object(ui32 comp_num) 
     { 
       // cast object to constant
       const param_nlt* const_p = const_cast<const param_nlt*>(this);
       // call using the constant object, then cast to non-const
-      return const_cast<param_nlt*>(const_p->get_comp_object(comp_num));
+      return const_cast<param_nlt*>(const_p->get_nlt_object(comp_num));
     }
 
     //////////////////////////////////////////////////////////////////////////
-    const param_nlt* param_nlt::get_comp_object(ui32 comp_num) const
+    const param_nlt* param_nlt::get_nlt_object(ui32 comp_num) const
     {
       const param_nlt* p = this;
       while (p && p->Cnlt != comp_num)
@@ -1546,8 +1755,8 @@ namespace ojph {
       while (p) {
           if (p->enabled == true && p->Cnlt >= num_comps) {
             p->enabled = false;
-            OJPH_INFO(0x00050161, "We are removing the NLT marker segment "
-              "for the non-existing component %d", p->Cnlt);
+            OJPH_INFO(0x00050161, "The NLT marker segment for the "
+              "non-existing component %d has been removed.", p->Cnlt);
           }
         p = p->next;
       }

--- a/src/core/codestream/ojph_params.cpp
+++ b/src/core/codestream/ojph_params.cpp
@@ -1385,7 +1385,7 @@ namespace ojph {
       int irrev = Sqcd & 0x1F;
 
       //marker size excluding header
-      Lqcd = 4 + (num_comps < 257 ? 0 : 1);
+      Lqcd = (ui16)(4 + (num_comps < 257 ? 0 : 1));
       if (irrev == 0)
         Lqcd = (ui16)(Lqcd + num_subbands);
       else if (irrev == 2)

--- a/src/core/codestream/ojph_params_local.h
+++ b/src/core/codestream/ojph_params_local.h
@@ -673,12 +673,13 @@ namespace ojph {
     struct param_nlt
     {
       using special_comp_num = ojph::param_nlt::special_comp_num;
+      using nonlinearity = ojph::param_nlt::nonlinearity;
     public:
       param_nlt() { 
         Lnlt = 6;
         Cnlt = special_comp_num::ALL_COMPS; // default
         BDnlt = 0;
-        Tnlt = 3;
+        Tnlt = nonlinearity::OJPH_NLT_NO_NLT;
         enabled = false; next = NULL; alloced_next = false;
       }
 
@@ -691,9 +692,9 @@ namespace ojph {
       }
 
       void check_validity(param_siz& siz);
-      void set_type3_transformation(ui32 comp_num, bool enable);
-      bool get_type3_transformation(ui32 comp_num, ui8& bit_depth, 
-                                    bool& is_signed) const;
+      void set_nonlinearity(ui32 comp_num, nonlinearity type);
+      bool get_nonlinearity(ui32 comp_num, ui8& bit_depth, 
+                            bool& is_signed, nonlinearity& type) const;
       bool write(outfile_base* file) const;
       void read(infile_base* file);
 

--- a/src/core/codestream/ojph_params_local.h
+++ b/src/core/codestream/ojph_params_local.h
@@ -626,7 +626,6 @@ namespace ojph {
         memset(&SPqcd, 0, sizeof(SPqcd));
         num_subbands = 0;
         base_delta = -1.0f;
-        enabled = true;
         next = NULL;
         top_qcd = this;
         comp_idx = OJPH_QCD_DEFAULT;
@@ -643,7 +642,7 @@ namespace ojph {
       void set_delta(float delta) { base_delta = delta; }
       void set_delta(ui32 comp_idx, float delta);
       ui32 get_num_guard_bits() const;
-      ui32 get_MAGBp() const;
+      ui32 get_MAGB() const;
       ui32 get_Kmax(const param_dfs* dfs, ui32 num_decompositions,
                     ui32 resolution, ui32 subband) const;
       ui32 propose_precision(const param_cod* cod) const;
@@ -684,7 +683,6 @@ namespace ojph {
       ui32 num_subbands;  // number of subbands
       float base_delta;   // base quantization step size -- all other
                           // step sizes are derived from it.
-      bool enabled;       // true if this object is enabled
       param_qcd *next;    // pointer to create chains of qcc marker segments
       param_qcd *top_qcd; // pointer to the top QCD (this is the default)
 
@@ -722,9 +720,9 @@ namespace ojph {
       }
 
       void check_validity(param_siz& siz);
-      void set_nonlinearity(ui32 comp_num, ui8 nl_type);
-      bool get_nonlinearity(ui32 comp_num, ui8& bit_depth, 
-                            bool& is_signed, ui8& nl_type) const;
+      void set_nonlinear_transform(ui32 comp_num, ui8 nl_type);
+      bool get_nonlinear_transform(ui32 comp_num, ui8& bit_depth, 
+                                   bool& is_signed, ui8& nl_type) const;
       bool write(outfile_base* file) const;
       void read(infile_base* file);
 
@@ -776,15 +774,13 @@ namespace ojph {
           Ccap[0] |= 0x0020;
         Ccap[0] &= 0xFFE0;
         ui32 Bp = 0;
-        ui32 B = qcd.get_MAGBp();
+        ui32 B = qcd.get_MAGB();
         if (B <= 8)
           Bp = 0;
         else if (B < 28)
           Bp = B - 8;
-        else if (B < 48)
-          Bp = 13 + (B >> 2);
         else
-          Bp = 31;
+          Bp = 13 + (B >> 2);
         Ccap[0] = (ui16)(Ccap[0] | (ui16)Bp);
       }
 

--- a/src/core/codestream/ojph_resolution.cpp
+++ b/src/core/codestream/ojph_resolution.cpp
@@ -61,7 +61,7 @@ namespace ojph {
                                ui32 comp_num, ui32 res_num)
     {
       mem_fixed_allocator* allocator = codestream->get_allocator();
-      const param_cod* cdp = codestream->get_cod(comp_num);
+      const param_cod* cdp = codestream->get_coc(comp_num);
       ui32 num_decomps = cdp->get_num_decompositions();
       ui32 t = num_decomps - codestream->get_skipped_res_for_recon();
       bool skipped_res_for_recon = res_num > t;
@@ -236,7 +236,7 @@ namespace ojph {
     {
       mem_fixed_allocator* allocator = codestream->get_allocator();
       elastic = codestream->get_elastic_alloc();
-      const param_cod* cdp = codestream->get_cod(comp_num);
+      const param_cod* cdp = codestream->get_coc(comp_num);
       ui32 t, num_decomps = cdp->get_num_decompositions();
       t = num_decomps - codestream->get_skipped_res_for_recon();
       skipped_res_for_recon = res_num > t;

--- a/src/core/codestream/ojph_resolution.cpp
+++ b/src/core/codestream/ojph_resolution.cpp
@@ -62,8 +62,8 @@ namespace ojph {
     {
       mem_fixed_allocator* allocator = codestream->get_allocator();
       const param_cod* cdp = codestream->get_cod(comp_num);
-      ui32 t = cdp->get_num_decompositions()
-             - codestream->get_skipped_res_for_recon();
+      ui32 num_decomps = cdp->get_num_decompositions();
+      ui32 t = num_decomps - codestream->get_skipped_res_for_recon();
       bool skipped_res_for_recon = res_num > t;
 
       const param_atk* atk = cdp->access_atk();
@@ -85,7 +85,6 @@ namespace ojph {
               "with index %d, but there are no such marker within the "
               "main codestream headers", dfs_idx);
           }
-          ui32 num_decomps = cdp->get_num_decompositions();
           ds = dfs->get_dwt_type(num_decomps - res_num + 1);
         }
       }
@@ -199,15 +198,15 @@ namespace ojph {
         allocator->pre_alloc_obj<precinct>((size_t)num_precincts.area());
       }
 
-      const param_siz* szp = codestream->get_siz();
-      ui32 precision = cdp->propose_precision(szp, comp_num);
-
       //allocate lines
       if (skipped_res_for_recon == false)
       {
         ui32 num_steps = atk->get_num_steps();
         allocator->pre_alloc_obj<line_buf>(num_steps + 2);
         allocator->pre_alloc_obj<lifting_buf>(num_steps + 2);
+
+        const param_qcd* qp = codestream->access_qcd()->get_qcc(comp_num);
+        ui32 precision = qp->propose_precision(cdp);
 
         ui32 width = res_rect.siz.w + 1;
         if (precision <= 32) {
@@ -448,9 +447,6 @@ namespace ojph {
         level_index[i] = level_index[i - 1] + val;
       cur_precinct_loc = point(0, 0);
 
-      const param_siz* szp = codestream->get_siz();
-      ui32 precision = cdp->propose_precision(szp, comp_num);
-
       //allocate lines
       if (skipped_res_for_recon == false)
       {
@@ -472,6 +468,9 @@ namespace ojph {
         sig->line = lines + num_steps;
         new (aug) lifting_buf;
         aug->line = lines + num_steps + 1;
+
+        const param_qcd* qp = codestream->access_qcd()->get_qcc(comp_num);
+        ui32 precision = qp->propose_precision(cdp);
 
         // initiate storage of line_buf
         ui32 width = res_rect.siz.w + 1;

--- a/src/core/codestream/ojph_subband.cpp
+++ b/src/core/codestream/ojph_subband.cpp
@@ -63,7 +63,7 @@ namespace ojph {
       if (empty)
         return;
 
-      const param_cod* cdp = codestream->get_cod(comp_num);
+      const param_cod* cdp = codestream->get_coc(comp_num);
       size log_cb = cdp->get_log_block_dims();
       size log_PP = cdp->get_log_precinct_size(res_num);
 
@@ -120,7 +120,7 @@ namespace ojph {
       this->band_rect = band_rect;
       this->parent = res;
 
-      const param_cod* cdp = codestream->get_cod(parent->get_comp_num());
+      const param_cod* cdp = codestream->get_coc(parent->get_comp_num());
       this->reversible = cdp->access_atk()->is_reversible();
       size log_cb = cdp->get_log_block_dims();
       log_PP = cdp->get_log_precinct_size(res_num);

--- a/src/core/codestream/ojph_subband.cpp
+++ b/src/core/codestream/ojph_subband.cpp
@@ -90,15 +90,16 @@ namespace ojph {
       //allocate codeblock headers
       allocator->pre_alloc_obj<coded_cb_header>((size_t)num_blocks.area());
 
+      const param_qcd* qp = codestream->access_qcd()->get_qcc(comp_num);
+      ui32 precision = qp->propose_precision(cdp);
+
       for (ui32 i = 0; i < num_blocks.w; ++i)
-        codeblock::pre_alloc(codestream, comp_num, nominal);
+        codeblock::pre_alloc(codestream, comp_num, nominal, precision);
 
       //allocate lines
       allocator->pre_alloc_obj<line_buf>(1);
       //allocate line_buf
       ui32 width = band_rect.siz.w + 1;
-      const param_siz* szp = codestream->get_siz();
-      ui32 precision = cdp->propose_precision(szp, comp_num);
       if (precision <= 32)      
         allocator->pre_alloc_data<si32>(width, 1);
       else
@@ -142,17 +143,18 @@ namespace ojph {
           dfs = dfs->get_dfs(cdp->get_dfs_index());
       }
       ui32 comp_num = parent->get_comp_num();
-      param_qcd* qcd = codestream->access_qcd(comp_num);
+      const param_qcd* qcd = codestream->access_qcd()->get_qcc(comp_num);
       ui32 num_decomps = cdp->get_num_decompositions();
       this->K_max = qcd->get_Kmax(dfs, num_decomps, this->res_num, band_num);
       if (!reversible)
       {
         float d = 
-          qcd->irrev_get_delta(dfs, num_decomps, res_num, subband_num);
+          qcd->get_irrev_delta(dfs, num_decomps, res_num, subband_num);
         d /= (float)(1u << (31 - this->K_max));
         delta = d;
         delta_inv = (1.0f/d);
       }
+      ui32 precision = qcd->propose_precision(cdp);
 
       this->empty = ((band_rect.siz.w == 0) || (band_rect.siz.h == 0));
       if (this->empty)
@@ -190,7 +192,8 @@ namespace ojph {
         ui32 cbx1 = ojph_min(tbx1, x_lower_bound + (i + 1) * nominal.w);
         cb_size.w = cbx1 - cbx0;
         blocks[i].finalize_alloc(codestream, this, nominal, cb_size,
-                                  coded_cbs + i, K_max, line_offset);
+                                 coded_cbs + i, K_max, line_offset, 
+                                 precision);
         line_offset += cb_size.w;
       }
 
@@ -198,8 +201,6 @@ namespace ojph {
       lines = allocator->post_alloc_obj<line_buf>(1);
       //allocate line_buf
       ui32 width = band_rect.siz.w + 1;
-      const param_siz* szp = codestream->get_siz();
-      ui32 precision = cdp->propose_precision(szp, comp_num);
       if (precision <= 32)      
         lines->wrap(allocator->post_alloc_data<si32>(width, 1), width, 1);
       else

--- a/src/core/codestream/ojph_subband.cpp
+++ b/src/core/codestream/ojph_subband.cpp
@@ -94,7 +94,7 @@ namespace ojph {
       ui32 precision = qp->propose_precision(cdp);
 
       for (ui32 i = 0; i < num_blocks.w; ++i)
-        codeblock::pre_alloc(codestream, comp_num, nominal, precision);
+        codeblock::pre_alloc(codestream, nominal, precision);
 
       //allocate lines
       allocator->pre_alloc_obj<line_buf>(1);

--- a/src/core/codestream/ojph_tile.cpp
+++ b/src/core/codestream/ojph_tile.cpp
@@ -210,12 +210,12 @@ namespace ojph {
 
         num_bits[i] = szp->get_bit_depth(i);
         is_signed[i] = szp->is_signed(i);
-        bool result = nlp->get_nonlinearity(i, bd, is, nlt_type3[i]);
+        bool result = nlp->get_nonlinear_transform(i, bd, is, nlt_type3[i]);
         if (result == true && (bd != num_bits[i] || is != is_signed[i]))
           OJPH_ERROR(0x000300A1, "Mismatch between Ssiz (bit_depth = %d, "
             "is_signed = %s) from SIZ marker segment, and BDnlt "
             "(bit_depth = %d, is_signed = %s) from NLT marker segment, "
-            "for component %d",i, num_bits[i], 
+            "for component %d", i, num_bits[i], 
             is_signed[i] ? "True" : "False", bd, is ? "True" : "False");
         cur_line[i] = 0;
       }

--- a/src/core/codestream/ojph_tile.cpp
+++ b/src/core/codestream/ojph_tile.cpp
@@ -67,7 +67,7 @@ namespace ojph {
       allocator->pre_alloc_obj<ui32>(num_comps); //for line_offsets
       allocator->pre_alloc_obj<ui32>(num_comps); //for num_bits
       allocator->pre_alloc_obj<bool>(num_comps); //for is_signed
-      allocator->pre_alloc_obj<bool>(num_comps); //for nlt_type3
+      allocator->pre_alloc_obj<ui8>(num_comps); //for nlt_type3
       allocator->pre_alloc_obj<ui32>(num_comps); //for cur_line
 
       ui32 tilepart_div = codestream->get_tilepart_div();
@@ -154,7 +154,7 @@ namespace ojph {
       line_offsets = allocator->post_alloc_obj<ui32>(num_comps);
       num_bits = allocator->post_alloc_obj<ui32>(num_comps);
       is_signed = allocator->post_alloc_obj<bool>(num_comps);
-      nlt_type3 = allocator->post_alloc_obj<bool>(num_comps);
+      nlt_type3 = allocator->post_alloc_obj<ui8>(num_comps);
       cur_line = allocator->post_alloc_obj<ui32>(num_comps);
 
       profile = codestream->get_profile();
@@ -210,8 +210,8 @@ namespace ojph {
 
         num_bits[i] = szp->get_bit_depth(i);
         is_signed[i] = szp->is_signed(i);
-        nlt_type3[i] = nlp->get_type3_transformation(i, bd, is);
-        if (nlt_type3[i] == true && (bd != num_bits[i] || is != is_signed[i]))
+        bool result = nlp->get_nonlinearity(i, bd, is, nlt_type3[i]);
+        if (result == true && (bd != num_bits[i] || is != is_signed[i]))
           OJPH_ERROR(0x000300A1, "Mismatch between Ssiz (bit_depth = %d, "
             "is_signed = %s) from SIZ marker segment, and BDnlt "
             "(bit_depth = %d, is_signed = %s) from NLT marker segment, "
@@ -244,6 +244,9 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     bool tile::push(line_buf *line, ui32 comp_num)
     {
+      constexpr ui8 type3 = 
+        param_nlt::nonlinearity::OJPH_NLT_BINARY_COMPLEMENT_NLT;
+
       assert(comp_num < num_comps);
       if (cur_line[comp_num] >= comp_rects[comp_num].siz.h)
         return false;
@@ -259,7 +262,7 @@ namespace ojph {
         if (reversible)
         {
           si64 shift = (si64)1 << (num_bits[comp_num] - 1);
-          if (is_signed[comp_num] && nlt_type3[comp_num])
+          if (is_signed[comp_num] && nlt_type3[comp_num] == type3)
             rev_convert_nlt_type3(line, line_offsets[comp_num],
               tc, 0, shift + 1, comp_width);
           else {
@@ -286,7 +289,7 @@ namespace ojph {
         ui32 comp_width = comp_rects[comp_num].siz.w;
         if (reversible)
         {
-          if (is_signed[comp_num] && nlt_type3[comp_num])
+          if (is_signed[comp_num] && nlt_type3[comp_num] == type3)
             rev_convert_nlt_type3(line, line_offsets[comp_num], 
               lines + comp_num, 0, shift + 1, comp_width);            
           else {
@@ -334,6 +337,9 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     bool tile::pull(line_buf* tgt_line, ui32 comp_num)
     {
+      constexpr ui8 type3 = 
+        param_nlt::nonlinearity::OJPH_NLT_BINARY_COMPLEMENT_NLT;
+
       assert(comp_num < num_comps);
       if (cur_line[comp_num] >= recon_comp_rects[comp_num].siz.h)
         return false;
@@ -347,7 +353,7 @@ namespace ojph {
         if (reversible)
         {
           si64 shift = (si64)1 << (num_bits[comp_num] - 1);
-          if (is_signed[comp_num] && nlt_type3[comp_num])
+          if (is_signed[comp_num] && nlt_type3[comp_num] == type3)
             rev_convert_nlt_type3(src_line, 0, tgt_line, 
               line_offsets[comp_num], shift + 1, comp_width);
           else {
@@ -390,7 +396,7 @@ namespace ojph {
             src_line = lines + comp_num;
           else
             src_line = comps[comp_num].pull_line();
-          if (is_signed[comp_num] && nlt_type3[comp_num])
+          if (is_signed[comp_num] && nlt_type3[comp_num] == type3)
             rev_convert_nlt_type3(src_line, 0, tgt_line, 
               line_offsets[comp_num], shift + 1, comp_width);
           else {

--- a/src/core/codestream/ojph_tile.h
+++ b/src/core/codestream/ojph_tile.h
@@ -89,7 +89,7 @@ namespace ojph {
       ui32 *num_bits;
       bool *is_signed;
       ui32 *cur_line;
-      bool *nlt_type3;
+      ui8 *nlt_type3;
       int prog_order;
 
     private:

--- a/src/core/codestream/ojph_tile_comp.cpp
+++ b/src/core/codestream/ojph_tile_comp.cpp
@@ -73,7 +73,7 @@ namespace ojph {
       mem_fixed_allocator* allocator = codestream->get_allocator();
 
       //allocate a resolution
-      num_decomps = codestream->get_cod(comp_num)->get_num_decompositions();
+      num_decomps = codestream->get_coc(comp_num)->get_num_decompositions();
 
       comp_downsamp = codestream->get_siz()->get_downsampling(comp_num);
       this->comp_rect = comp_rect;

--- a/src/core/common/ojph_params.h
+++ b/src/core/common/ojph_params.h
@@ -44,19 +44,18 @@
 
 namespace ojph {
 
-  ////////////////////////////////////////////////////////////////////////////
+  /***************************************************************************/
   //prototyping from local
   namespace local {
     struct param_siz;
     struct param_cod;
     struct param_qcd;
-    struct param_qcc;
     struct param_cap;
     struct param_nlt;
     class codestream;
   }
 
-  ////////////////////////////////////////////////////////////////////////////
+  /***************************************************************************/
   class OJPH_EXPORT param_siz
   {
   public:
@@ -89,7 +88,7 @@ namespace ojph {
     local::param_siz* state;
   };
 
-  ////////////////////////////////////////////////////////////////////////////
+  /***************************************************************************/
   class OJPH_EXPORT param_cod
   {
   public:
@@ -120,21 +119,91 @@ namespace ojph {
     local::param_cod* state;
   };
 
-  ////////////////////////////////////////////////////////////////////////////
+  /***************************************************************************/
+  /**
+    * @brief Quantization parameters object
+    * 
+    */
   class OJPH_EXPORT param_qcd
   {
   public:
     param_qcd(local::param_qcd* p) : state(p) {}
 
+    /**
+     * @brief Set the irreversible quantization base delta.  
+     *  
+     * This represents the default base delta and influences QCD marker 
+     * segment
+     * 
+     * @param delta 
+     */
     void set_irrev_quant(float delta);
+
+    /**
+     * @brief Set the irreversible quantization base delta for a specific 
+     *        component
+     * 
+     * This represents the default base delta for component comp_idx, and 
+     * influences QCC marker segment for the component, inserting one
+     * if needed, which is usually the case.
+     * 
+     * @param comp_idx 
+     * @param delta 
+     */
+    void set_irrev_quant(ui32 comp_idx, float delta);
 
   private:
     local::param_qcd* state;
   };
 
+  /*************************************************************************/
   /**
     * @brief non-linearity point transformation object
     *        (implements NLT marker segment)
+    * 
+    *  There are a few things to know here.  
+      * The NLT marker segment contains the nonlinearity type and the 
+      * bit depth and signedness of the component to which it applies.
+      * There is the default component ALL_COMPS which applies to all 
+      * components unless it is overridden by another NLT segment marker.
+      * The library checks that the settings make sense, and also make
+      * sure that bit depth and signedness are correct, creating any missing
+      * NLT marker segments in the process.
+      * If all components have the same bit depth and signedness, and need
+      * nonlinearity type 3 (Binary Complement to Sign Magnitude Conversion), 
+      * then the best option is to set ALL_COMPS to type 3.
+      * Otherwise, the best option is to set type 3 only to components that 
+      * need it, leaving out the default ALL_COMPS nonlinearity not set.
+      * Another option is for the end-user can set the ALL_COMPS to type 3, 
+      * and then put exception for the components that does not need type 3, 
+      * by setting them to type 0.
+      * 
+      * The library, during validity check, which is run when the codestream
+      * is created for writing, will do the following:
+      * -- If ALL_COMPS is set to type 0, it will be ignored, and the 
+      * codestream will NOT have the corresponding NLT marker segment.
+      * -- If ALL_COMPS is set to type 3, then the following will happen:
+      *   - If all the components (except those with type 0 set for them) have 
+      *   the same bit depth and signedness, then the ALL_COMPS NLT marker 
+      *   segment will be respected and inserted into the codestream.
+      *   Of course, components with NLT 0 will also have the corresponding
+      *   NLT marker segment inserted.
+      *   - If components, for which no NTL type 0 is specified, have differing
+      *   bit depth or signedness, then the ALL_COMPS will be ignored, and 
+      *   NLT markers are inserted for each component that needs type 3.
+      * Components that have their component field larger than the number of
+      * components in the codestream are removed.
+      * 
+      * It also worth noting that type 3 nonlinearity has no effect on 
+      * positive image samples.  It is also not recommended for integer-valued 
+      * types. It is only recommended for floating-point image samples, for 
+      * which some of the samples are negative, where type 3 nonlinearity 
+      * should be beneficial.  This is because the encoding engine expects 
+      * two-complement representation for negative values while floating point 
+      * numbers have a sign bit followed by an exponent, which has a biased 
+      * integer representation.  The core idea is to make floating-point
+      * representation more compatible with integer representation.
+
     * 
     */
   class OJPH_EXPORT param_nlt
@@ -145,7 +214,9 @@ namespace ojph {
       OJPH_NLT_NO_NLT = 0,                // supported
       OJPH_NLT_GAMMA_STYLE_NLT = 1,       // not supported
       OJPH_NLT_LUT_STYLE_NLT = 2,         // not supported
-      OJPH_NLT_BINARY_COMPLEMENT_NLT = 3  // supported
+      OJPH_NLT_BINARY_COMPLEMENT_NLT = 3, // supported
+      OJPH_NLT_UNDEFINED = 255          // This is used internally and is 
+                                          // not part of the standard 
     };
   public:
     param_nlt(local::param_nlt* p) : state(p) {}
@@ -157,37 +228,11 @@ namespace ojph {
       * When creating a codestream for writing, call this function before
       * you call codestream::write_headers.
       * 
-      * There are a few things to know here.  
-      * The NLT marker segment contains the nonlinearity type and the 
-      * bit depth and signedness of the component to which it applies.
-      * There is the default component ALL_COMPS which applies to all 
-      * components unless it is overridden by another NLT segment marker.
-      * The library checks that the settings make sense, and also make
-      * sure that bit depth and signedness are correct, creating any missing
-      * NLT marker segments.
-      * If all components have the same bit depth and signedness, and need
-      * nonlinearity type 3 (Binary Complement to Sign Magnitude Conversion), 
-      * then the best option is to set ALL_COMPS to type 3.
-      * Otherwise, the best option is to set type 3 only to components that 
-      * need it, leaving out the default ALL_COMPS nonlinearity not set.
-      * Another option is for the end-user can set the ALL_COMPS to type 3, 
-      * and then put exception for the components that does not need type 3, 
-      * by setting them to type 0.
-      * 
-      * It also worth noting that type 3 nonlinearity has no effect on 
-      * positive image samples.  It is also not recommended for integer-valued 
-      * types. It is only recommended for floating-points image samples for 
-      * which some of the samples are negative, where type 3 nonlinearity 
-      * should be beneficial.  This is because the encoding engine expects 
-      * two-complement representation for negative values while floating point 
-      * numbers have a sign bit followed by an exponent, which has a biased 
-      * integer representation.  The core idea is to make floating-point
-      * representation more compatible with integer representation.
       * 
       * @param comp_num: component number, or 65535 for the default setting
       * @param type: desired non-linearity from enum nonlinearity
       */
-    void set_nonlinearity(ui32 comp_num, nonlinearity type);
+    void set_nonlinearity(ui32 comp_num, ui8 nl_type);
 
     /**
       * @brief get the nonlinearity type associated with comp_num, which 
@@ -200,13 +245,13 @@ namespace ojph {
       * @return true if the nonlinearity for comp_num is set
       */
     bool get_nonlinearity(ui32 comp_num, ui8& bit_depth, 
-                          bool& is_signed, nonlinearity& type) const;
+                          bool& is_signed, ui8& nl_type) const;
 
   private:
     local::param_nlt* state;
   };
 
-  ////////////////////////////////////////////////////////////////////////////
+  /***************************************************************************/
   class OJPH_EXPORT comment_exchange
   {
     friend class local::codestream;

--- a/src/core/common/ojph_params.h
+++ b/src/core/common/ojph_params.h
@@ -232,7 +232,7 @@ namespace ojph {
       * @param comp_num: component number, or 65535 for the default setting
       * @param type: desired non-linearity from enum nonlinearity
       */
-    void set_nonlinearity(ui32 comp_num, ui8 nl_type);
+    void set_nonlinear_transform(ui32 comp_num, ui8 nl_type);
 
     /**
       * @brief get the nonlinearity type associated with comp_num, which 
@@ -244,8 +244,8 @@ namespace ojph {
       * @param type: nonlinearity type
       * @return true if the nonlinearity for comp_num is set
       */
-    bool get_nonlinearity(ui32 comp_num, ui8& bit_depth, 
-                          bool& is_signed, ui8& nl_type) const;
+    bool get_nonlinear_transform(ui32 comp_num, ui8& bit_depth, 
+                                 bool& is_signed, ui8& nl_type) const;
 
   private:
     local::param_nlt* state;

--- a/src/core/common/ojph_version.h
+++ b/src/core/common/ojph_version.h
@@ -34,5 +34,5 @@
 //***************************************************************************/
 
 #define OPENJPH_VERSION_MAJOR 0
-#define OPENJPH_VERSION_MINOR 18
-#define OPENJPH_VERSION_PATCH 2
+#define OPENJPH_VERSION_MINOR 19
+#define OPENJPH_VERSION_PATCH 0


### PR DESCRIPTION
This PR modifies the code for QCD and QCC marker segment to support components with differing bit depths/signedness.
For lossy compression, now different components can also have different quantization step sizes.