### PR TITLE
apps: ojph_sockets: Detect __GLIBC__ before using GNU-flavour strerror_r

### DIFF
--- a/src/apps/others/ojph_sockets.cpp
+++ b/src/apps/others/ojph_sockets.cpp
@@ -165,16 +165,16 @@ namespace ojph
                                   MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), 
                                   buf, max_buf_size, NULL);
       buf[max_buf_size - 1] = 0;
-    #elif (defined OJPH_OS_APPLE) || \
-      ((_POSIX_C_SOURCE >= 200112L) && !_GNU_SOURCE)
+    #elif (defined __GLIBC__) && \
+      ((defined _GNU_SOURCE) || (_POSIX_C_SOURCE < 200112L))
+      v = strerror_r(errnum, (char*)buf, max_buf_size);
+    #else
       // it is not clear if the returned value is in buf or in v
       int t = strerror_r(errnum, (char*)buf, max_buf_size);
       if (t != 0)
         OJPH_ERROR(0x00080002, "Error retrieving a text message for "
           "socket error number %d\n", errnum);
       buf[max_buf_size - 1] = 0;
-    #else
-      v = strerror_r(errnum, (char*)buf, max_buf_size);
     #endif
       std::string str;
       str = v;    


### PR DESCRIPTION
According to manpage, glibc is the only libc implementation whose strerror_r() may return a char * pointer instead of int. Let's guard usage of the GNU-flavour prototype, instead of the standard XSI one. This should fix compilation on musl, *BSD and etc.