### PR TITLE
core: fix SEGV in param_qcd due to underflow when num_subbands is 0

### DIFF
--- a/src/core/codestream/ojph_params.cpp
+++ b/src/core/codestream/ojph_params.cpp
@@ -1411,6 +1411,10 @@ namespace ojph {
       else
         idx = resolution ? (resolution - 1) * 3 + subband : 0;
       if (idx >= num_subbands) {
+        if (num_subbands == 0)
+          OJPH_ERROR(0x00050102, "QCD/QCC marker segment contains no "
+            "quantization step sizes");
+
         OJPH_INFO(0x00050101, "Trying to access quantization step size for "
           "subband %d when the QCD/QCC marker segment specifies "
           "quantization step sizes for %d subbands only.  To continue "
@@ -1468,6 +1472,10 @@ namespace ojph {
       else
         idx = resolution ? (resolution - 1) * 3 + subband : 0;
       if (idx >= num_subbands) {
+        if (num_subbands == 0)
+          OJPH_ERROR(0x00050112, "QCD/QCC marker segment contains no "
+            "quantization step sizes");
+
         OJPH_INFO(0x00050111, "Trying to access quantization step size for "
           "subband %d when the QCD/QCC marker segment specifies "
           "quantization step sizes for %d subbands only.  To continue "


### PR DESCRIPTION
In `ojph::local::param_qcd::get_Kmax` and
`ojph::local::param_qcd::get_irrev_delta`, a segmentation fault occurred when processing a QCD/QCC marker segment with zero subbands.

When `num_subbands` is 0, the condition `idx >= num_subbands` evaluates to true. The code then attempted to clamp the index using `idx = num_subbands - 1`. Since `num_subbands` is an unsigned 32-bit integer, this resulted in an integer underflow to `0xFFFFFFFF`. Subsequent access to `SPqcd.u8[idx]` caused an out-of-bounds read and a crash.

This patch adds an explicit check for `num_subbands == 0` within the bounds-checking logic. If no subbands are present, it now triggers an `OJPH_ERROR` to safely abort the operation, as a QCD/QCC segment without quantization step sizes is invalid.

Verified that this fix prevents the ASAN SEGV and passes the project's test suite.

Fixes: https://issues.oss-fuzz.com/issues/477315155
Co-authored-by: CodeMender <codemender-patching@google.com>
Signed-off-by: Bill Wendling <morbo@google.com>
