### PR TITLE
Adds an option to restart a codestream.

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -116,6 +116,17 @@ else()
 
 endif()
 
+## Set debug postfix for different platforms
+if (MSVC)
+  if (NOT DEFINED CMAKE_DEBUG_POSTFIX)
+    set(CMAKE_DEBUG_POSTFIX "d")
+  endif()
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+  if (NOT DEFINED CMAKE_DEBUG_POSTFIX)
+    set(CMAKE_DEBUG_POSTFIX "_d")
+  endif()
+endif()
+
 add_library(openjph ${SOURCES})
 
 ## The option BUILD_SHARED_LIBS

--- a/src/core/codestream/ojph_codestream.cpp
+++ b/src/core/codestream/ojph_codestream.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman 
+// Copyright (c) 2019, Aous Naman
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -57,13 +57,22 @@ namespace ojph {
   ////////////////////////////////////////////////////////////////////////////
   codestream::~codestream()
   {
-    if (state) delete state;
+    if (state)
+      delete state;
+    state = NULL;
   }
 
   ////////////////////////////////////////////////////////////////////////////
   codestream::codestream()
   {
     state = new local::codestream;
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  void codestream::restart()
+  {
+    assert(state != NULL);
+    state->restart();
   }
 
   ////////////////////////////////////////////////////////////////////////////
@@ -103,7 +112,7 @@ namespace ojph {
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  void codestream::set_tilepart_divisions(bool at_resolutions, 
+  void codestream::set_tilepart_divisions(bool at_resolutions,
                                           bool at_components)
   {
     ui32 value = 0;
@@ -147,7 +156,7 @@ namespace ojph {
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  void codestream::write_headers(outfile_base *file, 
+  void codestream::write_headers(outfile_base *file,
                                  const comment_exchange* comments,
                                  ui32 num_comments)
   {

--- a/src/core/codestream/ojph_codestream_local.cpp
+++ b/src/core/codestream/ojph_codestream_local.cpp
@@ -99,11 +99,11 @@ namespace ojph {
 
       precinct_scratch_needed_bytes = 0;
 
-      atk = atk_store;
-      atk[0].init_irv97();
-      atk[0].link(atk_store + 1);
-      atk[1].init_rev53();
-      atk[1].link(atk_store + 2);
+      cod.restart();
+      qcd.restart();
+      nlt.restart();
+      dfs.restart();
+      atk.restart();
 
       allocator->restart();
       elastic_alloc->restart();
@@ -548,7 +548,7 @@ namespace ojph {
       //finalize
       siz.check_validity(cod);
       cod.check_validity(siz);
-      cod.update_atk(atk);
+      cod.update_atk(&atk);
       qcd.check_validity(siz, cod);
       cap.check_validity(cod, qcd);
       nlt.check_validity(siz);
@@ -829,7 +829,7 @@ namespace ojph {
         else if (marker_idx == 14)
           dfs.read(file);
         else if (marker_idx == 15)
-          atk[2].read(file);
+          atk.read(file);
         else if (marker_idx == 16)
           nlt.read(file);
         else if (marker_idx == 17)
@@ -838,7 +838,7 @@ namespace ojph {
           OJPH_ERROR(0x00030051, "File ended before finding a tile segment");
       }
 
-      cod.update_atk(atk);
+      cod.update_atk(&atk);
       siz.link(&cod);
       if (dfs.exists())
         siz.link(&dfs);

--- a/src/core/codestream/ojph_codestream_local.cpp
+++ b/src/core/codestream/ojph_codestream_local.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman 
+// Copyright (c) 2019, Aous Naman
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -52,15 +52,35 @@ namespace ojph {
   namespace local
   {
 
-    ////////////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////
     codestream::codestream()
     : precinct_scratch(NULL), allocator(NULL), elastic_alloc(NULL)
+    {
+      allocator = new mem_fixed_allocator;
+      elastic_alloc = new mem_elastic_allocator(1048576); // 1 megabyte
+
+      init_colour_transform_functions();
+      init_wavelet_transform_functions();
+
+      restart();
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    codestream::~codestream()
+    {
+      if (allocator)
+        delete allocator;
+      if (elastic_alloc)
+        delete elastic_alloc;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void codestream::restart()
     {
       tiles = NULL;
       lines = NULL;
       comp_size = NULL;
       recon_comp_size = NULL;
-      allocator = NULL;
       outfile = NULL;
       infile = NULL;
 
@@ -85,20 +105,8 @@ namespace ojph {
       atk[1].init_rev53();
       atk[1].link(atk_store + 2);
 
-      allocator = new mem_fixed_allocator;
-      elastic_alloc = new mem_elastic_allocator(1048576); //1 megabyte
-
-      init_colour_transform_functions();
-      init_wavelet_transform_functions();
-    }
-
-    ////////////////////////////////////////////////////////////////////////////
-    codestream::~codestream()
-    {
-      if (allocator)
-        delete allocator;
-      if (elastic_alloc)
-        delete elastic_alloc;
+      allocator->restart();
+      elastic_alloc->restart();
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -126,10 +134,10 @@ namespace ojph {
         ui32 y1 = y0 + sz.get_tile_size().h; //end of tile
 
         tile_rect.org.y = ojph_max(y0, sz.get_image_offset().y);
-        tile_rect.siz.h = 
+        tile_rect.siz.h =
           ojph_min(y1, sz.get_image_extent().y) - tile_rect.org.y;
 
-        recon_tile_rect.org.y = ojph_max(ojph_div_ceil(y0, ds), 
+        recon_tile_rect.org.y = ojph_max(ojph_div_ceil(y0, ds),
           ojph_div_ceil(sz.get_image_offset().y, ds));
         recon_tile_rect.siz.h = ojph_min(ojph_div_ceil(y1, ds),
           ojph_div_ceil(sz.get_image_extent().y, ds))
@@ -142,7 +150,7 @@ namespace ojph {
           ui32 x1 = x0 + sz.get_tile_size().w;
 
           tile_rect.org.x = ojph_max(x0, sz.get_image_offset().x);
-          tile_rect.siz.w = 
+          tile_rect.siz.w =
             ojph_min(x1, sz.get_image_extent().x) - tile_rect.org.x;
 
           recon_tile_rect.org.x = ojph_max(ojph_div_ceil(x0, ds),
@@ -189,7 +197,7 @@ namespace ojph {
       // (rounding up leaves one extra entry).
       // This exta entry is necessary
       // We need 4 such tables. These tables store
-      // 1. missing msbs and 2. their flags, 
+      // 1. missing msbs and 2. their flags,
       // 3. number of layers and 4. their flags
       precinct_scratch_needed_bytes =
         4 * ((max_ratio * max_ratio * 4 + 2) / 3);
@@ -203,7 +211,7 @@ namespace ojph {
       allocator->alloc();
 
       //precinct scratch buffer
-      precinct_scratch = 
+      precinct_scratch =
         allocator->post_alloc_obj<ui8>(precinct_scratch_needed_bytes);
 
       //get tiles
@@ -220,7 +228,7 @@ namespace ojph {
         ui32 y1 = y0 + sz.get_tile_size().h; //end of tile
 
         tile_rect.org.y = ojph_max(y0, sz.get_image_offset().y);
-        tile_rect.siz.h = 
+        tile_rect.siz.h =
           ojph_min(y1, sz.get_image_extent().y) - tile_rect.org.y;
 
         ui32 offset = 0;
@@ -231,7 +239,7 @@ namespace ojph {
           ui32 x1 = x0 + sz.get_tile_size().w;
 
           tile_rect.org.x = ojph_max(x0, sz.get_image_offset().x);
-          tile_rect.siz.w = 
+          tile_rect.siz.w =
             ojph_min(x1, sz.get_image_extent().x) - tile_rect.org.x;
 
           ui32 tps = 0; // number of tileparts for this tile
@@ -256,7 +264,7 @@ namespace ojph {
         ui32 cw = siz.get_recon_width(i);
         recon_comp_size[i].w = cw;
         recon_comp_size[i].h = siz.get_recon_height(i);
-        lines[i].wrap(allocator->post_alloc_data<si32>(cw, 0), cw, 0);        
+        lines[i].wrap(allocator->post_alloc_data<si32>(cw, 0), cw, 0);
       }
 
       cur_comp = 0;
@@ -525,21 +533,21 @@ namespace ojph {
       if (tilepart_div != OJPH_TILEPART_COMPONENTS)
       {
         tilepart_div = OJPH_TILEPART_COMPONENTS;
-        OJPH_WARN(0x000300B1, 
+        OJPH_WARN(0x000300B1,
           "In BROADCAST profile, tile part divisions at the component level "
           "must be employed, while at the resolution level is not allowed. "
           "This has been corrected.");
-      }    
+      }
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void codestream::write_headers(outfile_base *file, 
+    void codestream::write_headers(outfile_base *file,
                                    const comment_exchange* comments,
                                    ui32 num_comments)
     {
       //finalize
       siz.check_validity(cod);
-      cod.check_validity(siz);  
+      cod.check_validity(siz);
       cod.update_atk(atk);
       qcd.check_validity(siz, cod);
       cap.check_validity(cod, qcd);
@@ -550,11 +558,11 @@ namespace ojph {
         check_broadcast_validity();
 
       int po = ojph::param_cod(&cod).get_progression_order();
-      if ((po == OJPH_PO_LRCP || po == OJPH_PO_RLCP) && 
+      if ((po == OJPH_PO_LRCP || po == OJPH_PO_RLCP) &&
            tilepart_div == OJPH_TILEPART_COMPONENTS)
       {
         tilepart_div |= OJPH_TILEPART_RESOLUTIONS;
-        OJPH_INFO(0x00030021, 
+        OJPH_INFO(0x00030021,
           "For LRCP and RLCP progression orders, tilepart divisions at the "
           "component level, means that we have a tilepart for every "
           "resolution and component.\n");
@@ -643,7 +651,7 @@ namespace ojph {
       *(ui16*)buf = swap_byte(JP2K_MARKER::COM);
       *(ui16*)(buf + 2) = swap_byte((ui16)(len - 2));
       //1 for General use (IS 8859-15:1999 (Latin) values)
-      *(ui16*)(buf + 4) = swap_byte((ui16)(1)); 
+      *(ui16*)(buf + 4) = swap_byte((ui16)(1));
       if (file->write(buf, len) != len)
         OJPH_ERROR(0x00030028, "Error writing to file");
 
@@ -750,7 +758,7 @@ namespace ojph {
           //Skipping CPF marker segment; this should not cause any issues
           skip_marker(file, "CPF", NULL, OJPH_MSG_LEVEL::NO_MSG, false);
         else if (marker_idx == 3)
-        { 
+        {
           cod.read(file);
           received_markers |= 1;
           ojph::param_cod c(&cod);
@@ -760,14 +768,14 @@ namespace ojph {
               "1 quality layer only.  This codestream has %d quality layers",
               num_qlayers);
         }
-        else if (marker_idx == 4) 
+        else if (marker_idx == 4)
         {
           param_cod* p = cod.add_coc_object(param_cod::OJPH_COD_UNKNOWN);
           p->read_coc(file, siz.get_num_components(), &cod);
           if (p->get_comp_idx() >= siz.get_num_components())
             OJPH_INFO(0x00030056, "The codestream carries a COC marker "
               "segment for a component indexed by %d, which is more than the "
-              "allowed index number, since the codestream has %d components", 
+              "allowed index number, since the codestream has %d components",
               p->get_comp_idx(), num_comps);
           param_cod *q = cod.get_coc(p->get_comp_idx());
           if (p != q && p->get_comp_idx() == q->get_comp_idx())
@@ -775,18 +783,18 @@ namespace ojph {
               "segments for one component of index %d",  p->get_comp_idx());
         }
         else if (marker_idx == 5)
-        { 
-          qcd.read(file); 
-          received_markers |= 2; 
+        {
+          qcd.read(file);
+          received_markers |= 2;
         }
         else if (marker_idx == 6)
         {
-          param_qcd* p = qcd.add_qcc_object(param_qcd::OJPH_QCD_UNKNOWN); 
+          param_qcd* p = qcd.add_qcc_object(param_qcd::OJPH_QCD_UNKNOWN);
           p->read_qcc(file, siz.get_num_components());
           if (p->get_comp_idx() >= siz.get_num_components())
             OJPH_ERROR(0x00030054, "The codestream carries a QCC marker "
               "segment for a component indexed by %d, which is more than the "
-              "allowed index number, since the codestream has %d components", 
+              "allowed index number, since the codestream has %d components",
               p->get_comp_idx(), num_comps);
           param_qcd *q = qcd.get_qcc(p->get_comp_idx());
           if (p != q && p->get_comp_idx() == q->get_comp_idx())
@@ -849,7 +857,7 @@ namespace ojph {
       if (skipped_res_for_read < skipped_res_for_recon)
         OJPH_ERROR(0x000300A1,
           "skipped_resolution for data %d must be equal or smaller than "
-          " skipped_resolution for reconstruction %d\n", 
+          " skipped_resolution for reconstruction %d\n",
           skipped_res_for_read, skipped_res_for_recon);
       if (skipped_res_for_read > cod.get_num_decompositions())
         OJPH_ERROR(0x000300A2,
@@ -908,7 +916,7 @@ namespace ojph {
             }
 
             bool sod_found = false;
-            ui16 other_tile_part_markers[7] = { SOT, POC, PPT, PLT, COM, 
+            ui16 other_tile_part_markers[7] = { SOT, POC, PPT, PLT, COM,
               NLT, SOD };
             while (true)
             {
@@ -931,7 +939,7 @@ namespace ojph {
                 result = skip_marker(infile, "COM", NULL,
                   OJPH_MSG_LEVEL::NO_MSG, resilient);
               else if (marker_idx == 4)
-                result = skip_marker(infile, "NLT", 
+                result = skip_marker(infile, "NLT",
                   "NLT marker in tile is not supported yet",
                   OJPH_MSG_LEVEL::WARN, resilient);
               else if (marker_idx == 5)
@@ -1015,7 +1023,7 @@ namespace ojph {
                 result = skip_marker(infile, "COM", NULL,
                   OJPH_MSG_LEVEL::NO_MSG, resilient);
               else if (marker_idx == 9)
-                result = skip_marker(infile, "NLT", 
+                result = skip_marker(infile, "NLT",
                   "PPT marker segment in a tile is not supported yet",
                   OJPH_MSG_LEVEL::WARN, resilient);
               else if (marker_idx == 10)
@@ -1092,7 +1100,7 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     void codestream::set_tilepart_divisions(ui32 value)
     {
-      tilepart_div = value;      
+      tilepart_div = value;
     }
 
     //////////////////////////////////////////////////////////////////////////

--- a/src/core/codestream/ojph_codestream_local.h
+++ b/src/core/codestream/ojph_codestream_local.h
@@ -163,9 +163,8 @@ namespace ojph {
 
     private:  // these are from Part 2 of the standard
       param_dfs dfs;         // downsmapling factor styles
-      param_atk* atk;        // a pointer to atk
-      param_atk atk_store[3];// 0 and 1 are for DWT from Part 1, 2 onward are
-                             // for arbitrary transformation kernels
+      param_atk atk;         // wavelet structure and coefficients
+
     private:
       mem_fixed_allocator *allocator;
       mem_elastic_allocator *elastic_alloc;

--- a/src/core/codestream/ojph_codestream_local.h
+++ b/src/core/codestream/ojph_codestream_local.h
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman 
+// Copyright (c) 2019, Aous Naman
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -68,23 +68,25 @@ namespace ojph {
     class codestream
     {
       friend ::ojph::codestream;
-      
+
     public:
       codestream();
       ~codestream();
 
+      void restart();
+
       void pre_alloc();
       void finalize_alloc();
 
-      ojph::param_siz access_siz()            //return externally wrapped siz
+      ojph::param_siz access_siz()            // returns externally wrapped siz
       { return ojph::param_siz(&siz); }
-      const param_siz* get_siz() //return internal siz
+      const param_siz* get_siz()              // returns internal siz
       { return &siz; }
-      ojph::param_cod access_cod()            //return externally wrapped cod
+      ojph::param_cod access_cod()            // returns externally wrapped cod
       { return ojph::param_cod(&cod); }
-      const param_cod* get_cod()              //return internal cod
+      const param_cod* get_cod()              // returns internal cod
       { return &cod; }
-      const param_cod* get_coc(ui32 comp_num) //return internal cod
+      const param_cod* get_coc(ui32 comp_num) // returns internal cod
       { return cod.get_coc(comp_num); }
       const param_qcd* access_qcd()
       { return &qcd; }
@@ -150,7 +152,7 @@ namespace ojph {
       int profile;
       ui32 tilepart_div;     // tilepart division value
       bool need_tlm;         // true if tlm markers are needed
-      
+
     private:
       param_siz siz;         // image and tile size
       param_cod cod;         // coding style default

--- a/src/core/codestream/ojph_params.cpp
+++ b/src/core/codestream/ojph_params.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman 
+// Copyright (c) 2019, Aous Naman
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -368,8 +368,8 @@ namespace ojph {
   ////////////////////////////////////////////////////////////////////////////
   void param_coc::set_block_dims(ui32 width, ui32 height)
   { ojph::param_cod(state).set_block_dims(width, height); }
-  
-  ////////////////////////////////////////////////////////////////////////////  
+
+  ////////////////////////////////////////////////////////////////////////////
   void param_coc::set_precinct_size(int num_levels, size* precinct_size)
   { ojph::param_cod(state).set_precinct_size(num_levels, precinct_size); }
 
@@ -441,10 +441,10 @@ namespace ojph {
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  bool param_nlt::get_nonlinear_transform(ui32 comp_num, ui8& bit_depth, 
+  bool param_nlt::get_nonlinear_transform(ui32 comp_num, ui8& bit_depth,
                                           bool& is_signed, ui8& nl_type) const
   {
-    return state->get_nonlinear_transform(comp_num, bit_depth, is_signed, 
+    return state->get_nonlinear_transform(comp_num, bit_depth, is_signed,
                                           nl_type);
   }
 
@@ -458,25 +458,25 @@ namespace ojph {
 
   //////////////////////////////////////////////////////////////////////////
   void comment_exchange::set_string(const char* str)
-  { 
+  {
     size_t t = strlen(str);
     if (len > 65531)
-      OJPH_ERROR(0x000500C1, 
+      OJPH_ERROR(0x000500C1,
         "COM marker string length cannot be larger than 65531");
-    this->data = str; 
+    this->data = str;
     this->len = (ui16)t;
     this->Rcom = 1;
   }
 
   //////////////////////////////////////////////////////////////////////////
   void comment_exchange::set_data(const char* data, ui16 len)
-  { 
+  {
     if (len > 65531)
-      OJPH_ERROR(0x000500C2, 
+      OJPH_ERROR(0x000500C2,
         "COM marker string length cannot be larger than 65531");
     this->data = data;
-    this->len = len; 
-    this->Rcom = 0; 
+    this->len = len;
+    this->Rcom = 0;
   }
 
   //////////////////////////////////////////////////////////////////////////
@@ -693,7 +693,7 @@ namespace ojph {
         OJPH_ERROR(0x00050043, "error reading SIZ marker");
       Rsiz = swap_byte(Rsiz);
       if ((Rsiz & 0x4000) == 0)
-        OJPH_ERROR(0x00050044, 
+        OJPH_ERROR(0x00050044,
           "Rsiz bit 14 is not set (this is not a JPH file)");
       if ((Rsiz & 0x8000) != 0 && (Rsiz & 0xD5F) != 0)
         OJPH_WARN(0x00050001, "Rsiz in SIZ has unimplemented fields");
@@ -726,13 +726,7 @@ namespace ojph {
       Csiz = swap_byte(Csiz);
       if (Csiz != num_comps)
         OJPH_ERROR(0x0005004E, "Csiz does not match the SIZ marker size");
-      if (Csiz > old_Csiz)
-      {
-        if (cptr != store)
-          delete[] cptr;
-        cptr = new siz_comp_info[(ui32)num_comps];
-        old_Csiz = Csiz;
-      }
+      set_num_components(Csiz);
       for (int c = 0; c < Csiz; ++c)
       {
         if (file->read(&cptr[c].SSiz, 1) != 1)
@@ -841,7 +835,7 @@ namespace ojph {
 
     //////////////////////////////////////////////////////////////////////////
     bool param_cod::is_reversible() const
-    { 
+    {
       if (SPcod.wavelet_trans <= 1)
         return get_wavelet_kern() == local::param_cod::DWT_REV53;
       else {
@@ -990,7 +984,7 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void param_cod::read_coc(infile_base* file, ui32 num_comps, 
+    void param_cod::read_coc(infile_base* file, ui32 num_comps,
                              param_cod *top_cod)
     {
       assert(type == COC_MAIN);
@@ -1015,7 +1009,7 @@ namespace ojph {
       if (file->read(&Scod, 1) != 1)
         OJPH_ERROR(0x00050124, "error reading COC segment");
       if (Scod & 0xF8)
-        OJPH_WARN(0x00050011, 
+        OJPH_WARN(0x00050011,
           "Unsupported options in Scoc field of the COC segment");
       if (file->read(&SPcod.num_decomp, 1) != 1)
         OJPH_ERROR(0x00050125, "error reading COC segment");
@@ -1045,7 +1039,7 @@ namespace ojph {
       this->atk = atk->get_atk(SPcod.wavelet_trans);
       if (this->atk == NULL)
         OJPH_ERROR(0x00050131, "A COD segment employs the DWT kernel "
-          "atk = %d, but a corresponding ATK segment cannot be found.", 
+          "atk = %d, but a corresponding ATK segment cannot be found.",
           SPcod.wavelet_trans);
       param_cod *p = next;
       while (p)
@@ -1053,7 +1047,7 @@ namespace ojph {
         p->atk = atk->get_atk(p->SPcod.wavelet_trans);
         if (p->atk == NULL)
           OJPH_ERROR(0x00050132, "A COC segment employs the DWT kernel "
-            "atk = %d, but a corresponding ATK segment cannot be found", 
+            "atk = %d, but a corresponding ATK segment cannot be found",
             SPcod.wavelet_trans);
         p = p->next;
       }
@@ -1122,7 +1116,7 @@ namespace ojph {
         {
           if (get_qcc(c) == this) // no qcc defined for component c
           {
-            const param_cod *p = cod.get_coc(c);          
+            const param_cod *p = cod.get_coc(c);
             if (bit_depth == 0) // first component captured by QCD
             {
               num_decompositions = p->get_num_decompositions();
@@ -1133,7 +1127,7 @@ namespace ojph {
             }
             else
             {
-              all_same = all_same 
+              all_same = all_same
                 && (num_decompositions == p->get_num_decompositions())
                 && (bit_depth == siz.get_bit_depth(c))
                 && (is_signed == siz.is_signed(c))
@@ -1161,7 +1155,7 @@ namespace ojph {
         if (qcd_wavelet_kern == param_cod::DWT_REV53)
           set_rev_quant(qcd_num_decompositions, qcd_bit_depth,
             qcd_component < 3 ? employing_color_transform : false);
-        else if (qcd_wavelet_kern == param_cod::DWT_IRV97) 
+        else if (qcd_wavelet_kern == param_cod::DWT_IRV97)
         {
           if (this->base_delta == -1.0f)
             this->base_delta = 1.0f / (float)(1 << qcd_bit_depth);
@@ -1333,7 +1327,7 @@ namespace ojph {
 
     //////////////////////////////////////////////////////////////////////////
     ui32 param_qcd::get_MAGB() const
-    { 
+    {
       ui32 B = 0;
 
       const param_qcd *p = this;
@@ -1359,7 +1353,7 @@ namespace ojph {
           }
         else
           assert(0);
-        
+
         p = p->next;
       }
 
@@ -1367,7 +1361,7 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    float param_qcd::get_irrev_delta(const param_dfs* dfs, 
+    float param_qcd::get_irrev_delta(const param_dfs* dfs,
                                      ui32 num_decompositions,
                                      ui32 resolution, ui32 subband) const
     {
@@ -1384,7 +1378,7 @@ namespace ojph {
           "subband %d when the QCD/QCC marker segment specifies "
           "quantization step sizes for %d subbands only.  To continue "
           "decoding, we are using the step size for subband %d, which can "
-          "produce incorrect results", 
+          "produce incorrect results",
           idx + 1, num_subbands, num_subbands - 1);
         idx = num_subbands - 1;
       }
@@ -1401,7 +1395,7 @@ namespace ojph {
     {
       ui32 comp_idx = cod->get_comp_idx();
       ui32 precision = 0;
-      const param_cod *main = 
+      const param_cod *main =
         cod->get_coc(param_cod::OJPH_COD_DEFAULT);
       if (main->is_employing_color_transform() && comp_idx < 3)
       {
@@ -1413,10 +1407,10 @@ namespace ojph {
       else {
         precision = get_largest_Kmax();
       }
-      // ``precision'' now holds the largest K_max, which excludes the sign 
+      // ``precision'' now holds the largest K_max, which excludes the sign
       // bit.
       // + 1 for the sign bit
-      // + 1 because my block decoder/encoder does not supports up to 30 
+      // + 1 because my block decoder/encoder does not supports up to 30
       //     bits (not 31), so we bump it by one more bit.
       return precision + 1 + 1;
     }
@@ -1441,7 +1435,7 @@ namespace ojph {
           "subband %d when the QCD/QCC marker segment specifies "
           "quantization step sizes for %d subbands only.  To continue "
           "decoding, we are using the step size for subband %d, which can "
-          "produce incorrect results", 
+          "produce incorrect results",
           idx + 1, num_subbands, num_subbands - 1);
         idx = num_subbands - 1;
       }
@@ -1486,8 +1480,8 @@ namespace ojph {
       }
       else
         assert(0);
-      
-      return num_bits + get_num_guard_bits();        
+
+      return num_bits + get_num_guard_bits();
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -1611,7 +1605,7 @@ namespace ojph {
         p->enabled = p->comp_idx < num_comps;
         p = p->next;
       }
-    }    
+    }
 
     //////////////////////////////////////////////////////////////////////////
     void param_qcd::read(infile_base *file)
@@ -1633,7 +1627,7 @@ namespace ojph {
       else if ((Sqcd & 0x1F) == 1)
       {
         num_subbands = 0;
-        OJPH_ERROR(0x00050089, 
+        OJPH_ERROR(0x00050089,
           "Scalar derived quantization is not supported yet in QCD marker");
         if (Lqcd != 5)
           OJPH_ERROR(0x00050085, "wrong Lqcd value in QCD marker");
@@ -1688,7 +1682,7 @@ namespace ojph {
       else if ((Sqcd & 0x1F) == 1)
       {
         num_subbands = 0;
-        OJPH_ERROR(0x000500AB, 
+        OJPH_ERROR(0x000500AB,
           "Scalar derived quantization is not supported yet in QCC marker");
         if (Lqcd != offset)
           OJPH_ERROR(0x000500A7, "wrong Lqcc value in QCC marker");
@@ -1710,8 +1704,8 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    param_qcd* param_qcd::get_qcc(ui32 comp_idx) 
-    { 
+    param_qcd* param_qcd::get_qcc(ui32 comp_idx)
+    {
       // cast object to constant
       const param_qcd* const_p = const_cast<const param_qcd*>(this);
       // call using the constant object, then cast to non-const
@@ -1760,7 +1754,7 @@ namespace ojph {
       if (this->enabled && this->Tnlt == nonlinearity::OJPH_NLT_NO_NLT)
         this->enabled = false;
 
-      if (this->enabled && 
+      if (this->enabled &&
           this->Tnlt == nonlinearity::OJPH_NLT_BINARY_COMPLEMENT_NLT)
       {
         bool all_same = true;
@@ -1775,16 +1769,16 @@ namespace ojph {
         for (ui32 c = 0; c < num_comps; ++c)
         { // captured by ALL_COMPS
           param_nlt* p = get_nlt_object(c);
-          if (p == NULL || !p->enabled) 
+          if (p == NULL || !p->enabled)
           {
             if (bit_depth != 0)
-            { 
+            {
               // we have seen an undefined component previously
               all_same = all_same && (bit_depth == siz.get_bit_depth(c));
               all_same = all_same && (is_signed == siz.is_signed(c));
             }
             else
-            { 
+            {
               // this is the first component which has not type 3 nlt definition
               bit_depth = siz.get_bit_depth(c);
               is_signed = siz.is_signed(c);
@@ -1797,7 +1791,7 @@ namespace ojph {
           }
         }
 
-        if (all_same && bit_depth != 0) 
+        if (all_same && bit_depth != 0)
         { // all the same, and some components are captured by ALL_COMPS
           this->BDnlt = (ui8)(bit_depth - 1);
           this->BDnlt = (ui8)(this->BDnlt | (is_signed ? 0x80 : 0));
@@ -1812,7 +1806,7 @@ namespace ojph {
             { // captured by ALL_COMPS
               if (p == NULL)
                 p = add_object(c);
-              p->enabled = true;                
+              p->enabled = true;
               p->Tnlt = nonlinearity::OJPH_NLT_BINARY_COMPLEMENT_NLT;
               p->BDnlt = (ui8)(siz.get_bit_depth(c) - 1);
               p->BDnlt = (ui8)(p->BDnlt | (siz.is_signed(c) ? 0x80 : 0));
@@ -1820,13 +1814,13 @@ namespace ojph {
           }
         }
       }
-      else { 
+      else {
         // fill NLT segment markers with correct information
         ui32 num_comps = siz.get_num_components();
         for (ui32 c = 0; c < num_comps; ++c)
         { // captured by ALL_COMPS
           param_nlt* p = get_nlt_object(c);
-          if (p != NULL && p->enabled) 
+          if (p != NULL && p->enabled)
           { // can be type 0 or type 3
             p->BDnlt = (ui8)(siz.get_bit_depth(c) - 1);
             p->BDnlt = (ui8)(p->BDnlt | (siz.is_signed(c) ? 0x80 : 0));
@@ -1843,7 +1837,7 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     void param_nlt::set_nonlinear_transform(ui32 comp_num, ui8 nl_type)
     {
-      if (nl_type != ojph::param_nlt::OJPH_NLT_NO_NLT && 
+      if (nl_type != ojph::param_nlt::OJPH_NLT_NO_NLT &&
           nl_type != ojph::param_nlt::OJPH_NLT_BINARY_COMPLEMENT_NLT)
       OJPH_ERROR(0x00050171, "Nonliearities other than type 0 "
         "(No Nonlinearity) or type  3 (Binary Binary Complement to Sign "
@@ -1857,7 +1851,7 @@ namespace ojph {
 
     //////////////////////////////////////////////////////////////////////////
     bool
-    param_nlt::get_nonlinear_transform(ui32 comp_num, ui8& bit_depth, 
+    param_nlt::get_nonlinear_transform(ui32 comp_num, ui8& bit_depth,
                                        bool& is_signed, ui8& nl_type) const
     {
       assert(Cnlt == special_comp_num::ALL_COMPS);
@@ -1925,8 +1919,8 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    param_nlt* param_nlt::get_nlt_object(ui32 comp_num) 
-    { 
+    param_nlt* param_nlt::get_nlt_object(ui32 comp_num)
+    {
       // cast object to constant
       const param_nlt* const_p = const_cast<const param_nlt*>(this);
       // call using the constant object, then cast to non-const
@@ -2045,7 +2039,7 @@ namespace ojph {
         if (file->read(&Lsot, 2) != 2)
         {
           OJPH_INFO(0x00050091, "error reading SOT marker");
-          Lsot = 0; Isot = 0; Psot = 0; TPsot = 0; TNsot = 0; 
+          Lsot = 0; Isot = 0; Psot = 0; TPsot = 0; TNsot = 0;
           return false;
         }
         Lsot = swap_byte(Lsot);
@@ -2187,7 +2181,7 @@ namespace ojph {
 
     //////////////////////////////////////////////////////////////////////////
     param_dfs::dfs_dwt_type param_dfs::get_dwt_type(ui32 decomp_level) const
-    { 
+    {
       decomp_level = ojph_min(decomp_level, Ids);
       ui32 d = decomp_level - 1;          // decomp_level starts from 1
       ui32 idx = d >> 2;                  // complete bytes
@@ -2200,7 +2194,7 @@ namespace ojph {
     ui32 param_dfs::get_subband_idx(ui32 num_decompositions, ui32 resolution,
                                     ui32 subband) const
     {
-      assert((resolution == 0 && subband == 0) || 
+      assert((resolution == 0 && subband == 0) ||
               (resolution > 0 && subband > 0 && subband < 4));
 
       ui32 ns[4] = { 0, 3, 1, 1 };
@@ -2270,7 +2264,7 @@ namespace ojph {
       if (l_Ids > max_Ddfs)
         OJPH_INFO(0x000500D5, "The DFS-Ids parameter is %d; while this is "
           "valid, the number is unnessarily large -- you do not need more "
-          "than %d.  Please contact me regarding this issue.", 
+          "than %d.  Please contact me regarding this issue.",
           l_Ids, max_Ddfs);
       Ids = l_Ids < max_Ddfs ? l_Ids : max_Ddfs;
       for (int i = 0; i < Ids; i += 4)
@@ -2392,10 +2386,10 @@ namespace ojph {
       }
 
       if (file->read(&Latk, 2) != 2)
-        OJPH_ERROR(0x000500E1, "error reading ATK-Latk parameter"); 
+        OJPH_ERROR(0x000500E1, "error reading ATK-Latk parameter");
       Latk = swap_byte(Latk);
       if (file->read(&Satk, 2) != 2)
-        OJPH_ERROR(0x000500E2, "error reading ATK-Satk parameter"); 
+        OJPH_ERROR(0x000500E2, "error reading ATK-Satk parameter");
       Satk = swap_byte(Satk);
       if (is_m_init0() == false)  // only even-indexed is supported
         OJPH_ERROR(0x000500E3, "ATK-Satk parameter sets m_init to 1, "
@@ -2403,16 +2397,16 @@ namespace ojph {
           "which is not supported yet.");
       if (is_whole_sample() == false)  // ARB filter not supported
         OJPH_ERROR(0x000500E4, "ATK-Satk parameter specified ARB filter, "
-          "which is not supported yet."); 
+          "which is not supported yet.");
       if (is_reversible() && get_coeff_type() >= 2) // reversible & float
         OJPH_ERROR(0x000500E5, "ATK-Satk parameter does not make sense. "
-          "It employs floats with reversible filtering."); 
+          "It employs floats with reversible filtering.");
       if (is_using_ws_extension() == false)  // only sym. ext is supported
         OJPH_ERROR(0x000500E6, "ATK-Satk parameter requires constant "
           "boundary extension, which is not supported yet.");
-      if (is_reversible() == false) 
+      if (is_reversible() == false)
         if (read_coefficient(file, Katk) == false)
-          OJPH_ERROR(0x000500E7, "error reading ATK-Katk parameter"); 
+          OJPH_ERROR(0x000500E7, "error reading ATK-Katk parameter");
       if (file->read(&Natk, 1) != 1)
         OJPH_ERROR(0x000500E8, "error reading ATK-Natk parameter");
       if (Natk > max_steps) {
@@ -2427,9 +2421,9 @@ namespace ojph {
         for (int s = 0; s < Natk; ++s)
         {
           if (file->read(&d[s].rev.Eatk, 1) != 1)
-            OJPH_ERROR(0x000500E9, "error reading ATK-Eatk parameter");           
+            OJPH_ERROR(0x000500E9, "error reading ATK-Eatk parameter");
           if (file->read(&d[s].rev.Batk, 2) != 2)
-            OJPH_ERROR(0x000500EA, "error reading ATK-Batk parameter");           
+            OJPH_ERROR(0x000500EA, "error reading ATK-Batk parameter");
           d[s].rev.Batk = (si16)swap_byte((ui16)d[s].rev.Batk);
           ui8 LCatk;
           if (file->read(&LCatk, 1) != 1)

--- a/src/core/common/ojph_codestream.h
+++ b/src/core/common/ojph_codestream.h
@@ -91,7 +91,7 @@ namespace ojph {
     /**
      *  @brief default constructor
      *
-     *  This object instantiate the actual implementation object
+     *  This function instantiate the actual implementation object
      *  local::codestream, using new.
      *
      */
@@ -100,15 +100,23 @@ namespace ojph {
     /**
      *  @brief default destructor
      *
-     *  This object destroys the internal local::codestream object.
+     *  This function destroys the internal local::codestream object.
      *
      */
     ~codestream();
 
     /**
-     *  @brief default destructor
+     *  @brief Restarts the codestream.
      *
-     *  This object destroys the internal local::codestream object.
+     *  This function restarts the codestream; after this call, the
+     *  codestream object behaves like it has never been used before,
+     *  except that all memory allocations are preserved.  Thus, after
+     *  restart(), there is no need to allocate memory, unless the new
+     *  codestream needs more storage to store codeblocks, or has a
+     *  different structure.
+     *
+     *  restart() is useful if we are decoding multiple codestreams that
+     *  have largely the same structure and byte length.
      *
      */
     void restart();

--- a/src/core/common/ojph_codestream.h
+++ b/src/core/common/ojph_codestream.h
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman 
+// Copyright (c) 2019, Aous Naman
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -68,179 +68,188 @@ namespace ojph {
   ////////////////////////////////////////////////////////////////////////////
   /**
    *  @brief The object represent a codestream.
-   * 
+   *
    *  Most end-user use this object to create a j2c codestream.  The object
    *  currently can be used in one of two modes, reading or writing.
-   * 
-   *  We try to follow the pImpl (pointer to Implementation) approach; 
-   *  therefore, objects in the ojph namespace hold pointers to internal 
-   *  implementations.  The actual implementation is usually in the 
-   *  ojph::local namespace. The actual implementation of the 
-   *  ojph::codestream object is in ojph_codestream.cpp, while the actual 
-   *  implementation can be found in ojph_codestream_local.h and 
+   *
+   *  We try to follow the pImpl (pointer to Implementation) approach;
+   *  therefore, objects in the ojph namespace hold pointers to internal
+   *  implementations.  The actual implementation is usually in the
+   *  ojph::local namespace. The actual implementation of the
+   *  ojph::codestream object is in ojph_codestream.cpp, while the actual
+   *  implementation can be found in ojph_codestream_local.h and
    *  ojph_codestream_local.cpp.
-   * 
-   *  Most of these member functions provides nothing more than calls 
-   *  into the internal implementation.  See ojph_codestream_local.h for 
+   *
+   *  Most of these member functions provides nothing more than calls
+   *  into the internal implementation.  See ojph_codestream_local.h for
    *  more documentation -- yet to be added.
-   * 
+   *
    */
   class OJPH_EXPORT codestream
   {
   public:
     /**
      *  @brief default constructor
-     * 
-     *  This object instantiate the actual implementation object 
+     *
+     *  This object instantiate the actual implementation object
      *  local::codestream, using new.
-     * 
+     *
      */
     codestream();
+
     /**
      *  @brief default destructor
-     * 
+     *
      *  This object destroys the internal local::codestream object.
-     * 
+     *
      */
     ~codestream();
 
     /**
+     *  @brief default destructor
+     *
+     *  This object destroys the internal local::codestream object.
+     *
+     */
+    void restart();
+
+    /**
      *  @brief Sets the sequence of pushing or pull rows from the machinery.
-     * 
-     *  For this function, planar means that the machinery processes one 
-     *  colour component in full before processing the next component.  This 
+     *
+     *  For this function, planar means that the machinery processes one
+     *  colour component in full before processing the next component.  This
      *  more efficient because the cache is used for one component instead of
-     *  many components, but it is not practical when a color transform is 
-     *  employed. This is because we need to employ the transform to the first 
-     *  three  components.  Therefore, planar, while recommended, can only be 
+     *  many components, but it is not practical when a color transform is
+     *  employed. This is because we need to employ the transform to the first
+     *  three  components.  Therefore, planar, while recommended, can only be
      *  used when there is no color transform.
-     * 
+     *
      *  @param planar true for when components are pushed in full one at
-     *         a time.   
+     *         a time.
      */
     void set_planar(bool planar);
 
     /**
      *  @brief Sets the codestream profile.
-     *  
+     *
      *  This is currently rather incomplete, but it accepts two profiles
      *  IMF and BROADCAST. More work is needed to improve this.
      *  Note that Rsiz field in the SIZ marker segment is not set properly.
-     * 
-     *  @param s a string of the profile name, value can be from 
-     *           OJPH_PN_STRING_XXXX, where only IMF and BROADCAST 
+     *
+     *  @param s a string of the profile name, value can be from
+     *           OJPH_PN_STRING_XXXX, where only IMF and BROADCAST
      *           are currently supported.
      */
     void set_profile(const char* s);
 
     /**
      *  @brief Sets the locations where a tile is partitioned into tile parts.
-     * 
+     *
      *  This function signals that we are interested in partitioning each tile
-     *  into tile parts at resolution or component level, or both.  This is 
-     *  useful when used with the TLM marker segment, because the TLM marker 
+     *  into tile parts at resolution or component level, or both.  This is
+     *  useful when used with the TLM marker segment, because the TLM marker
      *  segment provides information about the locations of these partitions in
      *  the file.  This way we can identify where resolution information ends
-     *  within the codestream.  It is also useful when large images are 
-     *  compressed, because an unpartitioned tile cannot be more than 4GB, but 
-     *  when partitioned, each tile part can be 4GB -- it is possible to 
-     *  partition at precinct boundaries to better utilize tile parts, and 
-     *  achieve a tile in the vicinity of 1TB, but this option is currently 
-     *  unsupported. 
-     * 
-     *  @param at_resolutions partitions the tile into tile parts at 
+     *  within the codestream.  It is also useful when large images are
+     *  compressed, because an unpartitioned tile cannot be more than 4GB, but
+     *  when partitioned, each tile part can be 4GB -- it is possible to
+     *  partition at precinct boundaries to better utilize tile parts, and
+     *  achieve a tile in the vicinity of 1TB, but this option is currently
+     *  unsupported.
+     *
+     *  @param at_resolutions partitions the tile into tile parts at
      *         resolutions.
-     *  @param at_components partitions every tile into tile parts are 
+     *  @param at_components partitions every tile into tile parts are
      *         components
      */
     void set_tilepart_divisions(bool at_resolutions, bool at_components);
 
     /**
      *  @brief Query if the tile will be partitioned at resolution boundary.
-     * 
+     *
      *  @return true if resolution-boundary tile partitioning is employed.
-     *  @return false if resolution-boundary tile partitioning is not 
+     *  @return false if resolution-boundary tile partitioning is not
      *          requested.
      */
     bool is_tilepart_division_at_resolutions();
 
     /**
      *  @brief Query if the tile will be partitioned at component boundary.
-     * 
+     *
      *  @return true if component-boundary tile partitioning is employed.
-     *  @return false if component-boundary tile partitioning is not 
+     *  @return false if component-boundary tile partitioning is not
      *          requested.
      */
     bool is_tilepart_division_at_components();
 
     /**
      *  @brief Request the addition of the optional TLM marker segment.
-     *  This request should occur before writing codestream headers 
+     *  This request should occur before writing codestream headers
      *  ojph::codestream::write_headers())
-     * 
+     *
      *  @param needed true when the marker is needed.
-     */    
+     */
     void request_tlm_marker(bool needed);
 
     /**
      *  @brief Query if the optional TLM marker segment is to be added.
-     * 
+     *
      *  @return true if the addition of the optional TLM marker segment
      *          is to be added.
      *  @return false if the addition of the optional TLM marker segment
      *          was not requested.
      */
-    
+
     bool is_tlm_requested();
 
-    /** 
+    /**
      *  @brief Writes codestream headers when the codestream is used for
-     *  writing.  This function should be called after setting all the 
+     *  writing.  This function should be called after setting all the
      *  codestream parameters, but before pushing image lines using
      *  ojph::codestream::exchange().
-     * 
-     *  @param file A class inherited from outfile_base, which used to store 
-     *              compressed image bitstream.  This enables storing the 
+     *
+     *  @param file A class inherited from outfile_base, which used to store
+     *              compressed image bitstream.  This enables storing the
      *              compressed bitstream to memory or an actual file.
      *  @param comments A pointer to an array of comment_exchange objects.
-     *                  Each object stores one comment to be inserted in the 
-     *                  bitstreams.  The number of elements in the array 
+     *                  Each object stores one comment to be inserted in the
+     *                  bitstreams.  The number of elements in the array
      *                  should be equal to num_comments.
      *  @param num_comments The number of elements in the `comments` array.
-     * 
+     *
      */
-    void write_headers(outfile_base *file, 
-                       const comment_exchange* comments = NULL, 
+    void write_headers(outfile_base *file,
+                       const comment_exchange* comments = NULL,
                        ui32 num_comments = 0);
 
     /**
      *  @brief This call is used to send image data rows to the library.
-     *         We expect to send one row from a single component with 
+     *         We expect to send one row from a single component with
      *         each call. The first call is always with line == NULL;
      *         the call would return a line_buf, and the component
-     *         number or index in `next_component.`  The caller would 
-     *         then need to fill the buffer of the line_buf with one 
+     *         number or index in `next_component.`  The caller would
+     *         then need to fill the buffer of the line_buf with one
      *         row from the component indexed by `next_component`, and
-     *         call exchange again to pass the component and get a 
-     *         new line_buf. 
-     * 
+     *         call exchange again to pass the component and get a
+     *         new line_buf.
+     *
      *  @param line A line_buf object; first call should supply NULL.
      *              Subsequent calls should pass the line_buf object
      *              obtained in the previous call.
-     *  @param next_component returns a component index; the end user must 
-     *                        fill the returned line_buf from the component 
-     *                        indexed by this index. 
-     *  @return line_buf* A line_buf which must be filled with the component 
-     *                    indexed by `next_component`, before calling 
+     *  @param next_component returns a component index; the end user must
+     *                        fill the returned line_buf from the component
+     *                        indexed by this index.
+     *  @return line_buf* A line_buf which must be filled with the component
+     *                    indexed by `next_component`, before calling
      *                    exchange again to pass this line.
      */
-    
+
     line_buf* exchange(line_buf* line, ui32& next_component);
 
     /**
      * @brief This is the last call to a writing (encoding) codestream.
      *        This will write encoded bitstream data to the file.  This
-     *        call does not close the file, because, in the future, we 
+     *        call does not close the file, because, in the future, we
      *        might wish to write more data to the file.  If you do not
      *        want to write more data, then call codestream::close().
      */
@@ -250,39 +259,39 @@ namespace ojph {
      * @brief This enables codestream resilience; that is, the library tries
      *        its best to decode the codestream, even if there are errors.
      *        This call is for a decoding (or reading) codestream, and
-     *        should be called before all other calls, before 
+     *        should be called before all other calls, before
      *        codestream::read_headers().
      */
     void enable_resilience();             // before read_headers
 
     /**
      * @brief This call reads the headers of a codestream.  It is for a
-     *        reading (or decoding) codestream, and should be called 
-     *        after codestream::enable_resilience(), but before 
+     *        reading (or decoding) codestream, and should be called
+     *        after codestream::enable_resilience(), but before
      *        codestream::restrict_input_resolution().
-     * 
+     *
      * @param file The file to read from.  The file should be inherited from
      *             ojph::infile_base; this enables reading from an actual file
-     *             or from memory-based file.  
+     *             or from memory-based file.
      */
     void read_headers(infile_base *file); // before resolution restrictions
 
     /**
      * @brief This function restricts resolution decoding for a codestream.
-     *        It is for a reading (decoding) codestream.  We can limit the 
+     *        It is for a reading (decoding) codestream.  We can limit the
      *        restrictions to decoding and reconstruction resolution,
-     *        or decoding only.  Call this function after 
+     *        or decoding only.  Call this function after
      *        codestream::read_headers() but before codestream::create()
-     * 
-     * @param skipped_res_for_data specifies for how many fine resolutions 
-     *                             decoding is skipped, i.e., reading and 
+     *
+     * @param skipped_res_for_data specifies for how many fine resolutions
+     *                             decoding is skipped, i.e., reading and
      *                             decoding is not performed for this number
-     *                             of fine resolutions. 
-     * @param skipped_res_for_recon specifies for how many fine resolutions 
+     *                             of fine resolutions.
+     * @param skipped_res_for_recon specifies for how many fine resolutions
      *                              reconstruction is skipped; the resulting
      *                              image is smaller than the original.  This
      *                              number should be smaller or equal to
-     *                              `skipped_res_for_data,` as it does not 
+     *                              `skipped_res_for_data,` as it does not
      *                              make sense otherwise.
      */
     void restrict_input_resolution(ui32 skipped_res_for_data,
@@ -290,17 +299,17 @@ namespace ojph {
 
     /**
      * @brief This call is for a decoding (or reading) codestream.  Call this
-     *        function after calling restrict_input_resolution(), if 
+     *        function after calling restrict_input_resolution(), if
      *        restrictions are needed.
      */
-    void create(); 
+    void create();
 
     /**
      * @brief This call is to pull one row from the codestream, being
      *        decoded.  The returned line_buf object holds one row from
      *        the image; the returned comp_num tells the reader the
      *        component to which this row belongs.
-     * 
+     *
      * @param comp_num returns the component to which the returned
      *                 line_buf object belongs.
      * @return line_buf* this object holds one row of the component indexed
@@ -311,13 +320,13 @@ namespace ojph {
     /**
      * @brief Call this function to close the underlying file; works for both
      *        encoding and decoding codestreams.
-     * 
+     *
      */
     void close();
 
     /**
      * @brief Returns the underlying SIZ marker segment object
-     * 
+     *
      * @return param_siz This object holds SIZ marker segment information,
      *                   which deals with codestream dimensions, number
      *                   of components, bit depth, ... etc.
@@ -326,7 +335,7 @@ namespace ojph {
 
     /**
      * @brief Returns the underlying COD marker segment object
-     * 
+     *
      * @return param_cod This object holds COD marker segment information,
      *                   which deals with coding parameters, such as
      *                   codeblock sizes, progression order, reversible,
@@ -336,7 +345,7 @@ namespace ojph {
 
     /**
      * @brief Returns the underlying QCD marker segment object
-     * 
+     *
      * @return param_qcd This object holds QCD marker segment information,
      *                   which deals with quantization parameters --
      *                   quantization step size for each subband.
@@ -345,7 +354,7 @@ namespace ojph {
 
     /**
      * @brief Returns the underlying NLT marker segment object
-     * 
+     *
      * @return param_nlt This object holds NLT marker segment information,
      *                   which deals with non-linearity point transformation
      *                   for each component.
@@ -355,7 +364,7 @@ namespace ojph {
     /**
      * @brief Query if the codestream extraction is planar or not.
      * See the documentation for ojph::codestream::set_planar()
-     * 
+     *
      * @return true if it is planar
      * @return false if it is not planar (interleaved)
      */

--- a/src/core/common/ojph_version.h
+++ b/src/core/common/ojph_version.h
@@ -34,5 +34,5 @@
 //***************************************************************************/
 
 #define OPENJPH_VERSION_MAJOR 0
-#define OPENJPH_VERSION_MINOR 21
-#define OPENJPH_VERSION_PATCH 5
+#define OPENJPH_VERSION_MINOR 22
+#define OPENJPH_VERSION_PATCH 0

--- a/src/core/others/ojph_file.cpp
+++ b/src/core/others/ojph_file.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman 
+// Copyright (c) 2019, Aous Naman
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -146,16 +146,16 @@ namespace ojph {
     else if (origin == OJPH_SEEK_CUR)
       offset += tell();
     else if (origin == OJPH_SEEK_END)
-      offset += (si64)buf_size;
+      offset += (si64)used_size;
     else {
-      assert(0); 
+      assert(0);
       return -1;
     }
-    
-    if (offset >= 0)
-      expand_storage((size_t)offset, false);
-    else
+
+    if (offset < 0)  // offset before the start of file
       return -1;
+
+    expand_storage((size_t)offset, false); // See if expansion is needed
 
     cur_ptr = buf + offset;
     return 0;
@@ -198,9 +198,9 @@ namespace ojph {
   /** */
   void mem_outfile::expand_storage(size_t needed_size, bool clear_all)
   {
-    needed_size += (needed_size + 1) >> 1; // x1.5
     if (needed_size > buf_size)
     {
+      needed_size += (needed_size + 1) >> 1; // x1.5
       si64 used_size = tell(); // current used size
 
       if (this->buf)
@@ -210,7 +210,7 @@ namespace ojph {
 
       if (clear_mem && !clear_all) // will be cleared later
         memset(this->buf + buf_size, 0, needed_size - this->buf_size);
-      
+
       this->buf_size = needed_size;
       this->cur_ptr = this->buf + used_size;
     }


### PR DESCRIPTION
This adds an option to restart the codestream, in order to use the codestream allocated memory again, i.e., removes the time needed to allocated memory.

This is useful if you are planning to decode multiple codeblocks that has a similar structure.
The allocated memory can expand if that is needed.

The PR:
- Adds the restart option to ojph::codestream.
- Fixes a bug in `ojph::mem_outfile`.
- Adds the request in issue #193.
- Modifies ojph::mem_fixed_allocator and ojph::mem_elastic_allocator
- Modifies the processing code of markers to work with restart.

These are example to show the benefit of this PR when one file is decoded multiple time.

**ojph_compress**

<details>

<summary> Needed code modification </summary

Add the following before main:
```
namespace ojph {
////////////////////////////////////////////////////////////////////////////
template<>
inline void line_buf::wrap(si32 *buffer, size_t num_ele, ui32 pre_size)
{
  this->i32 = buffer;
  this->size = num_ele;
  this->pre_size = pre_size;
  this->flags = LFT_32BIT | LFT_INTEGER;
}
}
```
and the following before `clock_t begin = clock();`:
```
  ojph::ppm_in ppm;
  ppm.open(input_filename);
  ojph::ui32 num_comps = 3;
  ojph::ui32 width = ppm.get_width();
  ojph::ui32 height = ppm.get_height();
  ojph::ui32 bits = ppm.get_bit_depth(0);
  ojph::ui32 bytes = bits > 8 ? 2 : 1;
  ojph::si32 *buffer, *tmp_buf, *clr_buf[3];
  tmp_buf = new ojph::si32[width];
  buffer = new ojph::si32[height * width * num_comps];
  clr_buf[0] = buffer;
  clr_buf[1] = clr_buf[0] + height * width;
  clr_buf[2] = clr_buf[1] + height * width;

  ojph::line_buf lf;
  lf.wrap(tmp_buf, ppm.get_width(), 0);

  for (ojph::ui32 i = 0; i < height; ++i)
    for (ojph::ui32 c = 0; c < num_comps; ++c)
    {
      ppm.read(&lf, c);
      std::copy(lf.i32, lf.i32 + width, clr_buf[c] + i * width);
    }
  ppm.close();

  ojph::mem_outfile j2c_file;
  ojph::codestream codestream;
  for (int iii = 0; iii < 50; ++iii)
  {
    clock_t begin = clock();

    codestream.restart();
    j2c_file.open(25<<20);

    ojph::ppm_in ppm;
    ppm.open(input_filename);
    ojph::param_siz siz = codestream.access_siz();
    siz.set_image_extent(ojph::point(image_offset.x + ppm.get_width(),
      image_offset.y + ppm.get_height()));
    ojph::ui32 num_comps = ppm.get_num_components();
    assert(num_comps == 3);
    siz.set_num_components(num_comps);
    for (ojph::ui32 c = 0; c < num_comps; ++c)
      siz.set_component(c, ppm.get_comp_subsampling(c),
        ppm.get_bit_depth(c), ppm.get_is_signed(c));
    siz.set_image_offset(image_offset);
    siz.set_tile_size(tile_size);
    siz.set_tile_offset(tile_offset);

    ojph::param_cod cod = codestream.access_cod();
    cod.set_num_decomposition(num_decompositions);
    cod.set_block_dims(block_size.w, block_size.h);
    if (num_precincts != -1)
      cod.set_precinct_size(num_precincts, precinct_size);
    cod.set_progression_order(prog_order);
    if (employ_color_transform == -1)
      cod.set_color_transform(true);
    else
      cod.set_color_transform(employ_color_transform == 1);
    cod.set_reversible(reversible);
    if (!reversible && quantization_step != -1.0f)
      codestream.access_qcd().set_irrev_quant(quantization_step);
    codestream.set_planar(false);
    if (profile_string[0] != '\0')
      codestream.set_profile(profile_string);
    codestream.set_tilepart_divisions(tileparts_at_resolutions,
                                      tileparts_at_components);
    codestream.request_tlm_marker(tlm_marker);

    if (dims.w != 0 || dims.h != 0)
      OJPH_WARN(0x01000011,
        "-dims option is not needed and was not used\n");
    if (num_components != 0)
      OJPH_WARN(0x01000012,
        "-num_comps is not needed and was not used\n");
    if (is_signed[0] != -1)
      OJPH_WARN(0x01000013,
        "-signed is not needed and was not used\n");
    if (bit_depth[0] != 0)
      OJPH_WARN(0x01000014,
        "-bit_depth is not needed and was not used\n");
    if (comp_downsampling[0].x != 0 || comp_downsampling[0].y != 0)
      OJPH_WARN(0x01000015,
        "-downsamp is not needed and was not used\n");

    ojph::comment_exchange com_ex;
    if (com_string)
      com_ex.set_string(com_string);
    // ojph::j2c_outfile j2c_file;
    // j2c_file.open(output_filename);

    codestream.write_headers(&j2c_file, &com_ex, com_string ? 1 : 0);

    ojph::ui32 next_comp;
    ojph::line_buf* cur_line = codestream.exchange(NULL, next_comp);
    if (codestream.is_planar())
    {
      ojph::param_siz siz = codestream.access_siz();
      for (ojph::ui32 c = 0; c < siz.get_num_components(); ++c)
      {
        ojph::point p = siz.get_downsampling(c);
        ojph::ui32 height = ojph_div_ceil(siz.get_image_extent().y, p.y);
        height -= ojph_div_ceil(siz.get_image_offset().y, p.y);
        for (ojph::ui32 i = 0; i < height; ++i)
        {
          assert(c == next_comp);
          std::copy(clr_buf[next_comp] + i * width,
            clr_buf[next_comp] + i * width + width,
            cur_line->i32);
          cur_line = codestream.exchange(cur_line, next_comp);
        }
      }
    }
    else
    {
      ojph::param_siz siz = codestream.access_siz();
      ojph::ui32 height = siz.get_image_extent().y;
      height -= siz.get_image_offset().y;
      for (ojph::ui32 i = 0; i < height; ++i)
      {
        for (ojph::ui32 c = 0; c < siz.get_num_components(); ++c)
        {
          assert(c == next_comp);
          std::copy(clr_buf[next_comp] + i * width,
            clr_buf[next_comp] + i * width + width,
            cur_line->i32);
          cur_line = codestream.exchange(cur_line, next_comp);
        }
      }
    }

    codestream.flush();
    codestream.close();
    j2c_file.seek(0, ojph::outfile_base::seek::OJPH_SEEK_END);
    ojph::si64 s = j2c_file.tell();
    j2c_file.close();

    clock_t end = clock();
    double elapsed_secs = double(end - begin) / CLOCKS_PER_SEC;
    printf("Elapsed time = %f, bytes written = %d\n", elapsed_secs, (int)s);
  }

  if (max_num_comps != initial_num_comps)
  {
    delete[] comp_downsampling;
    delete[] bit_depth;
    delete[] is_signed;
  }

  delete[] buffer;
  delete[] tmp_buf;

  j2c_file.write_to_file(output_filename);

  return 0;
```
</details> 

Running the code for lossless (reversible) compression of a 12 bpp, 4:4:4, 3840x2160, produces:
```
Elapsed time = 0.350000, bytes written = 20391005
Elapsed time = 0.341000, bytes written = 20391005
Elapsed time = 0.337000, bytes written = 20391005
Elapsed time = 0.282000, bytes written = 20391005
Elapsed time = 0.253000, bytes written = 20391005
Elapsed time = 0.224000, bytes written = 20391005
Elapsed time = 0.216000, bytes written = 20391005
Elapsed time = 0.218000, bytes written = 20391005
Elapsed time = 0.217000, bytes written = 20391005
Elapsed time = 0.218000, bytes written = 20391005
```
Notice how the needed time reduces by around 40%.

**ojph_expand**

<details>

<summary> Needed code modification </summary

Add the following before main:
```
namespace ojph {
////////////////////////////////////////////////////////////////////////////
template<>
inline void line_buf::wrap(si32 *buffer, size_t num_ele, ui32 pre_size)
{
  this->i32 = buffer;
  this->size = num_ele;
  this->pre_size = pre_size;
  this->flags = LFT_32BIT | LFT_INTEGER;
}
}
```
and the following before `clock_t begin = clock();`:

```
  FILE* f = fopen(input_filename, "rb");
  if (f == nullptr)
    OJPH_ERROR(0x0, "Unable to open the file %s\n", input_filename);
  if (ojph::ojph_fseek(f, 0, SEEK_END) != 0)
    OJPH_ERROR(0x0, "Unable to seek in file %s\n", input_filename);
  ojph::ui64 file_size = ojph::ojph_ftell(f);
  ojph::ui64 buf_size = file_size * 5 / 4;// increase by 25%
  ojph::ui8* src_buf = new ojph::ui8[buf_size];

  if (ojph::ojph_fseek(f, 0, SEEK_SET) != 0)
    OJPH_ERROR(0x0, "Unable to seek in file %s\n", input_filename);
  if (fread(src_buf, 1, file_size, f) != file_size)
      OJPH_ERROR(0x0, "Error reading from file %s\n", input_filename);
  fclose(f);

  ojph::mem_infile j2c_file;
  ojph::mem_outfile out_file;
  ojph::codestream codestream;

  for (int jjj = 0; jjj < 50; ++jjj)
  {
    clock_t begin = clock();

    j2c_file.open(src_buf, file_size);

    codestream.restart();
    codestream.read_headers(&j2c_file);

    codestream.set_planar(false);
    ojph::param_siz siz = codestream.access_siz();

    codestream.create();

    if (codestream.is_planar())
    {
      ojph::param_siz siz = codestream.access_siz();
      for (ojph::ui32 c = 0; c < siz.get_num_components(); ++c)
      {
        ojph::ui32 height = siz.get_recon_height(c);
        for (ojph::ui32 i = height; i > 0; --i)
        {
          ojph::ui32 comp_num;
          ojph::line_buf *line = codestream.pull(comp_num);
          assert(comp_num == c);
        }
      }
    }
    else
    {
      ojph::param_siz siz = codestream.access_siz();
      ojph::ui32 height = siz.get_recon_height(0);
      for (ojph::ui32 i = 0; i < height; ++i)
      {
        for (ojph::ui32 c = 0; c < siz.get_num_components(); ++c)
        {
          ojph::ui32 comp_num;
          ojph::line_buf *line = codestream.pull(comp_num);
          assert(comp_num == c);
        }
      }
    }

    codestream.close();

    clock_t end = clock();
    double elapsed_secs = double(end - begin) / CLOCKS_PER_SEC;
    printf("Elapsed time = %f\n", elapsed_secs);
  }

  delete src_buf;
  return 0;
```
</details>

Running the code for the same image above -- a 12 bpp, 4:4:4, 3840x2160 image compressed losslessly -- produces:
```
Elapsed time = 0.145000
Elapsed time = 0.136000
Elapsed time = 0.140000
Elapsed time = 0.138000
Elapsed time = 0.137000
Elapsed time = 0.132000
Elapsed time = 0.126000
Elapsed time = 0.115000
Elapsed time = 0.106000
Elapsed time = 0.102000
Elapsed time = 0.100000
Elapsed time = 0.099000
Elapsed time = 0.095000
Elapsed time = 0.092000
Elapsed time = 0.092000
Elapsed time = 0.089000
Elapsed time = 0.097000
Elapsed time = 0.088000
```
We also notice that needed time reduces by around 40%.






