### PR TITLE
'aligned_alloc' requires C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,9 +118,9 @@ endif()
 message(STATUS "Building ${CMAKE_BUILD_TYPE}")
 
 ## C++ version and flags
-# C++14 is needed for gtest, otherwise, C++11 is sufficient for the library
+## C++14 is needed for gtest, the library requires C++17
 if (NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 message(STATUS "C++ Standard is set to ${CMAKE_CXX_STANDARD}")
 


### PR DESCRIPTION
Fixing the issue that was causing build errors, at least on macos 10.15.7 
The use of 'aligned_alloc' API requires C++17, by standard.