### PR TITLE
fix move special functions in mem in and outfile

### DIFF
--- a/src/core/openjph/ojph_file.h
+++ b/src/core/openjph/ojph_file.h
@@ -234,12 +234,10 @@ namespace ojph {
 
   private:
 
-    /** @brief A utility to set an instance's fields to default values.
-     *  
-     *  This function is used in the default constructor as well as
-     *  move constructor and assignment.
+    /**
+     * @brief A utility function to swap the contents of two instances
      */
-    static void reset(mem_outfile&) noexcept;
+    void swap(mem_outfile& other) noexcept;
   
     /**
      *  @brief This function expands storage by x1.5 needed space.
@@ -313,6 +311,20 @@ namespace ojph {
     mem_infile() { close(); }
     ~mem_infile() override { }
 
+    mem_infile(mem_infile const&) = delete;
+    mem_infile& operator=(mem_infile const&) = delete;
+
+    /**
+     * Move construction leaves the moved-from value in default constructed state
+     * and transfers ownership of the internal state to the moved-to instance.
+     **/
+    mem_infile(mem_infile &&) noexcept;
+    /**
+     * move assignment with the same ownership transfer semantics as
+     * move construction.
+     **/
+    mem_infile& operator=(mem_infile&&) noexcept;
+
     void open(const ui8* data, size_t size);
 
     //read reads size bytes, returns the number of bytes read
@@ -324,6 +336,9 @@ namespace ojph {
     void close() override { data = cur_ptr = NULL; size = 0; }
 
   private:
+    // swap the contents of two instances
+    void swap(mem_infile&) noexcept;
+
     const ui8 *data, *cur_ptr;
     size_t size;
   };

--- a/src/core/others/ojph_file.cpp
+++ b/src/core/others/ojph_file.cpp
@@ -107,14 +107,19 @@ namespace ojph {
   ////////////////////////////////////////////////////////////////////////////
   mem_outfile::mem_outfile()
   {
-    reset(*this);
+    is_open = clear_mem = false;
+    buf_size = used_size = 0;
+    buf = cur_ptr = nullptr;
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  void mem_outfile::reset(mem_outfile& f) noexcept {
-    f.is_open = f.clear_mem = false;
-    f.buf_size = f.used_size = 0;
-    f.buf = f.cur_ptr = nullptr;
+  void mem_outfile::swap(mem_outfile& other) noexcept {
+    std::swap(this->is_open,other.is_open);
+    std::swap(this->clear_mem,other.clear_mem);
+    std::swap(this->buf_size,other.buf_size);
+    std::swap(this->used_size,other.used_size);
+    std::swap(this->buf,other.buf);
+    std::swap(this->cur_ptr,other.cur_ptr);
   }
 
   ////////////////////////////////////////////////////////////////////////////
@@ -128,24 +133,18 @@ namespace ojph {
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  mem_outfile::mem_outfile(mem_outfile&& rhs) noexcept
+  mem_outfile::mem_outfile(mem_outfile&& rhs) noexcept: mem_outfile()
   {
-    reset(*this);
-    std::swap(*this, rhs);
+    this->swap(rhs);
   }
 
   ////////////////////////////////////////////////////////////////////////////
   mem_outfile& mem_outfile::operator=(mem_outfile&& rhs) noexcept
   {
-    if (this == &rhs)
-       return *this;
-
-    if (this->buf)
-      ojph_aligned_free(this->buf);
-
-    reset(*this);
-    std::swap(*this, rhs);
-
+    if (this != &rhs) {
+      mem_outfile tmp(std::move(rhs));
+      this->swap(tmp);
+    }
     return *this;
   }
 
@@ -319,6 +318,22 @@ namespace ojph {
   ////////////////////////////////////////////////////////////////////////////
 
   ////////////////////////////////////////////////////////////////////////////
+  mem_infile::mem_infile(mem_infile&& rhs) noexcept: mem_infile()
+  {
+    this->swap(rhs);
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  mem_infile& mem_infile::operator=(mem_infile&& rhs) noexcept
+  {
+    if (this != &rhs) {
+      mem_infile tmp(std::move(rhs));
+      this->swap(tmp);
+    }
+    return *this;
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
   void mem_infile::open(const ui8* data, size_t size)
   {
     assert(this->data == NULL);
@@ -376,5 +391,12 @@ namespace ojph {
     return result;
   }
 
+  ////////////////////////////////////////////////////////////////////////////
+  void mem_infile::swap(mem_infile& other) noexcept
+  {
+    std::swap(this->data,other.data);
+    std::swap(this->cur_ptr,other.cur_ptr);
+    std::swap(this->size,other.size);
+  }
 
 }


### PR DESCRIPTION
Dear Aous,

I'm sorry I have to bother you with this again. Some changes were made to my last pull request that introduced a hard to see, but critical bug. In the move constructors a call to `std::swap` is performed which leads to an infinite recursion and stack overflow. The problem is that currently `std::swap` is now used with an argument of type `mem_outfile` in the `mem_outfile` move constructor. This will lead to infinite recursion, because `std::swap` itself uses the move constructor and move assignment of the `mem_outfile` class itself. Allow me to explain:

As an example, the version of the gnu standard library that I'm using defines `std::move` as:

```cpp
  template<typename _Tp>
    _GLIBCXX20_CONSTEXPR
    inline
#if __cplusplus >= 201103L
    typename enable_if<__and_<__not_<__is_tuple_like<_Tp>>,
			      is_move_constructible<_Tp>,
			      is_move_assignable<_Tp>>::value>::type
#else
    void
#endif
    swap(_Tp& __a, _Tp& __b)
    _GLIBCXX_NOEXCEPT_IF(__and_<is_nothrow_move_constructible<_Tp>,
				is_nothrow_move_assignable<_Tp>>::value)
    {
#if __cplusplus < 201103L
      // concept requirements
      __glibcxx_function_requires(_SGIAssignableConcept<_Tp>)
#endif
      _Tp __tmp = _GLIBCXX_MOVE(__a);
      __a = _GLIBCXX_MOVE(__b);
      __b = _GLIBCXX_MOVE(__tmp);
    }
```

which roughly simplifies to 

```cpp
template<typename T>
void move(T& lhs, T& rhs) {
  T tmp = std::move(lhs);
  lhs = std::move(rhs);
  rhs = std::move(tmp);
}
```

From this, we can see that calling `std::swap` like is currently done is a problem. It's of course fine to call `std::swap` on the member _fields_ themselves, but not on the instance of the class itself.

I'm pretty sure this is the reason that the late C++ expert Rainer Grimm writes [here](https://www.modernescpp.com/index.php/the-copy-and-swap-idiom/)

> If you use the Copy-and-Swap Idiom to implement the copy assignment and the move assignment operator, **you must define your own swap** — either as a member function or as a friend

We can also infer from the documentation on [`std::swap`](https://en.cppreference.com/w/cpp/algorithm/swap.html) on cppreference, that the use of the move constructor and assignment is not particular to glibcxx, but is actually part of the standard:


> This overload participates in overload resolution only if std::is_move_constructible_v<T> && std::is_move_assignable_v<T> is true.
> 1) Swaps the values a and b.
> This overload participates in overload resolution only if std::is_move_constructible_v<T> && std::is_move_assignable_v<T> is true.

This isn't well-defined unless the move constructor is defined without the use of std::swap.