### PR TITLE
Support testing for both Cygwin and MSYS

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,10 +74,10 @@ else()
       COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE_DIR:ojph_compress>/ojph_compress.wasm" "./"
     )
   endif(EMSCRIPTEN)
-  if(MSYS)
+  if(CYGWIN)
     add_custom_command(TARGET test_executables POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E copy "../bin/msys-gtest.dll" "./"
-      COMMAND ${CMAKE_COMMAND} -E copy "../bin/msys-gtest_main.dll" "./"
+      COMMAND ${CMAKE_COMMAND} -E copy "../bin/${CMAKE_SHARED_LIBRARY_PREFIX}gtest.dll" "./"
+      COMMAND ${CMAKE_COMMAND} -E copy "../bin/${CMAKE_SHARED_LIBRARY_PREFIX}gtest_main.dll" "./"
     )
-  endif(MSYS)
+  endif()
 endif(MSVC)


### PR DESCRIPTION
[MSYS implies and derives from Cygwin in CMake](https://gitlab.kitware.com/cmake/cmake/-/blob/60cdc353c102804c697f5ee718fe6cb3991ef14f/Modules/Platform/MSYS.cmake)

One could also consider adding [Cygwin to CI](https://github.com/cygwin/cygwin-install-action).