### PR TITLE
don't use delete with malloc on store

### DIFF
--- a/src/core/common/ojph_mem.h
+++ b/src/core/common/ojph_mem.h
@@ -81,8 +81,7 @@ namespace ojph {
       {
         // We should be here once only, because, in subsequent, calls we
         // should have size_data + size_obj <= allocated_data
-        if (store)
-          delete[] store;
+        free(store);
         allocated_data = size_data + size_obj;
         allocated_data = allocated_data + (allocated_data + 19) / 20; // 5%
         store = malloc(allocated_data);


### PR DESCRIPTION
```
/home/mark/git/OpenJPH/src/core/common/ojph_mem.h: In member function 'void ojph::mem_fixed_allocator::alloc()':
/home/mark/git/OpenJPH/src/core/common/ojph_mem.h:85:20: warning: deleting 'void*' is undefined [-Wdelete-incomplete]
   85 |           delete[] store;
      |                    ^~~~~
```