### PR TITLE
update Dockerfile to use clang instead of gcc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-FROM ubuntu:focal
+FROM ubuntu:noble
 
 RUN apt-get update
 
 # disable interactive install 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # install developement tools
 RUN apt-get -y install cmake
-RUN apt-get -y install g++
+#RUN apt-get -y install g++
+RUN apt-get -y install clang
 RUN apt-get -y install libtiff-dev
 
 # install developement debugging tools
@@ -17,9 +18,10 @@ RUN apt-get -y install valgrind
 WORKDIR /usr/src/openjph/
 COPY . .
 WORKDIR /usr/src/openjph/build
-RUN cmake -DCMAKE_BUILD_TYPE=Release ../
+RUN rm -R * || true
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=asan ../
 RUN make
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/src/openjph/bin
+ENV LD_LIBRARY_PATH=/usr/src/openjph/bin
 ENV PATH=$PATH:/usr/src/openjph/bin
 
 # finalize docker environment


### PR DESCRIPTION
DO NOT MERGE

This PR updates the Dockerfile to use clang instead of GCC.  

Using this Dockerfile on an AVX512 machine demonstrates that OpenJPH compiles OK but fails at runtime when using a AVX512 machine, as reported in issue #188 


