### PR TITLE
`nlt_type3[i]` not initialized when `get_nonlinear_transform() == false`

### DIFF
--- a/src/core/codestream/ojph_tile.cpp
+++ b/src/core/codestream/ojph_tile.cpp
@@ -276,9 +276,8 @@ namespace ojph {
             "(bit_depth = %d, is_signed = %s) from NLT marker segment, "
             "for component %d", i, num_bits[i], 
             is_signed[i] ? "True" : "False", bd, is ? "True" : "False");
-        if (result == false) {
+        if (result == false)
           nlt_type3[i] = param_nlt::nonlinearity::OJPH_NLT_NO_NLT;
-        }
         cur_line[i] = 0;
         reversible[i] = codestream->get_coc(i)->is_reversible();
       }

--- a/src/core/codestream/ojph_tile.cpp
+++ b/src/core/codestream/ojph_tile.cpp
@@ -276,6 +276,9 @@ namespace ojph {
             "(bit_depth = %d, is_signed = %s) from NLT marker segment, "
             "for component %d", i, num_bits[i], 
             is_signed[i] ? "True" : "False", bd, is ? "True" : "False");
+        if (result == false) {
+          nlt_type3[i] = param_nlt::nonlinearity::OJPH_NLT_NO_NLT;
+        }
         cur_line[i] = 0;
         reversible[i] = codestream->get_coc(i)->is_reversible();
       }


### PR DESCRIPTION
Dear library maintainers. I found this bug while working on my work-project, but I do not have any knowledge of how jpeg2000 compression works internally, so this is a "contextual fix". Here my observations and analysis:

## Symptoms

I am working with images stored on AWS HealthImaging. AWS is transcoding medical data to jpeg2000 compressed images. AWS also computes CRC32 checksums on the decompressed image data. While working on a data-loader, I noticed that CRC32 sums randomly did not match.

I turned to `valgrind` and analyzed my loader and traced the issue to the line

https://github.com/aous72/OpenJPH/blob/a0ae0ee9f66631d047bd5d81065300f1329b8356/src/core/codestream/ojph_tile.cpp#L421

for which `valgrind` reported that this "conditional jump depends on unitialized data".

## Analysis

By adding some more if-statements, I found out that the uninitialized data meant was `nlt_type3[comp_num]`. This seems to get initialized in this code section:

https://github.com/aous72/OpenJPH/blob/a0ae0ee9f66631d047bd5d81065300f1329b8356/src/core/codestream/ojph_tile.cpp#L270-L280

From what I could derive, jpeg2000 images can use the "non linear transform" optionally, but if it is not used, `nlp->get_nonlinear_transform(i, bd, is, nlt_type3[i])` returns `false`, and `nlt_type3[i]` is never set. I quickly checked the `param_nlt::nonlinearity` type and saw that it seems to define the value `OJPH_NLT_NO_NLT` which seems to match this case.

## Proposed solution

Set `nlt_type3[i] = param_nlt::nonlinearity::OJPH_NLT_NO_NLT;` when nonlinear-transform is disabled.

I have no idea if this is "correct" but it seems to fix the issue. With the fix, I now can reliably decode images from AWS HealthImaging with no hickups and `valgrind` is also happy.