### PR TITLE
This adds support for COC.

### DIFF
--- a/src/core/codestream/ojph_codeblock.cpp
+++ b/src/core/codestream/ojph_codeblock.cpp
@@ -74,7 +74,7 @@ namespace ojph {
                                    const size& cb_size,
                                    coded_cb_header* coded_cb,
                                    ui32 K_max, int line_offset,
-                                   ui32 precision)
+                                   ui32 precision, ui32 comp_idx)
     {
       mem_fixed_allocator* allocator = codestream->get_allocator();
 
@@ -101,10 +101,10 @@ namespace ojph {
       this->K_max = K_max;
       for (int i = 0; i < 4; ++i)
         this->max_val64[i] = 0;
-      ojph::param_cod cod = codestream->access_cod();
-      this->reversible = cod.is_reversible();
+      const param_cod* coc = codestream->get_coc(comp_idx);
+      this->reversible = coc->is_reversible();
       this->resilient = codestream->is_resilient();
-      this->stripe_causal = cod.get_block_vertical_causality();
+      this->stripe_causal = coc->get_block_vertical_causality();
       this->zero_block = false;
       this->coded_cb = coded_cb;
 

--- a/src/core/codestream/ojph_codeblock.h
+++ b/src/core/codestream/ojph_codeblock.h
@@ -75,8 +75,8 @@ namespace ojph {
                             ui32 precision);
       void finalize_alloc(codestream *codestream, subband* parent,
                           const size& nominal, const size& cb_size,
-                          coded_cb_header* coded_cb,
-                          ui32 K_max, int tbx0, ui32 precision);
+                          coded_cb_header* coded_cb, ui32 K_max, 
+                          int tbx0, ui32 precision, ui32 comp_idx);
       void push(line_buf *line);
       void encode(mem_elastic_allocator *elastic);
       void recreate(const size& cb_size, coded_cb_header* coded_cb);

--- a/src/core/codestream/ojph_codestream_local.cpp
+++ b/src/core/codestream/ojph_codestream_local.cpp
@@ -79,9 +79,6 @@ namespace ojph {
 
       precinct_scratch_needed_bytes = 0;
 
-      used_coc_fields = 0;
-      coc = coc_store;
-
       atk = atk_store;
       atk[0].init_irv97();
       atk[0].link(atk_store + 1);
@@ -626,6 +623,9 @@ namespace ojph {
       if (!cod.write(file))
         OJPH_ERROR(0x00030025, "Error writing to file");
 
+      if (!cod.write_coc(file, num_comps))
+        OJPH_ERROR(0x0003002E, "Error writing to file");
+
       if (!qcd.write(file))
         OJPH_ERROR(0x00030026, "Error writing to file");
 
@@ -751,7 +751,7 @@ namespace ojph {
           skip_marker(file, "CPF", NULL, OJPH_MSG_LEVEL::NO_MSG, false);
         else if (marker_idx == 3)
         { 
-          cod.read(file, param_cod::COD_MAIN); 
+          cod.read(file);
           received_markers |= 1;
           ojph::param_cod c(&cod);
           int num_qlayers = c.get_num_layers();
@@ -762,12 +762,17 @@ namespace ojph {
         }
         else if (marker_idx == 4) 
         {
-          ui32 num_comps = siz.get_num_components();
-          if (coc == coc_store && 
-              num_comps * sizeof(param_cod) > sizeof(coc_store))
-            coc = new param_cod[num_comps];
-          coc[used_coc_fields++].read(
-            file, param_cod::COC_MAIN, num_comps, &cod);
+          param_cod* p = cod.add_coc_object(param_cod::OJPH_COD_UNKNOWN);
+          p->read_coc(file, siz.get_num_components(), &cod);
+          if (p->get_comp_idx() >= siz.get_num_components())
+            OJPH_INFO(0x00030056, "The codestream carries a COC marker "
+              "segment for a component indexed by %d, which is more than the "
+              "allowed index number, since the codestream has %d components", 
+              p->get_comp_idx(), num_comps);
+          param_cod *q = cod.get_coc(p->get_comp_idx());
+          if (p != q && p->get_comp_idx() == q->get_comp_idx())
+            OJPH_ERROR(0x00030057, "The codestream has two COC marker "
+              "segments for one component of index %d",  p->get_comp_idx());
         }
         else if (marker_idx == 5)
         { 
@@ -779,15 +784,14 @@ namespace ojph {
           param_qcd* p = qcd.add_qcc_object(param_qcd::OJPH_QCD_UNKNOWN); 
           p->read_qcc(file, siz.get_num_components());
           if (p->get_comp_idx() >= siz.get_num_components())
-            OJPH_ERROR(0x00030054, "The codestream carries a QCC narker "
+            OJPH_ERROR(0x00030054, "The codestream carries a QCC marker "
               "segment for a component indexed by %d, which is more than the "
               "allowed index number, since the codestream has %d components", 
               p->get_comp_idx(), num_comps);
           param_qcd *q = qcd.get_qcc(p->get_comp_idx());
           if (p != q && p->get_comp_idx() == q->get_comp_idx())
             OJPH_ERROR(0x00030055, "The codestream has two QCC marker "
-              "segments for one component of index %d", 
-              p->get_comp_idx());
+              "segments for one component of index %d", p->get_comp_idx());
         }
         else if (marker_idx == 7)
           skip_marker(file, "RGN", "RGN is not supported yet",
@@ -827,12 +831,6 @@ namespace ojph {
       }
 
       cod.update_atk(atk);
-      for (int i = 0; i < used_coc_fields; ++i) 
-      {
-        if (i == 0) cod.link_cod(coc);
-        else coc[i - 1].link_cod(coc + i);
-        coc[i].update_atk(atk);
-      }
       siz.link(&cod);
       if (dfs.exists())
         siz.link(&dfs);

--- a/src/core/codestream/ojph_codestream_local.h
+++ b/src/core/codestream/ojph_codestream_local.h
@@ -159,11 +159,6 @@ namespace ojph {
       param_tlm tlm;         // tile-part lengths
       param_nlt nlt;         // non-linearity point transformation
 
-    private: // this is to handle qcc and coc
-      int used_coc_fields;
-      param_cod *coc;         // coding style component
-      param_cod coc_store[4]; // we allocate 4, we allocate more if needed
-
     private:  // these are from Part 2 of the standard
       param_dfs dfs;         // downsmapling factor styles
       param_atk* atk;        // a pointer to atk

--- a/src/core/codestream/ojph_params.cpp
+++ b/src/core/codestream/ojph_params.cpp
@@ -914,7 +914,7 @@ namespace ojph {
 
       //marker size excluding header
       Lcod = num_comps < 257 ? 9 : 10;
-      Lcod = (ui16)(Lcod + (Scod & 1 ? SPcod.num_decomp : 0));
+      Lcod = (ui16)(Lcod + (Scod & 1 ? 1 + SPcod.num_decomp : 0));
 
       ui8 buf[4];
       bool result = true;

--- a/src/core/codestream/ojph_params.cpp
+++ b/src/core/codestream/ojph_params.cpp
@@ -958,7 +958,6 @@ namespace ojph {
     {
       assert(type == COD_MAIN);
 
-      this->type = type;
       if (file->read(&Lcod, 2) != 2)
         OJPH_ERROR(0x00050071, "error reading COD segment");
       Lcod = swap_byte(Lcod);
@@ -997,7 +996,6 @@ namespace ojph {
       assert(type == COC_MAIN);
       assert(top_cod != NULL);
 
-      this->type = type;
       this->SGCod = top_cod->SGCod;
       this->top_cod = top_cod;
       if (file->read(&Lcod, 2) != 2)
@@ -1091,7 +1089,7 @@ namespace ojph {
       param_cod *p = this;
       while (p->next != NULL)
         p = p->next;
-      p->next = new param_cod(this, comp_idx);
+      p->next = new param_cod(this, (ui16)comp_idx);
       return p->next;
     }
 

--- a/src/core/codestream/ojph_params.cpp
+++ b/src/core/codestream/ojph_params.cpp
@@ -919,7 +919,8 @@ namespace ojph {
       ui8 buf[4];
       bool result = true;
 
-      *(ui16*)buf = swap_byte(JP2K_MARKER::COC);
+      *(ui16*)buf = JP2K_MARKER::COC;
+      *(ui16*)buf = swap_byte(*(ui16*)buf);
       result &= file->write(&buf, 2) == 2;
       *(ui16*)buf = swap_byte(Lcod);
       result &= file->write(&buf, 2) == 2;

--- a/src/core/codestream/ojph_params.cpp
+++ b/src/core/codestream/ojph_params.cpp
@@ -255,6 +255,15 @@ namespace ojph {
   }
 
   ////////////////////////////////////////////////////////////////////////////
+  param_coc param_cod::get_coc(ui32 component_idx)
+  {
+    local::param_cod *p = state->get_coc(component_idx);
+    if (p == state) // no COC segment marker for this component
+      p = state->add_coc_object(component_idx);
+    return param_coc(p);
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
   ui32 param_cod::get_num_decompositions() const
   {
     return state->get_num_decompositions();
@@ -275,12 +284,7 @@ namespace ojph {
   ////////////////////////////////////////////////////////////////////////////
   bool param_cod::is_reversible() const
   {
-    if (state->SPcod.wavelet_trans <= 1)
-      return state->get_wavelet_kern() == local::param_cod::DWT_REV53;
-    else {
-      assert(state->atk != NULL);
-      return state->access_atk()->is_reversible();
-    }
+    return state->is_reversible();
   }
 
   ////////////////////////////////////////////////////////////////////////////
@@ -346,8 +350,60 @@ namespace ojph {
   ////////////////////////////////////////////////////////////////////////////
   bool param_cod::get_block_vertical_causality() const
   {
-    return (state->SPcod.block_style & local::param_cod::VERT_CAUSAL_MODE)!=0;
+    return state->get_block_vertical_causality();
   }
+
+  ////////////////////////////////////////////////////////////////////////////
+  //
+  //
+  //
+  //
+  //
+  ////////////////////////////////////////////////////////////////////////////
+
+  ////////////////////////////////////////////////////////////////////////////
+  void param_coc::set_num_decomposition(ui32 num_decompositions)
+  { ojph::param_cod(state).set_num_decomposition(num_decompositions); }
+
+  ////////////////////////////////////////////////////////////////////////////
+  void param_coc::set_block_dims(ui32 width, ui32 height)
+  { ojph::param_cod(state).set_block_dims(width, height); }
+  
+  ////////////////////////////////////////////////////////////////////////////  
+  void param_coc::set_precinct_size(int num_levels, size* precinct_size)
+  { ojph::param_cod(state).set_precinct_size(num_levels, precinct_size); }
+
+  ////////////////////////////////////////////////////////////////////////////
+  void param_coc::set_reversible(bool reversible)
+  { ojph::param_cod(state).set_reversible(reversible); }
+
+  ////////////////////////////////////////////////////////////////////////////
+  ui32 param_coc::get_num_decompositions() const
+  { return ojph::param_cod(state).get_num_decompositions(); }
+
+  ////////////////////////////////////////////////////////////////////////////
+  size param_coc::get_block_dims() const
+  { return ojph::param_cod(state).get_block_dims(); }
+
+  ////////////////////////////////////////////////////////////////////////////
+  size param_coc::get_log_block_dims() const
+  { return ojph::param_cod(state).get_log_block_dims(); }
+
+  ////////////////////////////////////////////////////////////////////////////
+  bool param_coc::is_reversible() const
+  { return ojph::param_cod(state).is_reversible(); }
+
+  ////////////////////////////////////////////////////////////////////////////
+  size param_coc::get_precinct_size(ui32 level_num) const
+  { return ojph::param_cod(state).get_precinct_size(level_num); }
+
+  ////////////////////////////////////////////////////////////////////////////
+  size param_coc::get_log_precinct_size(ui32 level_num) const
+  { return ojph::param_cod(state).get_log_precinct_size(level_num); }
+
+  ////////////////////////////////////////////////////////////////////////////
+  bool param_coc::get_block_vertical_causality() const
+  { return ojph::param_cod(state).get_block_vertical_causality(); }
 
 
   ////////////////////////////////////////////////////////////////////////////
@@ -784,6 +840,17 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
 
     //////////////////////////////////////////////////////////////////////////
+    bool param_cod::is_reversible() const
+    { 
+      if (SPcod.wavelet_trans <= 1)
+        return get_wavelet_kern() == local::param_cod::DWT_REV53;
+      else {
+        assert(atk != NULL);
+        return atk->is_reversible();
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
     bool param_cod::write(outfile_base *file)
     {
       assert(type == COD_MAIN);
@@ -826,9 +893,68 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void param_cod::read(infile_base *file, param_cod::cod_type type)
+    bool param_cod::write_coc(outfile_base *file, ui32 num_comps)
     {
-      assert(this->type == UNDEFINED);
+      assert(type == COD_MAIN);
+      bool result = true;
+      param_cod *p = this->next;
+      while (p)
+      {
+        if (p->comp_idx < num_comps)
+          result &= p->internal_write_coc(file, num_comps);
+        p = p->next;
+      }
+      return result;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    bool param_cod::internal_write_coc(outfile_base *file, ui32 num_comps)
+    {
+      assert(type == COC_MAIN);
+
+      //marker size excluding header
+      Lcod = num_comps < 257 ? 9 : 10;
+      Lcod = (ui16)(Lcod + (Scod & 1 ? SPcod.num_decomp : 0));
+
+      ui8 buf[4];
+      bool result = true;
+
+      *(ui16*)buf = swap_byte(JP2K_MARKER::COC);
+      result &= file->write(&buf, 2) == 2;
+      *(ui16*)buf = swap_byte(Lcod);
+      result &= file->write(&buf, 2) == 2;
+      if (num_comps < 257)
+      {
+        *(ui8*)buf = (ui8)comp_idx;
+        result &= file->write(&buf, 1) == 1;
+      }
+      else
+      {
+        *(ui16*)buf = swap_byte(comp_idx);
+        result &= file->write(&buf, 2) == 2;
+      }
+      *(ui8*)buf = Scod;
+      result &= file->write(&buf, 1) == 1;
+      buf[0] = SPcod.num_decomp;
+      buf[1] = SPcod.block_width;
+      buf[2] = SPcod.block_height;
+      buf[3] = SPcod.block_style;
+      result &= file->write(&buf, 4) == 4;
+      *(ui8*)buf = SPcod.wavelet_trans;
+      result &= file->write(&buf, 1) == 1;
+      if (Scod & 1)
+        for (int i = 0; i <= SPcod.num_decomp; ++i)
+        {
+          *(ui8*)buf = SPcod.precinct_size[i];
+          result &= file->write(&buf, 1) == 1;
+        }
+
+      return result;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void param_cod::read(infile_base *file)
+    {
       assert(type == COD_MAIN);
 
       this->type = type;
@@ -864,16 +990,15 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void param_cod::read(infile_base* file, param_cod::cod_type type, 
-                         ui32 num_comps, param_cod *cod)
+    void param_cod::read_coc(infile_base* file, ui32 num_comps, 
+                             param_cod *top_cod)
     {
-      assert(this->type == UNDEFINED);
       assert(type == COC_MAIN);
-      assert(cod != NULL);
+      assert(top_cod != NULL);
 
       this->type = type;
-      this->SGCod = cod->SGCod;
-      this->parent = cod;
+      this->SGCod = top_cod->SGCod;
+      this->top_cod = top_cod;
       if (file->read(&Lcod, 2) != 2)
         OJPH_ERROR(0x00050121, "error reading COC segment");
       Lcod = swap_byte(Lcod);
@@ -881,12 +1006,12 @@ namespace ojph {
         ui8 t;
         if (file->read(&t, 1) != 1)
           OJPH_ERROR(0x00050122, "error reading COC segment");
-        comp_num = t;
+        comp_idx = t;
       }
       else {
-        if (file->read(&comp_num, 2) != 2)
+        if (file->read(&comp_idx, 2) != 2)
           OJPH_ERROR(0x00050123, "error reading COC segment");
-        comp_num = swap_byte(comp_num);
+        comp_idx = swap_byte(comp_idx);
       }
       if (file->read(&Scod, 1) != 1)
         OJPH_ERROR(0x00050124, "error reading COC segment");
@@ -917,11 +1042,56 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     void param_cod::update_atk(const param_atk* atk)
     {
+      assert(type == COD_MAIN);
       this->atk = atk->get_atk(SPcod.wavelet_trans);
       if (this->atk == NULL)
-        OJPH_ERROR(0x00050131, "A COD/COC segment employs the DWT kernel "
-          "atk=%d, but a corresponding ATK segment cannot be found", 
+        OJPH_ERROR(0x00050131, "A COD segment employs the DWT kernel "
+          "atk = %d, but a corresponding ATK segment cannot be found.", 
           SPcod.wavelet_trans);
+      param_cod *p = next;
+      while (p)
+      {
+        p->atk = atk->get_atk(p->SPcod.wavelet_trans);
+        if (p->atk == NULL)
+          OJPH_ERROR(0x00050132, "A COC segment employs the DWT kernel "
+            "atk = %d, but a corresponding ATK segment cannot be found", 
+            SPcod.wavelet_trans);
+        p = p->next;
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    const param_cod* param_cod::get_coc(ui32 comp_idx) const
+    {
+      assert(this->type == COD_MAIN || this->top_cod->type == COD_MAIN);
+      const param_cod *p, *q;
+      if (this->type == COD_MAIN)
+        q = p = this;
+      else
+        q = p = this->top_cod;
+      while (p && p->comp_idx != comp_idx)
+        p = p->next;
+      return p ? p : q;
+    }
+
+    ////////////////////////////////////////
+    param_cod* param_cod::get_coc(ui32 comp_idx)
+    {
+      // cast object to constant
+      const param_cod* const_p = const_cast<const param_cod*>(this);
+      // call using the constant object, then cast to non-const
+      return const_cast<param_cod*>(const_p->get_coc(comp_idx));
+    }
+
+    ////////////////////////////////////////
+    param_cod* param_cod::add_coc_object(ui32 comp_idx)
+    {
+      assert(type == COD_MAIN);
+      param_cod *p = this;
+      while (p->next != NULL)
+        p = p->next;
+      p->next = new param_cod(this, comp_idx);
+      return p->next;
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -1230,7 +1400,7 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     ui32 param_qcd::propose_precision(const param_cod* cod) const
     {
-      ui32 comp_idx = cod->get_comp_num();
+      ui32 comp_idx = cod->get_comp_idx();
       ui32 precision = 0;
       const param_cod *main = 
         cod->get_coc(param_cod::OJPH_COD_DEFAULT);
@@ -1552,11 +1722,15 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     const param_qcd* param_qcd::get_qcc(ui32 comp_idx) const
     {
-      assert(this->top_qcd->type == QCD_MAIN);
-      param_qcd* p = this->top_qcd;
+      assert(this->type == QCD_MAIN || this->top_qcd->type == QCD_MAIN);
+      const param_qcd *p, *q;
+      if (this->type == QCD_MAIN)
+        q = p = this;
+      else
+        q = p = this->top_qcd;
       while (p && p->comp_idx != comp_idx)
         p = p->next;
-      return p ? p : this->top_qcd;
+      return p ? p : q;
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -1566,14 +1740,8 @@ namespace ojph {
       param_qcd *p = this;
       while (p->next != NULL)
         p = p->next;
-      p->next = new param_qcd;
-      p = p->next;
-
-      p->type = QCC_MAIN;
-      p->next = NULL;
-      p->top_qcd = this;
-      p->comp_idx = (ui16)comp_idx;
-      return p;
+      p->next = new param_qcd(this, (ui16)comp_idx);
+      return p->next;
     }
 
     //////////////////////////////////////////////////////////////////////////

--- a/src/core/codestream/ojph_resolution.cpp
+++ b/src/core/codestream/ojph_resolution.cpp
@@ -1039,13 +1039,11 @@ namespace ojph {
     {
       if (this->res_num == resolution_num)
         return get_num_bytes();
-      else {
-        if (child_res)
-          return child_res->get_num_bytes(resolution_num);
-        else
-          return 0;
+      if (resolution_num < this->res_num) {
+        assert(child_res);
+        return child_res->get_num_bytes(resolution_num);
       }
-
+      return 0;
     }
   }
 }

--- a/src/core/codestream/ojph_subband.cpp
+++ b/src/core/codestream/ojph_subband.cpp
@@ -200,7 +200,7 @@ namespace ojph {
         cb_size.w = cbx1 - cbx0;
         blocks[i].finalize_alloc(codestream, this, nominal, cb_size,
                                  coded_cbs + i, K_max, line_offset, 
-                                 precision);
+                                 precision, comp_num);
         line_offset += cb_size.w;
       }
 

--- a/src/core/codestream/ojph_tile.h
+++ b/src/core/codestream/ojph_tile.h
@@ -81,7 +81,8 @@ namespace ojph {
       tile_comp *comps;
       ui32 num_lines;
       line_buf* lines;
-      bool reversible, employ_color_transform, resilient;
+      bool employ_color_transform, resilient;
+      bool *reversible;
       rect *comp_rects, *recon_comp_rects;
       ui32 *line_offsets;
       ui32 skipped_res_for_read;

--- a/src/core/codestream/ojph_tile_comp.cpp
+++ b/src/core/codestream/ojph_tile_comp.cpp
@@ -58,7 +58,8 @@ namespace ojph {
       mem_fixed_allocator* allocator = codestream->get_allocator();
 
       //allocate a resolution
-      ui32 num_decomps = codestream->access_cod().get_num_decompositions();
+      ui32 num_decomps;
+      num_decomps = codestream->get_coc(comp_num)->get_num_decompositions();
       allocator->pre_alloc_obj<resolution>(1);
 
       resolution::pre_alloc(codestream, comp_rect, recon_comp_rect, comp_num, 
@@ -130,13 +131,12 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     bool tile_comp::get_top_left_precinct(ui32 res_num, point &top_left)
     {
-      assert(res_num <= num_decomps);
-      res_num = num_decomps - res_num;
+      int resolution_num = (int)num_decomps - (int)res_num;
       resolution *r = res;
-      while (res_num > 0 && r != NULL)
+       while (resolution_num > 0 && r != NULL)
       {
         r = r->next_resolution();
-        --res_num;
+        --resolution_num;
       }
       if (r) //resolution does not exist if r is NULL
         return r->get_top_left_precinct(top_left);
@@ -147,13 +147,12 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     void tile_comp::write_one_precinct(ui32 res_num, outfile_base *file)
     {
-      assert(res_num <= num_decomps);
-      res_num = num_decomps - res_num;
+      int resolution_num = (int)num_decomps - (int)res_num;
       resolution *r = res;
-      while (res_num > 0 && r != NULL)
+      while (resolution_num > 0 && r != NULL)
       {
         r = r->next_resolution();
-        --res_num;
+        --resolution_num;
       }
       if (r) //resolution does not exist if r is NULL
         r->write_one_precinct(file);

--- a/src/core/common/ojph_params.h
+++ b/src/core/common/ojph_params.h
@@ -45,10 +45,21 @@
 namespace ojph {
 
   /***************************************************************************/
-  //prototyping from local
+  // defined here
+  class param_siz;
+  class param_cod;
+  class param_coc;
+  class param_qcd;
+  class param_cap;
+  class param_nlt;
+  class codestream;
+
+  /***************************************************************************/
+  // prototyping from local
   namespace local {
     struct param_siz;
     struct param_cod;
+    struct param_coc;
     struct param_qcd;
     struct param_cap;
     struct param_nlt;
@@ -100,6 +111,7 @@ namespace ojph {
     void set_progression_order(const char *name);
     void set_color_transform(bool color_transform);
     void set_reversible(bool reversible);
+    param_coc get_coc(ui32 component_idx);
 
     ui32 get_num_decompositions() const;
     size get_block_dims() const;
@@ -113,6 +125,29 @@ namespace ojph {
     bool is_using_color_transform() const;
     bool packets_may_use_sop() const;
     bool packets_use_eph() const;
+    bool get_block_vertical_causality() const;
+
+  private:
+    local::param_cod* state;
+  };
+
+  /***************************************************************************/
+  class OJPH_EXPORT param_coc
+  {
+  public:
+    param_coc(local::param_cod* p) : state(p) {}
+
+    void set_num_decomposition(ui32 num_decompositions);
+    void set_block_dims(ui32 width, ui32 height);
+    void set_precinct_size(int num_levels, size* precinct_size);
+    void set_reversible(bool reversible);
+
+    ui32 get_num_decompositions() const;
+    size get_block_dims() const;
+    size get_log_block_dims() const;
+    bool is_reversible() const;
+    size get_precinct_size(ui32 level_num) const;
+    size get_log_precinct_size(ui32 level_num) const;
     bool get_block_vertical_causality() const;
 
   private:

--- a/src/core/common/ojph_version.h
+++ b/src/core/common/ojph_version.h
@@ -34,5 +34,5 @@
 //***************************************************************************/
 
 #define OPENJPH_VERSION_MAJOR 0
-#define OPENJPH_VERSION_MINOR 19
-#define OPENJPH_VERSION_PATCH 1
+#define OPENJPH_VERSION_MINOR 20
+#define OPENJPH_VERSION_PATCH 0

--- a/src/core/transform/ojph_colour_sse2.cpp
+++ b/src/core/transform/ojph_colour_sse2.cpp
@@ -83,28 +83,6 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    // _mm_max_epi32 requires SSE4.1, so here we implement it in SSE2
-    static inline
-    __m128i ojph_mm_max_epi32(__m128i a, __m128i b)
-    {
-      __m128i c = _mm_cmpgt_epi32(a, b);  // 0xFFFFFFFF for a > b
-      __m128i d = _mm_and_si128(c, a);    // keep only a, where a > b
-      __m128i e = _mm_andnot_si128(c, b); // keep only b, where a <= b
-      return _mm_or_si128(d, e);          // combine
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    // _mm_min_epi32 requires SSE4.1, so here we implement it in SSE2
-    static inline
-    __m128i ojph_mm_min_epi32 (__m128i a, __m128i b)
-    {
-      __m128i c = _mm_cmplt_epi32(a, b);  // 0xFFFFFFFF for a < b
-      __m128i d = _mm_and_si128(c, a);    // keep only a, where a < b
-      __m128i e = _mm_andnot_si128(c, b); // keep only b, where a >= b
-      return _mm_or_si128(d, e);          // combine
-    }
-
-    //////////////////////////////////////////////////////////////////////////
     static inline
     __m128i ojph_mm_max_ge_epi32(__m128i a, __m128i b, __m128 x, __m128 y)
     {


### PR DESCRIPTION
This pull requests adds support for COC.
Support for COC allows us to have different coding styles for different components; in particular this can be useful for compressing one component losslessly while employing lossy compression for the others, such as the case for RGBA where we want to employ lossy compression for RGB and compress the alpha channel losslessly.

The applications do not have such support yet.