### PR TITLE
Issues3

### DIFF
--- a/.github/workflows/ccp-workflow.yml
+++ b/.github/workflows/ccp-workflow.yml
@@ -174,10 +174,6 @@ jobs:
     - name: cmake
       run: cmake -DOJPH_ENABLE_TIFF_SUPPORT=OFF -DOJPH_BUILD_TESTS=ON -DPython3_EXECUTABLE=${MINGW_PREFIX}/bin/python.exe ..
       working-directory: build
-    - name: ls1
-      run: ls -la ${MINGW_PREFIX}/
-    - name: ls2
-      run: ls -la ${MINGW_PREFIX}/bin/
     - name: build
       run: cmake --build . --config Release
       working-directory: build


### PR DESCRIPTION
Corrects MSYS2 Test to use MINGW Python3 instead of the default Windows Python3, as recommended by @kmilos.
Thanx to @kmilos.