### PR TITLE
Handle platform diff of -fPIC

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -135,9 +135,7 @@ if (BUILD_SHARED_LIBS AND WIN32)
 endif()
 
 ## include library version/name
-if (NOT MSVC)
-  target_compile_options(openjph PRIVATE -fPIC)
-endif()
+set_target_properties(openjph PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_compile_definitions(openjph PUBLIC _FILE_OFFSET_BITS=64)
 target_include_directories(openjph PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/common> $<INSTALL_INTERFACE:include/openjph>)
 


### PR DESCRIPTION
Fix #196 

Use cmake higher-level abstractions to handle platform differences of -fPIC
```cmake
# if (NOT MSVC)
#   target_compile_options(openjph PRIVATE -fPIC)
# endif()
set_target_properties(openjph PROPERTIES POSITION_INDEPENDENT_CODE ON)
```

Thanks for considering this contribution!I'm looking forward to your feedback and am open to making any necessary changes.