### PR TITLE
AVX2 block coder optimizations (encoder + decoder)

### DIFF
--- a/.github/workflows/ccp-workflow.yml
+++ b/.github/workflows/ccp-workflow.yml
@@ -140,7 +140,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: cmake
-      run: cmake -DOJPH_BUILD_TESTS=yes ..
+      run: cmake -DCMAKE_BUILD_TYPE=Release -DOJPH_BUILD_TESTS=yes ..
       working-directory: build
     - name: build
       run: make
@@ -192,7 +192,7 @@ jobs:
         update: false
         pacboy: cc:p cmake:p python:p
     - name: cmake
-      run: cmake -DOJPH_ENABLE_TIFF_SUPPORT=OFF -DOJPH_BUILD_TESTS=ON -DPython3_EXECUTABLE=${MINGW_PREFIX}/bin/python.exe ..
+      run: cmake -DCMAKE_BUILD_TYPE=Release -DOJPH_ENABLE_TIFF_SUPPORT=OFF -DOJPH_BUILD_TESTS=ON -DPython3_EXECUTABLE=${MINGW_PREFIX}/bin/python.exe ..
       working-directory: build
     - name: build
       run: cmake --build . --config Release

--- a/.github/workflows/ccp-workflow.yml
+++ b/.github/workflows/ccp-workflow.yml
@@ -73,7 +73,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: cmake
-      run: cmake -G "Visual Studio 17 2022" -A x64 -DOJPH_ENABLE_TIFF_SUPPORT=OFF -DOJPH_BUILD_STREAM_EXPAND=ON ..
+      run: cmake -A x64 -DOJPH_ENABLE_TIFF_SUPPORT=OFF -DOJPH_BUILD_STREAM_EXPAND=ON ..
       working-directory: build
     - name: build
       run: cmake --build . --config Release
@@ -162,7 +162,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: cmake
-      run: cmake -G "Visual Studio 17 2022" -A x64 -DOJPH_ENABLE_TIFF_SUPPORT=OFF -DOJPH_BUILD_TESTS=ON ..
+      run: cmake -A x64 -DOJPH_ENABLE_TIFF_SUPPORT=OFF -DOJPH_BUILD_TESTS=ON ..
       working-directory: build
     - name: build
       run: cmake --build . --config Release

--- a/src/core/coding/ojph_block_common.cpp
+++ b/src/core/coding/ojph_block_common.cpp
@@ -5,7 +5,8 @@
 // Copyright (c) 2022, Aous Naman 
 // Copyright (c) 2022, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2022, The University of New South Wales, Australia
-// 
+// Copyright (c) 2026, Osamu Watanabe
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -32,6 +33,7 @@
 // This file is part of the OpenJPH software implementation.
 // File: ojph_block_common.cpp
 // Author: Aous Naman
+// Author: Osamu Watanabe
 // Date: 13 May 2022
 //***************************************************************************/
 
@@ -102,9 +104,14 @@ namespace ojph {
 
     /// @brief uvlc_tbl0 contains decoding information for initial row of quads
     ui16 uvlc_tbl0[256+64] = { 0 };
-    /// @brief uvlc_tbl1 contains decoding information for non-initial row of 
+    /// @brief uvlc_tbl1 contains decoding information for non-initial row of
     ///        quads
     ui16 uvlc_tbl1[256] = { 0 };
+    /// @brief uvlc_tbl1_wide: wider UVLC table for non-initial rows.
+    ///        Index = mode(2 bits) * 1024 + vlc_data(10 bits) = 12 bits.
+    ///        Entry bits: [4:0]=total_bits, [12:5]=u_q0, [20:13]=u_q1.
+    ///        total_bits == 0x1F means fallback to original decode path.
+    ui32 uvlc_tbl1_wide[4096] = { 0 };
     /// @brief uvlc_bias contains decoding info. for initial row of quads
     ui8 uvlc_bias[256+64] = { 0 };
     /// @}
@@ -330,6 +337,85 @@ namespace ojph {
     }
 
     //************************************************************************/
+    /** @ingroup uvlc_decoding_tables_grp
+     *  @brief Initializes uvlc_tbl1_wide: wider UVLC table for non-initial
+     *         rows. Index = mode(2b) * 1024 + vlc(10b). Entry packs
+     *         total_bits[4:0], u_q0[12:5], u_q1[20:13].
+     *         total_bits == 0x1F signals fallback to original decode.
+     */
+    static bool uvlc_init_wide_table()
+    {
+      static const ui8 dec[8] = {
+        3 | (5 << 2) | (5 << 5), //000
+        1 | (0 << 2) | (1 << 5), //xx1
+        2 | (0 << 2) | (2 << 5), //x10
+        1 | (0 << 2) | (1 << 5), //xx1
+        3 | (1 << 2) | (3 << 5), //100
+        1 | (0 << 2) | (1 << 5), //xx1
+        2 | (0 << 2) | (2 << 5), //x10
+        1 | (0 << 2) | (1 << 5)  //xx1
+      };
+
+      for (ui32 idx = 0; idx < 4096; ++idx)
+      {
+        ui32 mode = idx >> 10;       // 2 bits
+        ui32 vlc = idx & 0x3FF;      // 10 bits
+
+        if (mode == 0) {
+          uvlc_tbl1_wide[idx] = 0;
+          continue;
+        }
+
+        if (mode <= 2) // single UVLC (one u_off set)
+        {
+          ui32 d = dec[vlc & 0x7];
+          ui32 prefix_len = d & 0x3;
+          ui32 suffix_len = (d >> 2) & 0x7;
+          ui32 u_pfx = d >> 5;
+          ui32 suffix_val = (vlc >> prefix_len) & ((1u << suffix_len) - 1);
+          ui32 u_val = u_pfx + suffix_val;
+          ui32 total = prefix_len + suffix_len;
+          ui32 u_q0 = (mode == 1) ? u_val : 0;
+          ui32 u_q1 = (mode == 2) ? u_val : 0;
+          uvlc_tbl1_wide[idx] = total | (u_q0 << 5) | (u_q1 << 13);
+          continue;
+        }
+
+        // mode == 3: both u_off set
+        // Bitstream layout: [prefix0][prefix1][suffix0][suffix1]
+        ui32 d0 = dec[vlc & 0x7];
+        ui32 p0_len = d0 & 0x3;
+        ui32 s0_len = (d0 >> 2) & 0x7;
+        ui32 u0_pfx = d0 >> 5;
+
+        ui32 vlc1 = vlc >> p0_len;  // consume prefix0
+        ui32 d1 = dec[vlc1 & 0x7];
+        ui32 p1_len = d1 & 0x3;
+        ui32 s1_len = (d1 >> 2) & 0x7;
+        ui32 u1_pfx = d1 >> 5;
+
+        ui32 total_prefix = p0_len + p1_len;
+        ui32 total_suffix = s0_len + s1_len;
+        ui32 total = total_prefix + total_suffix;
+
+        if (total > 10) {
+          uvlc_tbl1_wide[idx] = 0x1F; // fallback sentinel
+          continue;
+        }
+
+        // suffixes follow both prefixes in the bitstream
+        ui32 suffix_bits = vlc >> total_prefix;
+        ui32 s0_val = suffix_bits & ((1u << s0_len) - 1);
+        ui32 s1_val = (suffix_bits >> s0_len) & ((1u << s1_len) - 1);
+
+        ui32 u_q0 = u0_pfx + s0_val;
+        ui32 u_q1 = u1_pfx + s1_val;
+        uvlc_tbl1_wide[idx] = total | (u_q0 << 5) | (u_q1 << 13);
+      }
+      return true;
+    }
+
+    //************************************************************************/
     /** @ingroup vlc_decoding_tables_grp
      *  @brief Initializes VLC tables vlc_tbl0 and vlc_tbl1
      */
@@ -340,6 +426,12 @@ namespace ojph {
      *  @brief Initializes UVLC tables uvlc_tbl0 and uvlc_tbl1
      */
     static bool uvlc_tables_initialized = uvlc_init_tables();
+
+    //************************************************************************/
+    /** @ingroup uvlc_decoding_tables_grp
+     *  @brief Initializes wide UVLC table uvlc_tbl1_wide
+     */
+    static bool uvlc_wide_initialized = uvlc_init_wide_table();
 
   } // !namespace local
 } // !namespace ojph

--- a/src/core/coding/ojph_block_common.h
+++ b/src/core/coding/ojph_block_common.h
@@ -5,7 +5,8 @@
 // Copyright (c) 2022, Aous Naman 
 // Copyright (c) 2022, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2022, The University of New South Wales, Australia
-// 
+// Copyright (c) 2026, Osamu Watanabe
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -32,6 +33,7 @@
 // This file is part of the OpenJPH software implementation.
 // File: ojph_block_common.h
 // Author: Aous Naman
+// Author: Osamu Watanabe
 // Date: 13 May 2022
 //***************************************************************************/
 
@@ -44,6 +46,7 @@ namespace ojph{
     extern ui16 vlc_tbl1[1024];
     extern ui16 uvlc_tbl0[256+64];
     extern ui16 uvlc_tbl1[256];
+    extern ui32 uvlc_tbl1_wide[4096];
     extern ui8 uvlc_bias[256+64];
   } // !namespace local
 } // !namespace ojph

--- a/src/core/coding/ojph_block_decoder_avx2.cpp
+++ b/src/core/coding/ojph_block_decoder_avx2.cpp
@@ -582,187 +582,137 @@ namespace ojph {
     }
 
     //************************************************************************/
-    /** @brief State structure for reading and unstuffing of forward-growing
-     *         bitstreams; these are: MagSgn and SPP bitstreams
-     */
-    struct frwd_struct_avx2 {
-      const ui8* data;  //!<pointer to bitstream
-      ui8 tmp[48];      //!<temporary buffer of read data + 16 extra
-      ui32 bits;        //!<number of bits stored in tmp
-      ui32 unstuff;     //!<1 if a bit needs to be unstuffed from next byte
-      int size;         //!<size of data
-    };
-
-    //************************************************************************/
-    /** @brief Read and unstuffs 16 bytes from forward-growing bitstream
+    /** @brief De-stuffs a forward-growing bitstream into a flat buffer
      *
-     *  A template is used to accommodate a different requirement for
-     *  MagSgn and SPP bitstreams; in particular, when MagSgn bitstream is
-     *  consumed, 0xFF's are fed, while when SPP is exhausted 0's are fed in.
-     *  X controls this value.
+     *  This replicates, in one pass, the bit production of the frwd_struct
+     *  bitstream reader used by the other block decoders: a byte following
+     *  a 0xFF byte contributes only 7 bits (its MSB -- guaranteed 0 by the
+     *  encoder -- is OR'ed with the following bit), and bits beyond the
+     *  end of the data
+     *  read as X (1s for MagSgn, 0s for SPP).  With the stream flattened,
+     *  bits for any quad can be fetched at an absolute bit position (see
+     *  dfetch), removing the serial fetch/advance state from the decode
+     *  loops.
      *
-     *  Unstuffing prevent sequences that are more than 0xFF7F from appearing
-     *  in the compressed sequence.  So whenever a value of 0xFF is coded, the
-     *  MSB of the next byte is set 0 and must be ignored during decoding.
+     *  Writes at most cap + 1 destuffed bytes followed by 64 bytes of
+     *  padding; dst must have room for cap + 65 bytes.  cap must be
+     *  no smaller than the maximum number of bits the decoder can consume
+     *  divided by 8, so clipping the data at cap loses no decodable bits.
      *
-     *  Reading can go beyond the end of buffer by up to 16 bytes.
-     *
-     *  @tparam       X is the value fed in when the bitstream is exhausted
-     *  @param  [in]  msp is a pointer to frwd_struct_avx2 structure
-     *
+     *  @tparam      X is the value fed in when the bitstream is exhausted
+     *  @param [in]  src is a pointer to the start of the bitstream data
+     *  @param [in]  size is the number of bytes in the bitstream data
+     *  @param [in]  dst is the output buffer, of at least cap + 65 bytes
+     *  @param [in]  cap is the maximum number of destuffed bytes to write
+     *  @return ui32 clamp offset for dfetch; bytes at or beyond this
+     *               offset hold no stream bits (they read as X)
      */
     template<int X>
     static inline
-    void frwd_read(frwd_struct_avx2 *msp)
+    ui32 destuff_frwd(const ui8* src, int size, ui8* dst, ui32 cap)
     {
-      assert(msp->bits <= 128);
+      if (size < 0)
+        size = 0;
+      ui8* o = dst;
+      ui8* o_end = dst + cap;
+      const ui8* s = src;
+      const ui8* s_end = src + size;
+      ui64 acc = 0;       // partial output byte, low nb bits are valid
+      ui32 nb = 0;        // number of valid bits in acc; always < 8
+      bool prev_ff = false;
 
-      __m128i offset, val, validity, all_xff;
-      val = _mm_loadu_si128((__m128i*)msp->data);
-      int bytes = msp->size >= 16 ? 16 : msp->size;
-      validity = _mm_set1_epi8((char)bytes);
-      msp->data += bytes;
-      msp->size -= bytes;
-      int bits = 128;
-      offset = _mm_set_epi64x(0x0F0E0D0C0B0A0908,0x0706050403020100);
-      validity = _mm_cmpgt_epi8(validity, offset);
-      all_xff = _mm_set1_epi8(-1);
-      if (X == 0xFF) // the compiler should remove this if statement
+      // fast path; 16 source bytes at a time when they contain no 0xFF
+      while (s + 16 <= s_end && o + 24 <= o_end)
       {
-        __m128i t = _mm_xor_si128(validity, all_xff); // complement
-        val = _mm_or_si128(t, val); // fill with 0xFF
+        __m128i v = _mm_loadu_si128((const __m128i*)s);
+        int ff = _mm_movemask_epi8(_mm_cmpeq_epi8(v, _mm_set1_epi8(-1)));
+        if (ff != 0 || prev_ff)
+        { // process these 16 bytes one at a time
+          for (int i = 0; i < 16; ++i) {
+            ui8 b = *s++;
+            acc |= (ui64)b << nb;
+            nb += prev_ff ? 7u : 8u;
+            prev_ff = (b == 0xFFu);
+            if (nb >= 8) { *o++ = (ui8)acc; acc >>= 8; nb -= 8; }
+          }
+          continue;
+        }
+        ui64 v0, v1;
+        memcpy(&v0, s, 8);
+        memcpy(&v1, s + 8, 8);
+        ui64 w0 = acc | (v0 << nb);
+        ui64 w1 = (v1 << nb) | (nb ? (v0 >> (64 - nb)) : 0);
+        memcpy(o, &w0, 8);
+        memcpy(o + 8, &w1, 8);
+        acc = nb ? (v1 >> (64 - nb)) : 0;
+        o += 16;
+        s += 16;
       }
-      else if (X == 0)
-        val = _mm_and_si128(validity, val); // fill with zeros
-      else
-        assert(0);
-
-      __m128i ff_bytes;
-      ff_bytes = _mm_cmpeq_epi8(val, all_xff);
-      ff_bytes = _mm_and_si128(ff_bytes, validity);
-      ui32 flags = (ui32)_mm_movemask_epi8(ff_bytes);
-      flags <<= 1; // unstuff following byte
-      ui32 next_unstuff = flags >> 16;
-      flags |= msp->unstuff;
-      flags &= 0xFFFF;
-      while (flags)
-      { // bit unstuffing occurs on average once every 256 bytes
-        // therefore it is not an issue if it is a bit slow
-        // here we process 16 bytes
-        --bits; // consuming one stuffing bit
-
-        ui32 loc = 31 - count_leading_zeros(flags);
-        flags ^= 1 << loc;
-
-        __m128i m, t, c;
-        t = _mm_set1_epi8((char)loc);
-        m = _mm_cmpgt_epi8(offset, t);
-
-        t = _mm_and_si128(m, val);  // keep bits at locations larger than loc
-        c = _mm_srli_epi64(t, 1);   // 1 bits left
-        t = _mm_srli_si128(t, 8);   // 8 bytes left
-        t = _mm_slli_epi64(t, 63);  // keep the MSB only
-        t = _mm_or_si128(t, c);     // combine the above 3 steps
-
-        val = _mm_or_si128(t, _mm_andnot_si128(m, val));
-      }
-
-      // combine with earlier data
-      assert(msp->bits >= 0 && msp->bits <= 128);
-      int cur_bytes = msp->bits >> 3;
-      int cur_bits = msp->bits & 7;
-      __m128i b1, b2;
-      b1 = _mm_sll_epi64(val, _mm_set1_epi64x(cur_bits));
-      b2 = _mm_slli_si128(val, 8);  // 8 bytes right
-      b2 = _mm_srl_epi64(b2, _mm_set1_epi64x(64-cur_bits));
-      b1 = _mm_or_si128(b1, b2);
-      b2 = _mm_loadu_si128((__m128i*)(msp->tmp + cur_bytes));
-      b2 = _mm_or_si128(b1, b2);
-      _mm_storeu_si128((__m128i*)(msp->tmp + cur_bytes), b2);
-
-      int consumed_bits = bits < 128 - cur_bits ? bits : 128 - cur_bits;
-      cur_bytes = (msp->bits + (ui32)consumed_bits + 7) >> 3; // round up
-      int upper = _mm_extract_epi16(val, 7);
-      upper >>= consumed_bits - 128 + 16;
-      msp->tmp[cur_bytes] = (ui8)upper; // copy byte
-
-      msp->bits += (ui32)bits;
-      msp->unstuff = next_unstuff;   // next unstuff
-      assert(msp->unstuff == 0 || msp->unstuff == 1);
-    }
-
-    //************************************************************************/
-    /** @brief Initialize frwd_struct_avx2 struct and reads some bytes
-     *
-     *  @tparam      X is the value fed in when the bitstream is exhausted.
-     *               See frwd_read regarding the template
-     *  @param [in]  msp is a pointer to frwd_struct_avx2
-     *  @param [in]  data is a pointer to the start of data
-     *  @param [in]  size is the number of byte in the bitstream
-     */
-    template<int X>
-    static inline
-    void frwd_init(frwd_struct_avx2 *msp, const ui8* data, int size)
-    {
-      msp->data = data;
-      _mm_storeu_si128((__m128i *)msp->tmp, _mm_setzero_si128());
-      _mm_storeu_si128((__m128i *)msp->tmp + 1, _mm_setzero_si128());
-      _mm_storeu_si128((__m128i *)msp->tmp + 2, _mm_setzero_si128());
-
-      msp->bits = 0;
-      msp->unstuff = 0;
-      msp->size = size;
-
-      frwd_read<X>(msp); // read 128 bits more
-    }
-
-    //************************************************************************/
-    /** @brief Consume num_bits bits from the bitstream of frwd_struct_avx2
-     *
-     *  @param [in]  msp is a pointer to frwd_struct_avx2
-     *  @param [in]  num_bits is the number of bit to consume
-     */
-    static inline
-    void frwd_advance(frwd_struct_avx2 *msp, ui32 num_bits)
-    {
-      assert(num_bits > 0 && num_bits <= msp->bits && num_bits < 128);
-      msp->bits -= num_bits;
-
-      __m256i *p = (__m256i*)(msp->tmp + ((num_bits >> 3) & 0x18));
-      num_bits &= 63;
-
-      __m256i v = _mm256_loadu_si256(p);
-      __m256i shifted = _mm256_srlv_epi64(v, _mm256_set1_epi64x(num_bits));
-
-      __m256i carry_src = _mm256_permute4x64_epi64(v, 0x39);
-      carry_src = _mm256_blend_epi32(carry_src,
-                                      _mm256_setzero_si256(), 0xC0);
-      __m256i carry = _mm256_sllv_epi64(carry_src,
-                                         _mm256_set1_epi64x(64 - num_bits));
-
-      _mm256_storeu_si256((__m256i*)msp->tmp,
-                          _mm256_or_si256(shifted, carry));
-    }
-
-    //************************************************************************/
-    /** @brief Fetches 32 bits from the frwd_struct_avx2 bitstream
-     *
-     *  @tparam      X is the value fed in when the bitstream is exhausted.
-     *               See frwd_read regarding the template
-     *  @param [in]  msp is a pointer to frwd_struct_avx2
-     */
-    template<int X>
-    static inline
-    __m128i frwd_fetch(frwd_struct_avx2 *msp)
-    {
-      if (msp->bits <= 128)
+      // tail; one byte at a time
+      while (s < s_end && o < o_end)
       {
-        frwd_read<X>(msp);
-        if (msp->bits <= 128) //need to test
-          frwd_read<X>(msp);
+        ui8 b = *s++;
+        acc |= (ui64)b << nb;
+        nb += prev_ff ? 7u : 8u;
+        prev_ff = (b == 0xFFu);
+        if (nb >= 8) { *o++ = (ui8)acc; acc >>= 8; nb -= 8; }
       }
-      __m128i t = _mm_loadu_si128((__m128i*)msp->tmp);
-      return t;
+      // fill the bits above nb with X, and pad with X bytes
+      ui32 fill = (X == 0xFF) ? (0xFFu << nb) : 0;
+      *o = (ui8)((ui32)acc | fill);
+      __m256i pad = _mm256_set1_epi8((char)X);
+      _mm256_storeu_si256((__m256i*)(o + 1), pad);
+      _mm256_storeu_si256((__m256i*)(o + 33), pad);
+      return (ui32)(o - dst) + 1;
+    }
+
+    //************************************************************************/
+    /** @brief Fetches 128 bits from a destuffed MagSgn buffer
+     *
+     *  Returns the 128 bits starting at bit position pos of the buffer
+     *  produced by destuff_frwd.  Unlike a stateful bitstream reader,
+     *  this carries no
+     *  serial state; fetches at independent positions can execute out of
+     *  order.  The byte offset is clamped to limit so that positions past
+     *  the end of the stream read as 1s without leaving the buffer.
+     *
+     *  @param [in]  dbuf is the destuffed MagSgn buffer
+     *  @param [in]  limit is the clamp offset returned by destuff_frwd
+     *  @param [in]  pos is the absolute bit position to fetch from
+     */
+    OJPH_FORCE_INLINE
+    __m128i dfetch(const ui8* dbuf, ui32 limit, ui32 pos)
+    {
+      ui32 off = pos >> 3;
+      off = off < limit ? off : limit;
+      const ui8* p = dbuf + off;
+      __m128i v = _mm_loadu_si128((const __m128i*)p);
+      __m128i w = _mm_loadu_si128((const __m128i*)(p + 8));
+      int k = (int)(pos & 7);
+      __m128i r = _mm_srl_epi64(v, _mm_cvtsi32_si128(k));
+      __m128i c = _mm_sll_epi64(w, _mm_cvtsi32_si128(64 - k));
+      return _mm_or_si128(r, c);
+    }
+
+    //************************************************************************/
+    /** @brief Fetches at least 57 bits from a destuffed bitstream
+     *
+     *  Scalar counterpart of dfetch; returns the bits starting at bit
+     *  position pos of a buffer produced by destuff_frwd, in the lower
+     *  bits of the result.  Bits above 64 - (pos & 7) are garbage.
+     *
+     *  @param [in]  dbuf is the destuffed bitstream buffer
+     *  @param [in]  limit is the clamp offset returned by destuff_frwd
+     *  @param [in]  pos is the absolute bit position to fetch from
+     */
+    OJPH_FORCE_INLINE
+    ui64 dfetch64(const ui8* dbuf, ui32 limit, ui32 pos)
+    {
+      ui32 off = pos >> 3;
+      off = off < limit ? off : limit;
+      ui64 v;
+      memcpy(&v, dbuf + off, 8);
+      return v >> (pos & 7);
     }
 
     //************************************************************************/
@@ -776,7 +726,9 @@ namespace ojph {
      *  @return __m256i decoded two quads
      */
     OJPH_FORCE_INLINE
-    __m256i decode_two_quad32_avx2(__m256i inf_u_q, __m256i U_q, frwd_struct_avx2* magsgn, ui32 p, __m128i& vn) {
+    __m256i decode_two_quad32_avx2(__m256i inf_u_q, __m256i U_q,
+                                   const ui8* dbuf, ui32 limit, ui32& pos,
+                                   ui32 p, __m128i& vn) {
         __m256i row = _mm256_setzero_si256();
 
         // we keeps e_k, e_1, and rho in w2
@@ -802,36 +754,12 @@ namespace ojph {
             __m256i inc_sum = m_n; // inclusive scan
             inc_sum = _mm256_add_epi32(inc_sum, _mm256_bslli_epi128(inc_sum, 4));
             inc_sum = _mm256_add_epi32(inc_sum, _mm256_bslli_epi128(inc_sum, 8));
-            int total_mn1 = _mm256_extract_epi16(inc_sum, 6);
-            int total_mn2 = _mm256_extract_epi16(inc_sum, 14);
+            ui32 total_mn1 = (ui32)_mm256_extract_epi16(inc_sum, 6);
+            ui32 total_mn2 = (ui32)_mm256_extract_epi16(inc_sum, 14);
 
-            __m128i ms_vec0 = _mm_setzero_si128();
-            __m128i ms_vec1 = _mm_setzero_si128();
-            ui32 total_mn = (ui32)(total_mn1 + total_mn2);
-            if (total_mn1 > 0 && total_mn2 > 0
-                && total_mn1 < 64 && total_mn < 128)
-            {
-                __m128i ms_all = frwd_fetch<0xFF>(magsgn);
-                ms_vec0 = ms_all;
-                __m128i sh = _mm_set1_epi64x(total_mn1);
-                ms_vec1 = _mm_srl_epi64(ms_all, sh);
-                __m128i cross = _mm_srli_si128(ms_all, 8);
-                cross = _mm_sll_epi64(cross,
-                            _mm_set1_epi64x(64 - total_mn1));
-                ms_vec1 = _mm_or_si128(ms_vec1, cross);
-                frwd_advance(magsgn, total_mn);
-            }
-            else
-            {
-                if (total_mn1) {
-                    ms_vec0 = frwd_fetch<0xFF>(magsgn);
-                    frwd_advance(magsgn, (ui32)total_mn1);
-                }
-                if (total_mn2) {
-                    ms_vec1 = frwd_fetch<0xFF>(magsgn);
-                    frwd_advance(magsgn, (ui32)total_mn2);
-                }
-            }
+            __m128i ms_vec0 = dfetch(dbuf, limit, pos);
+            __m128i ms_vec1 = dfetch(dbuf, limit, pos + total_mn1);
+            pos += total_mn1 + total_mn2;
 
             __m256i ms_vec = _mm256_inserti128_si256(_mm256_castsi128_si256(ms_vec0), ms_vec1, 0x1);
 
@@ -908,7 +836,9 @@ namespace ojph {
      */
 
     OJPH_FORCE_INLINE
-    __m256i decode_four_quad16(const __m128i inf_u_q, __m128i U_q, frwd_struct_avx2* magsgn, ui32 p, __m128i& vn) {
+    __m256i decode_four_quad16(const __m128i inf_u_q, __m128i U_q,
+                               const ui8* dbuf, ui32 limit, ui32& pos,
+                               ui32 p, __m128i& vn) {
 
         __m256i w0;     // workers
         __m256i insig;  // lanes hold FF's if samples are insignificant
@@ -949,37 +879,13 @@ namespace ojph {
             inc_sum = _mm256_add_epi16(inc_sum, _mm256_bslli_epi128(inc_sum, 2));
             inc_sum = _mm256_add_epi16(inc_sum, _mm256_bslli_epi128(inc_sum, 4));
             inc_sum = _mm256_add_epi16(inc_sum, _mm256_bslli_epi128(inc_sum, 8));
-            int total_mn1 = _mm256_extract_epi16(inc_sum, 7);
-            int total_mn2 = _mm256_extract_epi16(inc_sum, 15);
+            ui32 total_mn1 = (ui32)_mm256_extract_epi16(inc_sum, 7);
+            ui32 total_mn2 = (ui32)_mm256_extract_epi16(inc_sum, 15);
             __m256i ex_sum = _mm256_bslli_epi128(inc_sum, 2); // exclusive scan
 
-            __m128i ms_vec0 = _mm_setzero_si128();
-            __m128i ms_vec1 = _mm_setzero_si128();
-            ui32 total_mn = (ui32)(total_mn1 + total_mn2);
-            if (total_mn1 > 0 && total_mn2 > 0
-                && total_mn1 < 64 && total_mn < 128)
-            {
-                __m128i ms_all = frwd_fetch<0xFF>(magsgn);
-                ms_vec0 = ms_all;
-                __m128i sh = _mm_set1_epi64x(total_mn1);
-                ms_vec1 = _mm_srl_epi64(ms_all, sh);
-                __m128i cross = _mm_srli_si128(ms_all, 8);
-                cross = _mm_sll_epi64(cross,
-                            _mm_set1_epi64x(64 - total_mn1));
-                ms_vec1 = _mm_or_si128(ms_vec1, cross);
-                frwd_advance(magsgn, total_mn);
-            }
-            else
-            {
-                if (total_mn1) {
-                    ms_vec0 = frwd_fetch<0xFF>(magsgn);
-                    frwd_advance(magsgn, (ui32)total_mn1);
-                }
-                if (total_mn2) {
-                    ms_vec1 = frwd_fetch<0xFF>(magsgn);
-                    frwd_advance(magsgn, (ui32)total_mn2);
-                }
-            }
+            __m128i ms_vec0 = dfetch(dbuf, limit, pos);
+            __m128i ms_vec1 = dfetch(dbuf, limit, pos + total_mn1);
+            pos += total_mn1 + total_mn2;
 
             __m256i ms_vec = _mm256_inserti128_si256(_mm256_castsi128_si256(ms_vec0), ms_vec1, 0x1);
 
@@ -1008,29 +914,25 @@ namespace ojph {
             d0 = _mm256_or_si256(d0, d1);
 
             // find location of e_k and mask
-            __m256i shift, t0, t1, Uq0, Uq1;
+            __m256i shift;
             __m256i ones = _mm256_set1_epi16(1);
             __m256i twos = _mm256_set1_epi16(2);
-            __m256i U_q_m1 = _mm256_sub_epi32(U_q_avx, ones);
-            Uq0 = _mm256_and_si256(U_q_m1, _mm256_set_epi32(0, 0, 0, 0x1F, 0, 0, 0, 0x1F));
-            Uq1 = _mm256_bsrli_epi128(U_q_m1, 14);
+            // shift = (2 - e_k) << (U_q - 1); AVX2 has no _mm256_sllv_epi16,
+            // so the variable shift is emulated with a pshufb power-of-two
+            // lookup and a 16-bit multiply.  U_q - 1 <= 14 in this path;
+            // for U_q == 0 the lookup indices have their MSB set, so pshufb
+            // returns 0, the same shift value the former uniform 16-bit
+            // shift emulation produced (it shifted by 31)
+            __m256i kq = _mm256_sub_epi16(U_q_avx, ones);
+            __m256i idx = _mm256_or_si256(kq,
+                _mm256_slli_epi16(_mm256_sub_epi16(kq,
+                                            _mm256_set1_epi16(8)), 8));
+            const __m256i pow2_tbl = _mm256_setr_epi8(
+                1, 2, 4, 8, 16, 32, 64, (char)128, 0, 0, 0, 0, 0, 0, 0, 0,
+                1, 2, 4, 8, 16, 32, 64, (char)128, 0, 0, 0, 0, 0, 0, 0, 0);
+            __m256i pow2 = _mm256_shuffle_epi8(pow2_tbl, idx);
             w0 = _mm256_sub_epi16(twos, w0);
-            t0 = _mm256_and_si256(w0, _mm256_set_epi64x(0, -1, 0, -1));
-            t1 = _mm256_and_si256(w0, _mm256_set_epi64x(-1, 0, -1, 0));
-            {//no _mm256_sllv_epi16 in avx2
-                __m128i t_0_sse = _mm256_castsi256_si128(t0);
-                t_0_sse = _mm_sll_epi16(t_0_sse, _mm256_castsi256_si128(Uq0));
-                __m128i t_1_sse = _mm256_extracti128_si256(t0 , 0x1);
-                t_1_sse = _mm_sll_epi16(t_1_sse, _mm256_extracti128_si256(Uq0, 0x1));
-                t0 = _mm256_inserti128_si256(_mm256_castsi128_si256(t_0_sse), t_1_sse, 0x1);
-
-                t_0_sse = _mm256_castsi256_si128(t1);
-                t_0_sse = _mm_sll_epi16(t_0_sse, _mm256_castsi256_si128(Uq1));
-                t_1_sse = _mm256_extracti128_si256(t1, 0x1);
-                t_1_sse = _mm_sll_epi16(t_1_sse, _mm256_extracti128_si256(Uq1, 0x1));
-                t1 = _mm256_inserti128_si256(_mm256_castsi128_si256(t_0_sse), t_1_sse, 0x1);
-            }
-            shift = _mm256_or_si256(t0, t1);
+            shift = _mm256_mullo_epi16(w0, pow2);
             ms_vec = _mm256_and_si256(d0, _mm256_sub_epi16(shift, ones));
 
             // next e_1
@@ -1120,8 +1022,11 @@ namespace ojph {
         ui32 v_n_scratch_32[v_n_size];
 #endif
 
-        frwd_struct_avx2 magsgn;
-        frwd_init<0xFF>(&magsgn, coded_data, lcup - scup);
+        // maximum consumable MagSgn bits: 4096 samples x (mmsbp2 < 16) bits
+        const ui32 dbuf_cap = 4096 * 15 / 8;
+        ui8 dbuf[dbuf_cap + 72];
+        ui32 limit = destuff_frwd<0xFF>(coded_data, lcup - scup, dbuf, dbuf_cap);
+        ui32 pos = 0;
 
         {
           ui16 *sp = scratch;
@@ -1139,7 +1044,7 @@ namespace ojph {
               }
 
               __m128i vn = _mm_set1_epi16(2);
-              __m256i row = decode_four_quad16(inf_u_q, U_q, &magsgn, p, vn);
+              __m256i row = decode_four_quad16(inf_u_q, U_q, dbuf, limit, pos, p, vn);
 
               w = _mm_cvtsi32_si128(*(unsigned short const*)(vp));
               _mm_storeu_si128((__m128i*)vp, _mm_or_si128(w, vn));
@@ -1207,7 +1112,7 @@ namespace ojph {
               __m128i U_q = _mm_loadu_si128((__m128i*)vp_32);
 
             __m128i vn = _mm_set1_epi16(2);
-            __m256i row = decode_four_quad16(inf_u_q, U_q, &magsgn, p, vn);
+            __m256i row = decode_four_quad16(inf_u_q, U_q, dbuf, limit, pos, p, vn);
 
             __m128i w = _mm_cvtsi32_si128(*(unsigned short const*)(vp));
             _mm_storeu_si128((__m128i*)vp, _mm_or_si128(w, vn));
@@ -1244,8 +1149,11 @@ namespace ojph {
         memset(v_n_scratch + (width >> 1) + 2, 0, 14 * sizeof(ui32));
 #endif
 
-        frwd_struct_avx2 magsgn;
-        frwd_init<0xFF>(&magsgn, coded_data, lcup - scup);
+        // maximum consumable MagSgn bits: 4096 samples x (mmsbp2 <= 32) bits
+        const ui32 dbuf_cap = 4096 * 32 / 8;
+        ui8 dbuf[dbuf_cap + 72];
+        ui32 limit = destuff_frwd<0xFF>(coded_data, lcup - scup, dbuf, dbuf_cap);
+        ui32 pos = 0;
 
         const __m256i avx_mmsbp2 = _mm256_set1_epi32((int)mmsbp2);
 
@@ -1268,7 +1176,7 @@ namespace ojph {
                 return false;
             }
 
-            __m256i row = decode_two_quad32_avx2(inf_u_q, U_q, &magsgn, p, vn);
+            __m256i row = decode_two_quad32_avx2(inf_u_q, U_q, dbuf, limit, pos, p, vn);
             row = _mm256_permutevar8x32_epi32(row, _mm256_setr_epi32(0, 2, 4, 6, 1, 3, 5, 7));
             _mm_store_si128((__m128i*)dp, _mm256_castsi256_si128(row));
             _mm_store_si128((__m128i*)(dp + stride), _mm256_extracti128_si256(row, 0x1));
@@ -1334,7 +1242,7 @@ namespace ojph {
             __m256i U_q = _mm256_castsi128_si256(_mm_loadl_epi64((__m128i*)(vp + v_n_size)));
             U_q = _mm256_permutevar8x32_epi32(U_q, _mm256_setr_epi32(0, 0, 0, 0, 1, 1, 1, 1));
 
-            __m256i row = decode_two_quad32_avx2(inf_u_q, U_q,  &magsgn, p, vn);
+            __m256i row = decode_two_quad32_avx2(inf_u_q, U_q, dbuf, limit, pos, p, vn);
             row = _mm256_permutevar8x32_epi32(row, _mm256_setr_epi32(0, 2, 4, 6, 1, 3, 5, 7));
             _mm_store_si128((__m128i*)dp, _mm256_castsi256_si128(row));
             _mm_store_si128((__m128i*)(dp + stride), _mm256_extracti128_si256(row, 0x1));
@@ -1430,8 +1338,13 @@ namespace ojph {
           // We add an extra 8 entries, just in case we need more
           ui16 prev_row_sig[256 + 8] = {0}; // 528 Bytes
 
-          frwd_struct_avx2 sigprop;
-          frwd_init<0>(&sigprop, coded_data + lengths1, (int)lengths2);
+          // maximum consumable SPP bits: 4096 samples x 2 bits (one
+          // significance bit and one sign bit per sample)
+          const ui32 spp_cap = 4096 * 2 / 8;
+          ui8 spp_buf[spp_cap + 72];
+          ui32 spp_limit = destuff_frwd<0>(coded_data + lengths1,
+                                           (int)lengths2, spp_buf, spp_cap);
+          ui32 spp_pos = 0;
 
           for (ui32 y = 0; y < height; y += 4)
           {
@@ -1496,8 +1409,7 @@ namespace ojph {
               ui32 new_sig = mbr;
               if (new_sig)
               {
-                __m128i cwd_vec = frwd_fetch<0>(&sigprop);
-                ui32 cwd = (ui32)_mm_extract_epi16(cwd_vec, 0);
+                ui64 cwd = dfetch64(spp_buf, spp_limit, spp_pos);
 
                 ui32 cnt = 0;
                 ui32 col_mask = 0xFu;
@@ -1559,7 +1471,8 @@ namespace ojph {
 
                 if (new_sig)
                 {
-                  cwd |= (ui32)_mm_extract_epi16(cwd_vec, 1) << (16 - cnt);
+                  // the sign bits sit right after the cnt consumed bits
+                  // of cwd; no reassembly is needed
 
                   // Spread new_sig, such that each bit is in one byte with a
                   // value of 0 if new_sig bit is 0, and 0xFF if new_sig is 1
@@ -1585,7 +1498,7 @@ namespace ojph {
 
                   // Spread cwd, such that each bit is in one byte
                   // with a value of 0 or 1.
-                  cwd_vec = _mm_set1_epi16((si16)cwd);
+                  __m128i cwd_vec = _mm_set1_epi16((si16)cwd);
                   cwd_vec = _mm_shuffle_epi8(cwd_vec,
                     _mm_set_epi8(1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0));
                   cwd_vec = _mm_and_si128(cwd_vec,
@@ -1628,7 +1541,7 @@ namespace ojph {
                     m = _mm_add_epi32(m, _mm_set1_epi32(1));
                   }
                 }
-                frwd_advance(&sigprop, cnt);
+                spp_pos += cnt;
               }
 
               new_sig |= cs;

--- a/src/core/coding/ojph_block_decoder_avx2.cpp
+++ b/src/core/coding/ojph_block_decoder_avx2.cpp
@@ -101,7 +101,7 @@ namespace ojph {
 
       ui32 val = 0xFFFFFFFF;       // feed in 0xFF if buffer is exhausted
       if (melp->size > 4) {        // if there is data in the MEL segment
-        val = *(ui32*)melp->data;  // read 32 bits from MEL data
+        memcpy(&val, melp->data, 4);  // read 32 bits from MEL data
         melp->data += 4;           // advance pointer
         melp->size -= 4;           // reduce counter
       }
@@ -414,21 +414,27 @@ namespace ojph {
      *  above the bits remaining in the window, leaving 56 to 63 valid
      *  bits.  Because the inserted bits land above the remaining ones,
      *  consumers of the low bits need not wait for the load, keeping it
-     *  off the critical dependency chain.  The pointer advances by at
-     *  most 8 bytes per call, and in total by no more than the consumed
-     *  bit count divided by 8, plus 8.
+     *  off the critical dependency chain.  The read offset is clamped to
+     *  limit so that, when consumption overruns the stream (truncated
+     *  codeblocks), reads come from the zero padding -- the bytes there
+     *  are exactly the fill the stream would produce -- instead of from
+     *  uninitialized buffer memory.
      *
      *  @param [in,out]  val is the bit window; its low bits are valid
      *  @param [in,out]  bits is the number of valid bits in val
-     *  @param [in,out]  ptr is the read position in the destuffed buffer
+     *  @param [in,out]  off is the read offset in the destuffed buffer
+     *  @param [in]      dbuf is the destuffed bitstream buffer
+     *  @param [in]      limit is the clamp offset returned by destuff_vlc
      */
     OJPH_FORCE_INLINE
-    void drefill(ui64& val, ui32& bits, const ui8*& ptr)
+    void drefill(ui64& val, ui32& bits, ui32& off,
+                 const ui8* dbuf, ui32 limit)
     {
       ui64 v;
-      memcpy(&v, ptr, 8);
+      ui32 o = off < limit ? off : limit;
+      memcpy(&v, dbuf + o, 8);
       val |= v << bits;
-      ptr += (63 - bits) >> 3;
+      off += (63 - bits) >> 3;
       bits |= 56;
     }
 
@@ -1200,7 +1206,8 @@ namespace ojph {
               __m128i r = _mm_or_si128(t0, t1);
               r = _mm_shuffle_epi8(r, shuffle_mask);
 
-              *(ui32*)dp = (ui32)_mm_extract_epi32(r, 0);
+              ui32 t = (ui32)_mm_extract_epi32(r, 0);
+              memcpy(dp, &t, 4);
             }
             dp[0] = 0; // set an extra entry on the right with 0
           }
@@ -1272,13 +1279,14 @@ namespace ojph {
               // We need data for at least 5 columns out of 8.
               // Therefore loading 32 bits is easier than loading 16 bits
               // twice.
-              ui32 ps = *(ui32*)prev_sig;
-              ui32 ns = *(ui32*)(cur_sig + mstr);
+              ui32 ps, ns, cs;
+              memcpy(&ps, prev_sig, 4);
+              memcpy(&ns, cur_sig + mstr, 4);
               ui32 u = (ps & 0x88888888) >> 3; // the row on top
               if (!stripe_causal)
                 u |= (ns & 0x11111111) << 3;   // the row below
 
-              ui32 cs = *(ui32*)cur_sig;
+              memcpy(&cs, cur_sig, 4);
               // vertical integration
               ui32 mbr =  cs;                // this sig. info.
               mbr |= (cs & 0x77777777) << 1; //above neighbors
@@ -1563,8 +1571,9 @@ namespace ojph {
         // at most 7 + 7 + 30 bits, so 4096 bytes always suffice
         const ui32 vlc_cap = 4096;
         ui8 vlc_buf[vlc_cap + 72];
-        destuff_vlc(coded_data, lcup, scup, vlc_buf, vlc_cap);
-        const ui8* vlc_ptr = vlc_buf;
+        ui32 vlc_limit = destuff_vlc(coded_data, lcup, scup,
+                                     vlc_buf, vlc_cap);
+        ui32 vlc_off = 0;
         ui32 vlc_bits = 0;
 
         int run = mel_get_run(&mel); // decode runs of events from MEL bitstrm
@@ -1581,7 +1590,7 @@ namespace ojph {
           /////////////
 
           // first quad
-          drefill(vlc_val, vlc_bits, vlc_ptr);
+          drefill(vlc_val, vlc_bits, vlc_off, vlc_buf, vlc_limit);
 
           //decode VLC using the context c_q and the head of VLC bitstream
           ui16 t0 = vlc_tbl0[ c_q + (vlc_val & 0x7F) ];
@@ -1699,7 +1708,7 @@ namespace ojph {
             c_q |= ((sp[2 - (si32)sstr] & 0x20U) << 4);
 
             // first quad
-            drefill(vlc_val, vlc_bits, vlc_ptr);
+            drefill(vlc_val, vlc_bits, vlc_off, vlc_buf, vlc_limit);
 
             //decode VLC using the context c_q and the head of VLC bitstream
             ui16 t0 = vlc_tbl1[ c_q + (vlc_val & 0x7F) ];

--- a/src/core/coding/ojph_block_decoder_avx2.cpp
+++ b/src/core/coding/ojph_block_decoder_avx2.cpp
@@ -6,6 +6,7 @@
 // Copyright (c) 2022, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2022, The University of New South Wales, Australia
 // Copyright (c) 2024, Intel Corporation
+// Copyright (c) 2026, Osamu Watanabe
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -727,30 +728,20 @@ namespace ojph {
       assert(num_bits > 0 && num_bits <= msp->bits && num_bits < 128);
       msp->bits -= num_bits;
 
-      __m128i *p = (__m128i*)(msp->tmp + ((num_bits >> 3) & 0x18));
+      __m256i *p = (__m256i*)(msp->tmp + ((num_bits >> 3) & 0x18));
       num_bits &= 63;
 
-      __m128i v0, v1, c0, c1, t;
-      v0 = _mm_loadu_si128(p);
-      v1 = _mm_loadu_si128(p + 1);
+      __m256i v = _mm256_loadu_si256(p);
+      __m256i shifted = _mm256_srlv_epi64(v, _mm256_set1_epi64x(num_bits));
 
-      // shift right by num_bits
-      c0 = _mm_srl_epi64(v0, _mm_set1_epi64x(num_bits));
-      t = _mm_srli_si128(v0, 8);
-      t = _mm_sll_epi64(t, _mm_set1_epi64x(64 - num_bits));
-      c0 = _mm_or_si128(c0, t);
-      t = _mm_slli_si128(v1, 8);
-      t = _mm_sll_epi64(t, _mm_set1_epi64x(64 - num_bits));
-      c0 = _mm_or_si128(c0, t);
+      __m256i carry_src = _mm256_permute4x64_epi64(v, 0x39);
+      carry_src = _mm256_blend_epi32(carry_src,
+                                      _mm256_setzero_si256(), 0xC0);
+      __m256i carry = _mm256_sllv_epi64(carry_src,
+                                         _mm256_set1_epi64x(64 - num_bits));
 
-      _mm_storeu_si128((__m128i*)msp->tmp, c0);
-
-      c1 = _mm_srl_epi64(v1, _mm_set1_epi64x(num_bits));
-      t = _mm_srli_si128(v1, 8);
-      t = _mm_sll_epi64(t, _mm_set1_epi64x(64 - num_bits));
-      c1 = _mm_or_si128(c1, t);
-
-      _mm_storeu_si128((__m128i*)msp->tmp + 1, c1);
+      _mm256_storeu_si256((__m256i*)msp->tmp,
+                          _mm256_or_si256(shifted, carry));
     }
 
     //************************************************************************/
@@ -784,7 +775,8 @@ namespace ojph {
      *  @param vn       used for handling E values (stores v_n values)
      *  @return __m256i decoded two quads
      */
-    static inline __m256i decode_two_quad32_avx2(__m256i inf_u_q, __m256i U_q, frwd_struct_avx2* magsgn, ui32 p, __m128i& vn) {
+    OJPH_FORCE_INLINE
+    __m256i decode_two_quad32_avx2(__m256i inf_u_q, __m256i U_q, frwd_struct_avx2* magsgn, ui32 p, __m128i& vn) {
         __m256i row = _mm256_setzero_si256();
 
         // we keeps e_k, e_1, and rho in w2
@@ -815,13 +807,30 @@ namespace ojph {
 
             __m128i ms_vec0 = _mm_setzero_si128();
             __m128i ms_vec1 = _mm_setzero_si128();
-            if (total_mn1) {
-                ms_vec0 = frwd_fetch<0xFF>(magsgn);
-                frwd_advance(magsgn, (ui32)total_mn1);
+            ui32 total_mn = (ui32)(total_mn1 + total_mn2);
+            if (total_mn1 > 0 && total_mn2 > 0
+                && total_mn1 < 64 && total_mn < 128)
+            {
+                __m128i ms_all = frwd_fetch<0xFF>(magsgn);
+                ms_vec0 = ms_all;
+                __m128i sh = _mm_set1_epi64x(total_mn1);
+                ms_vec1 = _mm_srl_epi64(ms_all, sh);
+                __m128i cross = _mm_srli_si128(ms_all, 8);
+                cross = _mm_sll_epi64(cross,
+                            _mm_set1_epi64x(64 - total_mn1));
+                ms_vec1 = _mm_or_si128(ms_vec1, cross);
+                frwd_advance(magsgn, total_mn);
             }
-            if (total_mn2) {
-                ms_vec1 = frwd_fetch<0xFF>(magsgn);
-                frwd_advance(magsgn, (ui32)total_mn2);
+            else
+            {
+                if (total_mn1) {
+                    ms_vec0 = frwd_fetch<0xFF>(magsgn);
+                    frwd_advance(magsgn, (ui32)total_mn1);
+                }
+                if (total_mn2) {
+                    ms_vec1 = frwd_fetch<0xFF>(magsgn);
+                    frwd_advance(magsgn, (ui32)total_mn2);
+                }
             }
 
             __m256i ms_vec = _mm256_inserti128_si256(_mm256_castsi128_si256(ms_vec0), ms_vec1, 0x1);
@@ -898,7 +907,8 @@ namespace ojph {
      *  @return __m128i decoded quad
      */
 
-    static inline __m256i decode_four_quad16(const __m128i inf_u_q, __m128i U_q, frwd_struct_avx2* magsgn, ui32 p, __m128i& vn) {
+    OJPH_FORCE_INLINE
+    __m256i decode_four_quad16(const __m128i inf_u_q, __m128i U_q, frwd_struct_avx2* magsgn, ui32 p, __m128i& vn) {
 
         __m256i w0;     // workers
         __m256i insig;  // lanes hold FF's if samples are insignificant
@@ -945,13 +955,30 @@ namespace ojph {
 
             __m128i ms_vec0 = _mm_setzero_si128();
             __m128i ms_vec1 = _mm_setzero_si128();
-            if (total_mn1) {
-                ms_vec0 = frwd_fetch<0xFF>(magsgn);
-                frwd_advance(magsgn, (ui32)total_mn1);
+            ui32 total_mn = (ui32)(total_mn1 + total_mn2);
+            if (total_mn1 > 0 && total_mn2 > 0
+                && total_mn1 < 64 && total_mn < 128)
+            {
+                __m128i ms_all = frwd_fetch<0xFF>(magsgn);
+                ms_vec0 = ms_all;
+                __m128i sh = _mm_set1_epi64x(total_mn1);
+                ms_vec1 = _mm_srl_epi64(ms_all, sh);
+                __m128i cross = _mm_srli_si128(ms_all, 8);
+                cross = _mm_sll_epi64(cross,
+                            _mm_set1_epi64x(64 - total_mn1));
+                ms_vec1 = _mm_or_si128(ms_vec1, cross);
+                frwd_advance(magsgn, total_mn);
             }
-            if (total_mn2) {
-                ms_vec1 = frwd_fetch<0xFF>(magsgn);
-                frwd_advance(magsgn, (ui32)total_mn2);
+            else
+            {
+                if (total_mn1) {
+                    ms_vec0 = frwd_fetch<0xFF>(magsgn);
+                    frwd_advance(magsgn, (ui32)total_mn1);
+                }
+                if (total_mn2) {
+                    ms_vec1 = frwd_fetch<0xFF>(magsgn);
+                    frwd_advance(magsgn, (ui32)total_mn2);
+                }
             }
 
             __m256i ms_vec = _mm256_inserti128_si256(_mm256_castsi128_si256(ms_vec0), ms_vec1, 0x1);
@@ -1065,377 +1092,157 @@ namespace ojph {
      *  @param [in]   stride is the decoded codeblock buffer stride
      *  @param [in]   stripe_causal is true for stripe causal mode
      */
-    bool ojph_decode_codeblock_avx2(ui8* coded_data, ui32* decoded_data,
-                                    ui32 missing_msbs, ui32 num_passes,
-                                    ui32 lengths1, ui32 lengths2,
-                                    ui32 width, ui32 height, ui32 stride,
-                                    bool stripe_causal)
+    //************************************************************************/
+    /** @brief Step-2 MagSgn decode for the 16-bit (4-quad) path.
+     *
+     *  Outlined into its own function so that decode_four_quad16 can be
+     *  force-inlined here without inflating register pressure in the
+     *  much larger ojph_decode_codeblock_avx2 (which also hosts the
+     *  mutually-exclusive 32-bit step-2 path). Returns false on a
+     *  precision-overflow error, true otherwise.
+     */
+    OJPH_NO_INLINE
+    bool decode_cb_step2_16bit(ui16* scratch, ui32* decoded_data,
+                               ui8* coded_data, ui32 width, ui32 height,
+                               ui32 stride, ui32 sstr, ui32 p, ui32 mmsbp2,
+                               int lcup, int scup)
     {
-      static bool insufficient_precision = false;
-      static bool modify_code = false;
-      static bool truncate_spp_mrp = false;
+        // reduce bitplane by 16 because we now have 16 bits instead of 32
+        p -= 16;
 
-      if (num_passes > 1 && lengths2 == 0)
-      {
-        OJPH_WARN(0x00010001, "A malformed codeblock that has more than "
-                              "one coding pass, but zero length for "
-                              "2nd and potential 3rd pass.");
-        num_passes = 1;
-      }
-
-      if (num_passes > 3)
-      {
-        OJPH_WARN(0x00010002, "We do not support more than 3 coding passes; "
-                              "This codeblocks has %d passes.",
-                              num_passes);
-        return false;
-      }
-
-      if (missing_msbs > 30) // p < 0
-      {
-        if (insufficient_precision == false)
-        {
-          insufficient_precision = true;
-          OJPH_WARN(0x00010003, "32 bits are not enough to decode this "
-                                "codeblock. This message will not be "
-                                "displayed again.");
-        }
-        return false;
-      }
-      else if (missing_msbs == 30) // p == 0
-      { // not enough precision to decode and set the bin center to 1
-        if (modify_code == false) {
-          modify_code = true;
-          OJPH_WARN(0x00010004, "Not enough precision to decode the cleanup "
-                                "pass. The code can be modified to support "
-                                "this case. This message will not be "
-                                "displayed again.");
-        }
-         return false;         // 32 bits are not enough to decode this
-       }
-      else if (missing_msbs == 29) // if p is 1, then num_passes must be 1
-      {
-        if (num_passes > 1) {
-          num_passes = 1;
-          if (truncate_spp_mrp == false) {
-            truncate_spp_mrp = true;
-            OJPH_WARN(0x00010005, "Not enough precision to decode the SgnProp "
-                                  "nor MagRef passes; both will be skipped. "
-                                  "This message will not be displayed "
-                                  "again.");
-          }
-        }
-      }
-      ui32 p = 30 - missing_msbs; // The least significant bitplane for CUP
-      // There is a way to handle the case of p == 0, but a different path
-      // is required
-
-      if (lengths1 < 2)
-      {
-        OJPH_WARN(0x00010006, "Wrong codeblock length.");
-        return false;
-      }
-
-      // read scup and fix the bytes there
-      int lcup, scup;
-      lcup = (int)lengths1;  // length of CUP
-      //scup is the length of MEL + VLC
-      scup = (((int)coded_data[lcup-1]) << 4) + (coded_data[lcup-2] & 0xF);
-      if (scup < 2 || scup > lcup || scup > 4079) //something is wrong
-        return false;
-
-      // The temporary storage scratch holds two types of data in an
-      // interleaved fashion. The interleaving allows us to use one
-      // memory pointer.
-      // We have one entry for a decoded VLC code, and one entry for UVLC.
-      // Entries are 16 bits each, corresponding to one quad,
-      // but since we want to use XMM registers of the SSE family
-      // of SIMD; we allocated 16 bytes or more per quad row; that is,
-      // the width is no smaller than 16 bytes (or 8 entries), and the
-      // height is 512 quads
-      // Each VLC entry contains, in the following order, starting
-      // from MSB
-      // e_k (4bits), e_1 (4bits), rho (4bits), useless for step 2 (4bits)
-      // Each entry in UVLC contains u_q
-      // One extra row to handle the case of SPP propagating downwards
-      // when codeblock width is 4
-      ui16 scratch[8 * 513] = {0};          // 8+ kB
-
-      // We need an extra two entries (one inf and one u_q) beyond
-      // the last column.
-      // If the block width is 4 (2 quads), then we use sstr of 8
-      // (enough for 4 quads). If width is 8 (4 quads) we use
-      // sstr is 16 (enough for 8 quads). For a width of 16 (8
-      // quads), we use 24 (enough for 12 quads).
-      ui32 sstr = ((width + 2u) + 7u) & ~7u; // multiples of 8
-
-      assert((stride & 0x3) == 0);
-
-      ui32 mmsbp2 = missing_msbs + 2;
-
-      // The cleanup pass is decoded in two steps; in step one,
-      // the VLC and MEL segments are decoded, generating a record that
-      // has 2 bytes per quad. The 2 bytes contain, u, rho, e^1 & e^k.
-      // This information should be sufficient for the next step.
-      // In step 2, we decode the MagSgn segment.
-
-      // step 1 decoding VLC and MEL segments
-      {
-        // init structures
-        dec_mel_st mel;
-        mel_init(&mel, coded_data, lcup, scup);
-        rev_struct vlc;
-        rev_init(&vlc, coded_data, lcup, scup);
-
-        int run = mel_get_run(&mel); // decode runs of events from MEL bitstrm
-                                     // data represented as runs of 0 events
-                                     // See mel_decode description
-
-        ui32 vlc_val;
-        ui32 c_q = 0;
-        ui16 *sp = scratch;
-        //initial quad row
-        for (ui32 x = 0; x < width; sp += 4)
-        {
-          // decode VLC
-          /////////////
-
-          // first quad
-          vlc_val = rev_fetch(&vlc);
-
-          //decode VLC using the context c_q and the head of VLC bitstream
-          ui16 t0 = vlc_tbl0[ c_q + (vlc_val & 0x7F) ];
-
-          // if context is zero, use one MEL event
-          if (c_q == 0) //zero context
-          {
-            run -= 2; //subtract 2, since events number if multiplied by 2
-
-            // Is the run terminated in 1? if so, use decoded VLC code,
-            // otherwise, discard decoded data, since we will decoded again
-            // using a different context
-            t0 = (run == -1) ? t0 : 0;
-
-            // is run -1 or -2? this means a run has been consumed
-            if (run < 0)
-              run = mel_get_run(&mel);  // get another run
-          }
-          //run -= (c_q == 0) ? 2 : 0;
-          //t0 = (c_q != 0 || run == -1) ? t0 : 0;
-          //if (run < 0)
-          //  run = mel_get_run(&mel);  // get another run
-          sp[0] = t0;
-          x += 2;
-
-          // prepare context for the next quad; eqn. 1 in ITU T.814
-          c_q = ((t0 & 0x10U) << 3) | ((t0 & 0xE0U) << 2);
-
-          //remove data from vlc stream (0 bits are removed if vlc is not used)
-          vlc_val = rev_advance(&vlc, t0 & 0x7);
-
-          //second quad
-          ui16 t1 = 0;
-
-          //decode VLC using the context c_q and the head of VLC bitstream
-          t1 = vlc_tbl0[c_q + (vlc_val & 0x7F)];
-
-          // if context is zero, use one MEL event
-          if (c_q == 0 && x < width) //zero context
-          {
-            run -= 2; //subtract 2, since events number if multiplied by 2
-
-            // if event is 0, discard decoded t1
-            t1 = (run == -1) ? t1 : 0;
-
-            if (run < 0) // have we consumed all events in a run
-              run = mel_get_run(&mel); // if yes, then get another run
-          }
-          t1 = x < width ? t1 : 0;
-          //run -= (c_q == 0 && x < width) ? 2 : 0;
-          //t1 = (c_q != 0 || run == -1) ? t1 : 0;
-          //if (run < 0)
-          //  run = mel_get_run(&mel);  // get another run
-          sp[2] = t1;
-          x += 2;
-
-          //prepare context for the next quad, eqn. 1 in ITU T.814
-          c_q = ((t1 & 0x10U) << 3) | ((t1 & 0xE0U) << 2);
-
-          //remove data from vlc stream, if qinf is not used, cwdlen is 0
-          vlc_val = rev_advance(&vlc, t1 & 0x7);
-
-          // decode u
-          /////////////
-          // uvlc_mode is made up of u_offset bits from the quad pair
-          ui32 uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
-          if (uvlc_mode == 0xc0)// if both u_offset are set, get an event from
-          {                     // the MEL run of events
-            run -= 2; //subtract 2, since events number if multiplied by 2
-
-            uvlc_mode += (run == -1) ? 0x40 : 0; // increment uvlc_mode by
-                                                 // is 0x40
-
-            if (run < 0)//if run is consumed (run is -1 or -2), get another run
-              run = mel_get_run(&mel);
-          }
-          //run -= (uvlc_mode == 0xc0) ? 2 : 0;
-          //uvlc_mode += (uvlc_mode == 0xc0 && run == -1) ? 0x40 : 0;
-          //if (run < 0)
-          //  run = mel_get_run(&mel);  // get another run
-
-          //decode uvlc_mode to get u for both quads
-          ui32 uvlc_entry = uvlc_tbl0[uvlc_mode + (vlc_val & 0x3F)];
-          //remove total prefix length
-          vlc_val = rev_advance(&vlc, uvlc_entry & 0x7);
-          uvlc_entry >>= 3;
-          //extract suffixes for quad 0 and 1
-          ui32 len = uvlc_entry & 0xF;           //suffix length for 2 quads
-          ui32 tmp = vlc_val & ((1 << len) - 1); //suffix value for 2 quads
-          vlc_val = rev_advance(&vlc, len);
-          ojph_unused(vlc_val); //static code analysis: unused value
-          uvlc_entry >>= 4;
-          // quad 0 length
-          len = uvlc_entry & 0x7; // quad 0 suffix length
-          uvlc_entry >>= 3;
-          ui16 u_q = (ui16)(1 + (uvlc_entry&7) + (tmp&~(0xFFU<<len))); //kap. 1
-          sp[1] = u_q;
-          u_q = (ui16)(1 + (uvlc_entry >> 3) + (tmp >> len));  //kappa == 1
-          sp[3] = u_q;
-        }
-        sp[0] = sp[1] = 0;
-
-        //non initial quad rows
-        for (ui32 y = 2; y < height; y += 2)
-        {
-          c_q = 0;                                // context
-          ui16 *sp = scratch + (y >> 1) * sstr;   // this row of quads
-
-          for (ui32 x = 0; x < width; sp += 4)
-          {
-            // decode VLC
-            /////////////
-
-            // sigma_q (n, ne, nf)
-            c_q |= ((sp[0 - (si32)sstr] & 0xA0U) << 2);
-            c_q |= ((sp[2 - (si32)sstr] & 0x20U) << 4);
-
-            // first quad
-            vlc_val = rev_fetch(&vlc);
-
-            //decode VLC using the context c_q and the head of VLC bitstream
-            ui16 t0 = vlc_tbl1[ c_q + (vlc_val & 0x7F) ];
-
-            // if context is zero, use one MEL event
-            if (c_q == 0) //zero context
-            {
-              run -= 2; //subtract 2, since events number is multiplied by 2
-
-              // Is the run terminated in 1? if so, use decoded VLC code,
-              // otherwise, discard decoded data, since we will decoded again
-              // using a different context
-              t0 = (run == -1) ? t0 : 0;
-
-              // is run -1 or -2? this means a run has been consumed
-              if (run < 0)
-                run = mel_get_run(&mel);  // get another run
-            }
-            //run -= (c_q == 0) ? 2 : 0;
-            //t0 = (c_q != 0 || run == -1) ? t0 : 0;
-            //if (run < 0)
-            //  run = mel_get_run(&mel);  // get another run
-            sp[0] = t0;
-            x += 2;
-
-            // prepare context for the next quad; eqn. 2 in ITU T.814
-            // sigma_q (w, sw)
-            c_q = ((t0 & 0x40U) << 2) | ((t0 & 0x80U) << 1);
-            // sigma_q (nw)
-            c_q |= sp[0 - (si32)sstr] & 0x80;
-            // sigma_q (n, ne, nf)
-            c_q |= ((sp[2 - (si32)sstr] & 0xA0U) << 2);
-            c_q |= ((sp[4 - (si32)sstr] & 0x20U) << 4);
-
-            //remove data from vlc stream (0 bits are removed if vlc is unused)
-            vlc_val = rev_advance(&vlc, t0 & 0x7);
-
-            //second quad
-            ui16 t1 = 0;
-
-            //decode VLC using the context c_q and the head of VLC bitstream
-            t1 = vlc_tbl1[ c_q + (vlc_val & 0x7F)];
-
-            // if context is zero, use one MEL event
-            if (c_q == 0 && x < width) //zero context
-            {
-              run -= 2; //subtract 2, since events number if multiplied by 2
-
-              // if event is 0, discard decoded t1
-              t1 = (run == -1) ? t1 : 0;
-
-              if (run < 0) // have we consumed all events in a run
-                run = mel_get_run(&mel); // if yes, then get another run
-            }
-            t1 = x < width ? t1 : 0;
-            //run -= (c_q == 0 && x < width) ? 2 : 0;
-            //t1 = (c_q != 0 || run == -1) ? t1 : 0;
-            //if (run < 0)
-            //  run = mel_get_run(&mel);  // get another run
-            sp[2] = t1;
-            x += 2;
-
-            // partial c_q, will be completed when we process the next quad
-            // sigma_q (w, sw)
-            c_q = ((t1 & 0x40U) << 2) | ((t1 & 0x80U) << 1);
-            // sigma_q (nw)
-            c_q |= sp[2 - (si32)sstr] & 0x80;
-
-            //remove data from vlc stream, if qinf is not used, cwdlen is 0
-            vlc_val = rev_advance(&vlc, t1 & 0x7);
-
-            // decode u
-            /////////////
-            // uvlc_mode is made up of u_offset bits from the quad pair
-            ui32 uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
-            ui32 uvlc_entry = uvlc_tbl1[uvlc_mode + (vlc_val & 0x3F)];
-            //remove total prefix length
-            vlc_val = rev_advance(&vlc, uvlc_entry & 0x7);
-            uvlc_entry >>= 3;
-            //extract suffixes for quad 0 and 1
-            ui32 len = uvlc_entry & 0xF;           //suffix length for 2 quads
-            ui32 tmp = vlc_val & ((1 << len) - 1); //suffix value for 2 quads
-            vlc_val = rev_advance(&vlc, len);
-            ojph_unused(vlc_val); //static code analysis: unused value
-            uvlc_entry >>= 4;
-            // quad 0 length
-            len = uvlc_entry & 0x7; // quad 0 suffix length
-            uvlc_entry >>= 3;
-            ui16 u_q = (ui16)((uvlc_entry & 7) + (tmp & ~(0xFFU << len)));
-            sp[1] = u_q;
-            u_q = (ui16)((uvlc_entry >> 3) + (tmp >> len)); // u_q
-            sp[3] = u_q;
-          }
-          sp[0] = sp[1] = 0;
-        }
-      }
-
-      // step2 we decode magsgn
-      // mmsbp2 equals K_max + 1 (we decode up to K_max bits + 1 sign bit)
-      // The 32 bit path decode 16 bits data, for which one would think
-      // 16 bits are enough, because we want to put in the center of the
-      // bin.
-      // If you have mmsbp2 equals 16 bit, and reversible coding, and
-      // no bitplanes are missing, then we can decoding using the 16 bit
-      // path, but we are not doing this here.
-      if (mmsbp2 >= 16)
-      {
-        // We allocate a scratch row for storing v_n values.
-        // We have 512 quads horizontally.
-        // We may go beyond the last entry by up to 4 entries.
-        // Here we allocate additional 8 entries.
-        // There are two rows in this structure, the bottom
-        // row is used to store processed entries.
         const int v_n_size = 512 + 16;
-        ui32 v_n_scratch[2 * v_n_size] = {0}; // 4+ kB
+#ifdef __MINGW64__
+        ui16 v_n_scratch[v_n_size] = {0};
+        ui32 v_n_scratch_32[v_n_size] = {0};
+#else
+        ui16 v_n_scratch[v_n_size];
+        memset(v_n_scratch + (width >> 1) + 4, 0, 8 * sizeof(ui16));
+        ui32 v_n_scratch_32[v_n_size];
+#endif
+
+        frwd_struct_avx2 magsgn;
+        frwd_init<0xFF>(&magsgn, coded_data, lcup - scup);
+
+        {
+          ui16 *sp = scratch;
+          ui16 *vp = v_n_scratch;
+          ui32 *dp = decoded_data;
+          vp[0] = 2; // for easy calculation of emax
+
+          for (ui32 x = 0; x < width; x += 8, sp += 8, vp += 4, dp += 8) {
+              ////process four quads
+              __m128i inf_u_q = _mm_loadu_si128((__m128i*)sp);
+              __m128i U_q = _mm_srli_epi32(inf_u_q, 16);
+              __m128i w = _mm_cmpgt_epi32(U_q, _mm_set1_epi32((int)mmsbp2));
+              if (!_mm_testz_si128(w, w)) {
+                  return false;
+              }
+
+              __m128i vn = _mm_set1_epi16(2);
+              __m256i row = decode_four_quad16(inf_u_q, U_q, &magsgn, p, vn);
+
+              w = _mm_cvtsi32_si128(*(unsigned short const*)(vp));
+              _mm_storeu_si128((__m128i*)vp, _mm_or_si128(w, vn));
+
+              __m256i  w0 = _mm256_shuffle_epi8(row, _mm256_set_epi16(0x0D0C, -1, 0x0908, -1, 0x0504, -1, 0x0100, -1, 0x0D0C, -1, 0x0908, -1, 0x0504, -1, 0x0100, -1));
+              __m256i  w1 = _mm256_shuffle_epi8(row, _mm256_set_epi16(0x0F0E, -1, 0x0B0A, -1, 0x0706, -1, 0x0302, -1, 0x0F0E, -1, 0x0B0A, -1, 0x0706, -1, 0x0302, -1));
+
+              _mm256_storeu_si256((__m256i*)dp, w0);
+              _mm256_storeu_si256((__m256i*)(dp + stride), w1);
+          }
+        }
+
+        for (ui32 y = 2; y < height; y += 2) {
+          {
+            // perform 15 - count_leading_zeros(*vp) here
+            ui16 *vp = v_n_scratch;
+            ui32 *vp_32 = v_n_scratch_32;
+
+            ui16* sp = scratch + (y >> 1) * sstr;
+            const __m256i avx_mmsbp2 = _mm256_set1_epi32((int)mmsbp2);
+            const __m256i avx_31 = _mm256_set1_epi32(31);
+            const __m256i avx_f0 = _mm256_set1_epi32(0xF0);
+            const __m256i avx_1 = _mm256_set1_epi32(1);
+            const __m256i avx_0 = _mm256_setzero_si256();
+
+            for (ui32 x = 0; x <= width; x += 16, vp += 8, sp += 16, vp_32 += 8) {
+              __m128i v = _mm_loadu_si128((__m128i*)vp);
+              __m128i v_p1 = _mm_loadu_si128((__m128i*)(vp + 1));
+              v = _mm_or_si128(v, v_p1);
+
+              __m256i v_avx = _mm256_cvtepu16_epi32(v);
+              v_avx = avx2_lzcnt_epi32(v_avx);
+              v_avx = _mm256_sub_epi32(avx_31, v_avx);
+
+              __m256i inf_u_q = _mm256_loadu_si256((__m256i*)sp);
+              __m256i gamma = _mm256_and_si256(inf_u_q, avx_f0);
+              __m256i w0 = _mm256_sub_epi32(gamma, avx_1);
+              gamma = _mm256_and_si256(gamma, w0);
+              gamma = _mm256_cmpeq_epi32(gamma, avx_0);
+
+              v_avx = _mm256_andnot_si256(gamma, v_avx);
+              v_avx = _mm256_max_epi32(v_avx, avx_1);
+
+              inf_u_q = _mm256_srli_epi32(inf_u_q, 16);
+              v_avx = _mm256_add_epi32(inf_u_q, v_avx);
+
+              w0 = _mm256_cmpgt_epi32(v_avx, avx_mmsbp2);
+              if (!_mm256_testz_si256(w0, w0)) {
+                  return false;
+              }
+
+              _mm256_storeu_si256((__m256i*)vp_32, v_avx);
+            }
+          }
+
+          ui16 *vp = v_n_scratch;
+          ui32* vp_32 = v_n_scratch_32;
+          ui16 *sp = scratch + (y >> 1) * sstr;
+          ui32 *dp = decoded_data + y * stride;
+          vp[0] = 2; // for easy calculation of emax
+
+          for (ui32 x = 0; x < width; x += 8, sp += 8, vp += 4, dp += 8, vp_32 += 4) {
+            ////process four quads
+              __m128i inf_u_q = _mm_loadu_si128((__m128i*)sp);
+              __m128i U_q = _mm_loadu_si128((__m128i*)vp_32);
+
+            __m128i vn = _mm_set1_epi16(2);
+            __m256i row = decode_four_quad16(inf_u_q, U_q, &magsgn, p, vn);
+
+            __m128i w = _mm_cvtsi32_si128(*(unsigned short const*)(vp));
+            _mm_storeu_si128((__m128i*)vp, _mm_or_si128(w, vn));
+
+            __m256i  w0 = _mm256_shuffle_epi8(row, _mm256_set_epi16(0x0D0C, -1, 0x0908, -1, 0x0504, -1, 0x0100, -1, 0x0D0C, -1, 0x0908, -1, 0x0504, -1, 0x0100, -1));
+            __m256i  w1 = _mm256_shuffle_epi8(row, _mm256_set_epi16(0x0F0E, -1, 0x0B0A, -1, 0x0706, -1, 0x0302, -1, 0x0F0E, -1, 0x0B0A, -1, 0x0706, -1, 0x0302, -1));
+
+            _mm256_storeu_si256((__m256i*)dp, w0);
+            _mm256_storeu_si256((__m256i*)(dp + stride), w1);
+          }
+        }
+        return true;
+    }
+
+    //************************************************************************/
+    /** @brief Step-2 MagSgn decode for the 32-bit (2-quad) path.
+     *
+     *  Outlined for the same reason as decode_cb_step2_16bit: it keeps the
+     *  always-inlined decode_two_quad32_avx2 kernel in its own register
+     *  allocation scope, isolated from step-1 and from the 16-bit path.
+     *  Returns false on a precision-overflow error, true otherwise.
+     */
+    OJPH_NO_INLINE
+    bool decode_cb_step2_32bit(ui16* scratch, ui32* decoded_data,
+                               ui8* coded_data, ui32 width, ui32 height,
+                               ui32 stride, ui32 sstr, ui32 p, ui32 mmsbp2,
+                               int lcup, int scup)
+    {
+        const int v_n_size = 512 + 16;
+#ifdef __MINGW64__
+        ui32 v_n_scratch[2 * v_n_size] = {0};
+#else
+        ui32 v_n_scratch[2 * v_n_size];
+        memset(v_n_scratch + (width >> 1) + 2, 0, 14 * sizeof(ui32));
+#endif
 
         frwd_struct_avx2 magsgn;
         frwd_init<0xFF>(&magsgn, coded_data, lcup - scup);
@@ -1537,128 +1344,22 @@ namespace ojph {
             _mm_storeu_si128((__m128i*)vp, w0);
           }
         }
-      }
-      else {
+        return true;
+    }
 
-        // reduce bitplane by 16 because we now have 16 bits instead of 32
-        p -= 16;
-
-        // We allocate a scratch row for storing v_n values.
-        // We have 512 quads horizontally.
-        // We may go beyond the last entry by up to 8 entries.
-        // Therefore we allocate additional 8 entries.
-        // There are two rows in this structure, the bottom
-        // row is used to store processed entries.
-        const int v_n_size = 512 + 16;
-        ui16 v_n_scratch[v_n_size] = {0}; // 1+ kB
-        ui32 v_n_scratch_32[v_n_size] = {0}; // 2+ kB
-
-        frwd_struct_avx2 magsgn;
-        frwd_init<0xFF>(&magsgn, coded_data, lcup - scup);
-
-        {
-          ui16 *sp = scratch;
-          ui16 *vp = v_n_scratch;
-          ui32 *dp = decoded_data;
-          vp[0] = 2; // for easy calculation of emax
-
-          for (ui32 x = 0; x < width; x += 8, sp += 8, vp += 4, dp += 8) {
-              ////process four quads
-              __m128i inf_u_q = _mm_loadu_si128((__m128i*)sp);
-              __m128i U_q = _mm_srli_epi32(inf_u_q, 16);
-              __m128i w = _mm_cmpgt_epi32(U_q, _mm_set1_epi32((int)mmsbp2));
-              if (!_mm_testz_si128(w, w)) {
-                  return false;
-              }
-
-              __m128i vn = _mm_set1_epi16(2);
-              __m256i row = decode_four_quad16(inf_u_q, U_q, &magsgn, p, vn);
-
-              w = _mm_cvtsi32_si128(*(unsigned short const*)(vp));
-              _mm_storeu_si128((__m128i*)vp, _mm_or_si128(w, vn));
-
-              __m256i  w0 = _mm256_shuffle_epi8(row, _mm256_set_epi16(0x0D0C, -1, 0x0908, -1, 0x0504, -1, 0x0100, -1, 0x0D0C, -1, 0x0908, -1, 0x0504, -1, 0x0100, -1));
-              __m256i  w1 = _mm256_shuffle_epi8(row, _mm256_set_epi16(0x0F0E, -1, 0x0B0A, -1, 0x0706, -1, 0x0302, -1, 0x0F0E, -1, 0x0B0A, -1, 0x0706, -1, 0x0302, -1));
-
-              _mm256_storeu_si256((__m256i*)dp, w0);
-              _mm256_storeu_si256((__m256i*)(dp + stride), w1);
-          }
-        }
-
-        for (ui32 y = 2; y < height; y += 2) {
-          {
-            // perform 15 - count_leading_zeros(*vp) here
-            ui16 *vp = v_n_scratch;
-            ui32 *vp_32 = v_n_scratch_32;
-
-            ui16* sp = scratch + (y >> 1) * sstr;
-            const __m256i avx_mmsbp2 = _mm256_set1_epi32((int)mmsbp2);
-            const __m256i avx_31 = _mm256_set1_epi32(31);
-            const __m256i avx_f0 = _mm256_set1_epi32(0xF0);
-            const __m256i avx_1 = _mm256_set1_epi32(1);
-            const __m256i avx_0 = _mm256_setzero_si256();
-
-            for (ui32 x = 0; x <= width; x += 16, vp += 8, sp += 16, vp_32 += 8) {
-              __m128i v = _mm_loadu_si128((__m128i*)vp);
-              __m128i v_p1 = _mm_loadu_si128((__m128i*)(vp + 1));
-              v = _mm_or_si128(v, v_p1);
-
-              __m256i v_avx = _mm256_cvtepu16_epi32(v);
-              v_avx = avx2_lzcnt_epi32(v_avx);
-              v_avx = _mm256_sub_epi32(avx_31, v_avx);
-
-              __m256i inf_u_q = _mm256_loadu_si256((__m256i*)sp);
-              __m256i gamma = _mm256_and_si256(inf_u_q, avx_f0);
-              __m256i w0 = _mm256_sub_epi32(gamma, avx_1);
-              gamma = _mm256_and_si256(gamma, w0);
-              gamma = _mm256_cmpeq_epi32(gamma, avx_0);
-
-              v_avx = _mm256_andnot_si256(gamma, v_avx);
-              v_avx = _mm256_max_epi32(v_avx, avx_1);
-
-              inf_u_q = _mm256_srli_epi32(inf_u_q, 16);
-              v_avx = _mm256_add_epi32(inf_u_q, v_avx);
-
-              w0 = _mm256_cmpgt_epi32(v_avx, avx_mmsbp2);
-              if (!_mm256_testz_si256(w0, w0)) {
-                  return false;
-              }
-
-              _mm256_storeu_si256((__m256i*)vp_32, v_avx);
-            }
-          }
-
-          ui16 *vp = v_n_scratch;
-          ui32* vp_32 = v_n_scratch_32;
-          ui16 *sp = scratch + (y >> 1) * sstr;
-          ui32 *dp = decoded_data + y * stride;
-          vp[0] = 2; // for easy calculation of emax
-
-          for (ui32 x = 0; x < width; x += 8, sp += 8, vp += 4, dp += 8, vp_32 += 4) {
-            ////process four quads
-              __m128i inf_u_q = _mm_loadu_si128((__m128i*)sp);
-              __m128i U_q = _mm_loadu_si128((__m128i*)vp_32);
-
-            __m128i vn = _mm_set1_epi16(2);
-            __m256i row = decode_four_quad16(inf_u_q, U_q, &magsgn, p, vn);
-
-            __m128i w = _mm_cvtsi32_si128(*(unsigned short const*)(vp));
-            _mm_storeu_si128((__m128i*)vp, _mm_or_si128(w, vn));
-
-            __m256i  w0 = _mm256_shuffle_epi8(row, _mm256_set_epi16(0x0D0C, -1, 0x0908, -1, 0x0504, -1, 0x0100, -1, 0x0D0C, -1, 0x0908, -1, 0x0504, -1, 0x0100, -1));
-            __m256i  w1 = _mm256_shuffle_epi8(row, _mm256_set_epi16(0x0F0E, -1, 0x0B0A, -1, 0x0706, -1, 0x0302, -1, 0x0F0E, -1, 0x0B0A, -1, 0x0706, -1, 0x0302, -1));
-
-            _mm256_storeu_si256((__m256i*)dp, w0);
-            _mm256_storeu_si256((__m256i*)(dp + stride), w1);
-          }
-        }
-
-        // increase bitplane back by 16 because we need to process 32 bits
-        p += 16;
-      }
-
-      if (num_passes > 1)
-      {
+    //************************************************************************/
+    /** @brief Significance-Propagation and Magnitude-Refinement passes.
+     *
+     *  Outlined from ojph_decode_codeblock_avx2 so the (lossless cleanup-only)
+     *  common path does not pay the register-allocation cost of this ~375-line
+     *  block. Only runs when num_passes > 1.
+     */
+    OJPH_NO_INLINE
+    void decode_cb_spp_mrp(ui16* scratch, ui32* decoded_data, ui8* coded_data,
+                           ui32 width, ui32 height, ui32 stride, ui32 sstr,
+                           ui32 p, ui32 num_passes, ui32 lengths1,
+                           ui32 lengths2, bool stripe_causal)
+    {
         // We use scratch again, we can divide it into multiple regions
         // sigma holds all the significant samples, and it cannot
         // be modified after it is set.  it will be used during the
@@ -2034,7 +1735,411 @@ namespace ojph {
             }
           }
         }
+    }
+
+    //************************************************************************/
+    /** @brief Step-1: decode the VLC and MEL segments into the scratch buffer.
+     *
+     *  Outlined so the serial scalar VLC/MEL chain gets its own register
+     *  allocation, isolated from the step-2 / SPP-MRP code paths.
+     */
+    OJPH_NO_INLINE
+    void decode_cb_step1_vlc(ui16* scratch, ui8* coded_data, int lcup,
+                             int scup, ui32 width, ui32 height, ui32 sstr)
+    {
+        // init structures
+        dec_mel_st mel;
+        mel_init(&mel, coded_data, lcup, scup);
+        rev_struct vlc;
+        rev_init(&vlc, coded_data, lcup, scup);
+
+        int run = mel_get_run(&mel); // decode runs of events from MEL bitstrm
+                                     // data represented as runs of 0 events
+                                     // See mel_decode description
+
+        ui32 vlc_val;
+        ui32 c_q = 0;
+        ui16 *sp = scratch;
+        //initial quad row
+        for (ui32 x = 0; x < width; sp += 4)
+        {
+          // decode VLC
+          /////////////
+
+          // first quad
+          vlc_val = rev_fetch(&vlc);
+
+          //decode VLC using the context c_q and the head of VLC bitstream
+          ui16 t0 = vlc_tbl0[ c_q + (vlc_val & 0x7F) ];
+
+          // if context is zero, use one MEL event
+          if (c_q == 0) //zero context
+          {
+            run -= 2; //subtract 2, since events number if multiplied by 2
+
+            // Is the run terminated in 1? if so, use decoded VLC code,
+            // otherwise, discard decoded data, since we will decoded again
+            // using a different context
+            t0 = (run == -1) ? t0 : 0;
+
+            // is run -1 or -2? this means a run has been consumed
+            if (run < 0)
+              run = mel_get_run(&mel);  // get another run
+          }
+          //run -= (c_q == 0) ? 2 : 0;
+          //t0 = (c_q != 0 || run == -1) ? t0 : 0;
+          //if (run < 0)
+          //  run = mel_get_run(&mel);  // get another run
+          sp[0] = t0;
+          x += 2;
+
+          // prepare context for the next quad; eqn. 1 in ITU T.814
+          c_q = ((t0 & 0x10U) << 3) | ((t0 & 0xE0U) << 2);
+
+          //remove data from vlc stream (0 bits are removed if vlc is not used)
+          vlc_val = rev_advance(&vlc, t0 & 0x7);
+
+          //second quad
+          ui16 t1 = 0;
+
+          //decode VLC using the context c_q and the head of VLC bitstream
+          t1 = vlc_tbl0[c_q + (vlc_val & 0x7F)];
+
+          // if context is zero, use one MEL event
+          if (c_q == 0 && x < width) //zero context
+          {
+            run -= 2; //subtract 2, since events number if multiplied by 2
+
+            // if event is 0, discard decoded t1
+            t1 = (run == -1) ? t1 : 0;
+
+            if (run < 0) // have we consumed all events in a run
+              run = mel_get_run(&mel); // if yes, then get another run
+          }
+          t1 = x < width ? t1 : 0;
+          //run -= (c_q == 0 && x < width) ? 2 : 0;
+          //t1 = (c_q != 0 || run == -1) ? t1 : 0;
+          //if (run < 0)
+          //  run = mel_get_run(&mel);  // get another run
+          sp[2] = t1;
+          x += 2;
+
+          //prepare context for the next quad, eqn. 1 in ITU T.814
+          c_q = ((t1 & 0x10U) << 3) | ((t1 & 0xE0U) << 2);
+
+          //remove data from vlc stream, if qinf is not used, cwdlen is 0
+          vlc_val = rev_advance(&vlc, t1 & 0x7);
+
+          // decode u
+          /////////////
+          // uvlc_mode is made up of u_offset bits from the quad pair
+          ui32 uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
+          if (uvlc_mode == 0xc0)// if both u_offset are set, get an event from
+          {                     // the MEL run of events
+            run -= 2; //subtract 2, since events number if multiplied by 2
+
+            uvlc_mode += (run == -1) ? 0x40 : 0; // increment uvlc_mode by
+                                                 // is 0x40
+
+            if (run < 0)//if run is consumed (run is -1 or -2), get another run
+              run = mel_get_run(&mel);
+          }
+          //run -= (uvlc_mode == 0xc0) ? 2 : 0;
+          //uvlc_mode += (uvlc_mode == 0xc0 && run == -1) ? 0x40 : 0;
+          //if (run < 0)
+          //  run = mel_get_run(&mel);  // get another run
+
+          //decode uvlc_mode to get u for both quads
+          ui32 uvlc_entry = uvlc_tbl0[uvlc_mode + (vlc_val & 0x3F)];
+          //remove total prefix length
+          vlc_val = rev_advance(&vlc, uvlc_entry & 0x7);
+          uvlc_entry >>= 3;
+          //extract suffixes for quad 0 and 1
+          ui32 len = uvlc_entry & 0xF;           //suffix length for 2 quads
+          ui32 tmp = vlc_val & ((1 << len) - 1); //suffix value for 2 quads
+          vlc_val = rev_advance(&vlc, len);
+          ojph_unused(vlc_val); //static code analysis: unused value
+          uvlc_entry >>= 4;
+          // quad 0 length
+          len = uvlc_entry & 0x7; // quad 0 suffix length
+          uvlc_entry >>= 3;
+          ui16 u_q = (ui16)(1 + (uvlc_entry&7) + (tmp&~(0xFFU<<len))); //kap. 1
+          sp[1] = u_q;
+          u_q = (ui16)(1 + (uvlc_entry >> 3) + (tmp >> len));  //kappa == 1
+          sp[3] = u_q;
+        }
+        sp[0] = sp[1] = 0;
+
+        //non initial quad rows
+        for (ui32 y = 2; y < height; y += 2)
+        {
+          c_q = 0;                                // context
+          ui16 *sp = scratch + (y >> 1) * sstr;   // this row of quads
+
+          for (ui32 x = 0; x < width; sp += 4)
+          {
+            // decode VLC
+            /////////////
+
+            // sigma_q (n, ne, nf)
+            c_q |= ((sp[0 - (si32)sstr] & 0xA0U) << 2);
+            c_q |= ((sp[2 - (si32)sstr] & 0x20U) << 4);
+
+            // first quad
+            vlc_val = rev_fetch(&vlc);
+
+            //decode VLC using the context c_q and the head of VLC bitstream
+            ui16 t0 = vlc_tbl1[ c_q + (vlc_val & 0x7F) ];
+
+            // if context is zero, use one MEL event
+            if (c_q == 0) //zero context
+            {
+              run -= 2; //subtract 2, since events number is multiplied by 2
+
+              // Is the run terminated in 1? if so, use decoded VLC code,
+              // otherwise, discard decoded data, since we will decoded again
+              // using a different context
+              t0 = (run == -1) ? t0 : 0;
+
+              // is run -1 or -2? this means a run has been consumed
+              if (run < 0)
+                run = mel_get_run(&mel);  // get another run
+            }
+            //run -= (c_q == 0) ? 2 : 0;
+            //t0 = (c_q != 0 || run == -1) ? t0 : 0;
+            //if (run < 0)
+            //  run = mel_get_run(&mel);  // get another run
+            sp[0] = t0;
+            x += 2;
+
+            // prepare context for the next quad; eqn. 2 in ITU T.814
+            // sigma_q (w, sw)
+            c_q = ((t0 & 0x40U) << 2) | ((t0 & 0x80U) << 1);
+            // sigma_q (nw)
+            c_q |= sp[0 - (si32)sstr] & 0x80;
+            // sigma_q (n, ne, nf)
+            c_q |= ((sp[2 - (si32)sstr] & 0xA0U) << 2);
+            c_q |= ((sp[4 - (si32)sstr] & 0x20U) << 4);
+
+            //remove data from vlc stream (0 bits are removed if vlc is unused)
+            vlc_val = rev_advance(&vlc, t0 & 0x7);
+
+            //second quad
+            ui16 t1 = 0;
+
+            //decode VLC using the context c_q and the head of VLC bitstream
+            t1 = vlc_tbl1[ c_q + (vlc_val & 0x7F)];
+
+            // if context is zero, use one MEL event
+            if (c_q == 0 && x < width) //zero context
+            {
+              run -= 2; //subtract 2, since events number if multiplied by 2
+
+              // if event is 0, discard decoded t1
+              t1 = (run == -1) ? t1 : 0;
+
+              if (run < 0) // have we consumed all events in a run
+                run = mel_get_run(&mel); // if yes, then get another run
+            }
+            t1 = x < width ? t1 : 0;
+            //run -= (c_q == 0 && x < width) ? 2 : 0;
+            //t1 = (c_q != 0 || run == -1) ? t1 : 0;
+            //if (run < 0)
+            //  run = mel_get_run(&mel);  // get another run
+            sp[2] = t1;
+            x += 2;
+
+            // partial c_q, will be completed when we process the next quad
+            // sigma_q (w, sw)
+            c_q = ((t1 & 0x40U) << 2) | ((t1 & 0x80U) << 1);
+            // sigma_q (nw)
+            c_q |= sp[2 - (si32)sstr] & 0x80;
+
+            //remove data from vlc stream, if qinf is not used, cwdlen is 0
+            vlc_val = rev_advance(&vlc, t1 & 0x7);
+
+            // decode u using wide UVLC table
+            /////////////
+            ui32 uvlc_mode = (((t0 >> 3) & 1) | (((t1 >> 3) & 1) << 1));
+            ui32 uvlc_entry =
+              uvlc_tbl1_wide[(uvlc_mode << 10) | (vlc_val & 0x3FF)];
+            ui32 total_bits = uvlc_entry & 0x1F;
+            if (total_bits < 0x1F) {
+              sp[1] = (ui16)((uvlc_entry >> 5) & 0xFF);
+              sp[3] = (ui16)((uvlc_entry >> 13) & 0xFF);
+              vlc_val = rev_advance(&vlc, total_bits);
+              ojph_unused(vlc_val);
+            } else {
+              uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
+              uvlc_entry = uvlc_tbl1[uvlc_mode + (vlc_val & 0x3F)];
+              vlc_val = rev_advance(&vlc, uvlc_entry & 0x7);
+              uvlc_entry >>= 3;
+              ui32 len = uvlc_entry & 0xF;
+              ui32 tmp = vlc_val & ((1 << len) - 1);
+              vlc_val = rev_advance(&vlc, len);
+              ojph_unused(vlc_val);
+              uvlc_entry >>= 4;
+              len = uvlc_entry & 0x7;
+              uvlc_entry >>= 3;
+              sp[1] = (ui16)((uvlc_entry & 7) + (tmp & ~(0xFFU << len)));
+              sp[3] = (ui16)((uvlc_entry >> 3) + (tmp >> len));
+            }
+          }
+          sp[0] = sp[1] = 0;
+        }
+    }
+
+    bool ojph_decode_codeblock_avx2(ui8* coded_data, ui32* decoded_data,
+                                    ui32 missing_msbs, ui32 num_passes,
+                                    ui32 lengths1, ui32 lengths2,
+                                    ui32 width, ui32 height, ui32 stride,
+                                    bool stripe_causal)
+    {
+      static bool insufficient_precision = false;
+      static bool modify_code = false;
+      static bool truncate_spp_mrp = false;
+
+      if (num_passes > 1 && lengths2 == 0)
+      {
+        OJPH_WARN(0x00010001, "A malformed codeblock that has more than "
+                              "one coding pass, but zero length for "
+                              "2nd and potential 3rd pass.");
+        num_passes = 1;
       }
+
+      if (num_passes > 3)
+      {
+        OJPH_WARN(0x00010002, "We do not support more than 3 coding passes; "
+                              "This codeblocks has %d passes.",
+                              num_passes);
+        return false;
+      }
+
+      if (missing_msbs > 30) // p < 0
+      {
+        if (insufficient_precision == false)
+        {
+          insufficient_precision = true;
+          OJPH_WARN(0x00010003, "32 bits are not enough to decode this "
+                                "codeblock. This message will not be "
+                                "displayed again.");
+        }
+        return false;
+      }
+      else if (missing_msbs == 30) // p == 0
+      { // not enough precision to decode and set the bin center to 1
+        if (modify_code == false) {
+          modify_code = true;
+          OJPH_WARN(0x00010004, "Not enough precision to decode the cleanup "
+                                "pass. The code can be modified to support "
+                                "this case. This message will not be "
+                                "displayed again.");
+        }
+         return false;         // 32 bits are not enough to decode this
+       }
+      else if (missing_msbs == 29) // if p is 1, then num_passes must be 1
+      {
+        if (num_passes > 1) {
+          num_passes = 1;
+          if (truncate_spp_mrp == false) {
+            truncate_spp_mrp = true;
+            OJPH_WARN(0x00010005, "Not enough precision to decode the SgnProp "
+                                  "nor MagRef passes; both will be skipped. "
+                                  "This message will not be displayed "
+                                  "again.");
+          }
+        }
+      }
+      ui32 p = 30 - missing_msbs; // The least significant bitplane for CUP
+      // There is a way to handle the case of p == 0, but a different path
+      // is required
+
+      if (lengths1 < 2)
+      {
+        OJPH_WARN(0x00010006, "Wrong codeblock length.");
+        return false;
+      }
+
+      // read scup and fix the bytes there
+      int lcup, scup;
+      lcup = (int)lengths1;  // length of CUP
+      //scup is the length of MEL + VLC
+      scup = (((int)coded_data[lcup-1]) << 4) + (coded_data[lcup-2] & 0xF);
+      if (scup < 2 || scup > lcup || scup > 4079) //something is wrong
+        return false;
+
+      // The temporary storage scratch holds two types of data in an
+      // interleaved fashion. The interleaving allows us to use one
+      // memory pointer.
+      // We have one entry for a decoded VLC code, and one entry for UVLC.
+      // Entries are 16 bits each, corresponding to one quad,
+      // but since we want to use XMM registers of the SSE family
+      // of SIMD; we allocated 16 bytes or more per quad row; that is,
+      // the width is no smaller than 16 bytes (or 8 entries), and the
+      // height is 512 quads
+      // Each VLC entry contains, in the following order, starting
+      // from MSB
+      // e_k (4bits), e_1 (4bits), rho (4bits), useless for step 2 (4bits)
+      // Each entry in UVLC contains u_q
+      // One extra row to handle the case of SPP propagating downwards
+      // when codeblock width is 4
+      // We need an extra two entries (one inf and one u_q) beyond
+      // the last column.
+      // If the block width is 4 (2 quads), then we use sstr of 8
+      // (enough for 4 quads). If width is 8 (4 quads) we use
+      // sstr is 16 (enough for 8 quads). For a width of 16 (8
+      // quads), we use 24 (enough for 12 quads).
+      ui32 sstr = ((width + 2u) + 7u) & ~7u; // multiples of 8
+
+#ifdef __MINGW64__
+      ui16 scratch[8 * 513] = {0};
+#else
+      ui16 scratch[8 * 513];
+      ui32 quad_rows = (height + 1u) >> 1;
+      size_t scratch_zero = (size_t)(quad_rows + 1) * sstr;
+      if (scratch_zero > 8 * 513) scratch_zero = 8 * 513;
+      memset(scratch, 0, scratch_zero * sizeof(ui16));
+#endif
+
+      assert((stride & 0x3) == 0);
+
+      ui32 mmsbp2 = missing_msbs + 2;
+
+      // The cleanup pass is decoded in two steps; in step one,
+      // the VLC and MEL segments are decoded, generating a record that
+      // has 2 bytes per quad. The 2 bytes contain, u, rho, e^1 & e^k.
+      // This information should be sufficient for the next step.
+      // In step 2, we decode the MagSgn segment.
+
+      // step 1: decode VLC and MEL segments into scratch
+      decode_cb_step1_vlc(scratch, coded_data, lcup, scup, width, height, sstr);
+
+      // step2 we decode magsgn
+      // mmsbp2 equals K_max + 1 (we decode up to K_max bits + 1 sign bit)
+      // The 32 bit path decode 16 bits data, for which one would think
+      // 16 bits are enough, because we want to put in the center of the
+      // bin.
+      // If you have mmsbp2 equals 16 bit, and reversible coding, and
+      // no bitplanes are missing, then we can decoding using the 16 bit
+      // path, but we are not doing this here.
+      if (mmsbp2 >= 16)
+      {
+        if (!decode_cb_step2_32bit(scratch, decoded_data, coded_data,
+                                   width, height, stride, sstr, p, mmsbp2,
+                                   lcup, scup))
+          return false;
+      }
+      else {
+        if (!decode_cb_step2_16bit(scratch, decoded_data, coded_data,
+                                   width, height, stride, sstr, p, mmsbp2,
+                                   lcup, scup))
+          return false;
+      }
+
+      if (num_passes > 1)
+        decode_cb_spp_mrp(scratch, decoded_data, coded_data, width, height,
+                          stride, sstr, p, num_passes, lengths1, lengths2,
+                          stripe_causal);
 
       return true;
     }

--- a/src/core/coding/ojph_block_decoder_avx2.cpp
+++ b/src/core/coding/ojph_block_decoder_avx2.cpp
@@ -272,314 +272,6 @@ namespace ojph {
       return t; // return run
     }
 
-    //************************************************************************/
-    /** @brief A structure for reading and unstuffing a segment that grows
-     *         backward, such as VLC and MRP
-     */
-    struct rev_struct {
-      rev_struct() : data(NULL), tmp(0), bits(0), size(0), unstuff(false)
-      {}
-      //storage
-      ui8* data;     //!<pointer to where to read data
-      ui64 tmp;	     //!<temporary buffer of read data
-      ui32 bits;     //!<number of bits stored in tmp
-      int size;      //!<number of bytes left
-      bool unstuff;  //!<true if the last byte is more than 0x8F
-                     //!<then the current byte is unstuffed if it is 0x7F
-    };
-
-    //************************************************************************/
-    /** @brief Read and unstuff data from a backwardly-growing segment
-     *
-     *  This reader can read up to 8 bytes from before the VLC segment.
-     *  Care must be taken not read from unreadable memory, causing a
-     *  segmentation fault.
-     *
-     *  Note that there is another subroutine rev_read_mrp that is slightly
-     *  different.  The other one fills zeros when the buffer is exhausted.
-     *  This one basically does not care if the bytes are consumed, because
-     *  any extra data should not be used in the actual decoding.
-     *
-     *  Unstuffing is needed to prevent sequences more than 0xFF8F from
-     *  appearing in the bits stream; since we are reading backward, we keep
-     *  watch when a value larger than 0x8F appears in the bitstream.
-     *  If the byte following this is 0x7F, we unstuff this byte (ignore the
-     *  MSB of that byte, which should be 0).
-     *
-     *  @param [in]  vlcp is a pointer to rev_struct structure
-     */
-    static inline
-    void rev_read(rev_struct *vlcp)
-    {
-      //process 4 bytes at a time
-      if (vlcp->bits > 32)  // if there are more than 32 bits in tmp, then
-        return;             // reading 32 bits can overflow vlcp->tmp
-      ui32 val = 0;
-      //the next line (the if statement) needs to be tested first
-      if (vlcp->size > 3)  // if there are more than 3 bytes left in VLC
-      {
-        // (vlcp->data - 3) move pointer back to read 32 bits at once
-        val = *(ui32*)(vlcp->data - 3); // then read 32 bits
-        vlcp->data -= 4;          // move data pointer back by 4
-        vlcp->size -= 4;          // reduce available byte by 4
-      }
-      else if (vlcp->size > 0)
-      { // 4 or less
-        int i = 24;
-        while (vlcp->size > 0) {
-          ui32 v = *vlcp->data--; // read one byte at a time
-          val |= (v << i);        // put byte in its correct location
-          --vlcp->size;
-          i -= 8;
-        }
-      }
-
-      __m128i tmp_vec = _mm_set1_epi32((int32_t)val);
-      tmp_vec = _mm_srlv_epi32(tmp_vec, _mm_setr_epi32(24, 16, 8, 0));
-      tmp_vec = _mm_and_si128(tmp_vec, _mm_set1_epi32(0xff));
-
-      __m128i unstuff_vec = _mm_cmpgt_epi32(tmp_vec, _mm_set1_epi32(0x8F));
-      bool unstuff_next = _mm_extract_epi32(unstuff_vec, 3);
-      unstuff_vec = _mm_slli_si128(unstuff_vec, 4);
-      unstuff_vec = _mm_insert_epi32(unstuff_vec, vlcp->unstuff * 0xffffffff, 0);
-
-      __m128i val_7f = _mm_set1_epi32(0x7F);
-      __m128i this_byte_7f = _mm_cmpeq_epi32(_mm_and_si128(tmp_vec, val_7f), val_7f);
-      unstuff_vec = _mm_and_si128(unstuff_vec, this_byte_7f);
-      unstuff_vec = _mm_srli_epi32(unstuff_vec, 31);
-
-      __m128i inc_sum = _mm_sub_epi32(_mm_set1_epi32(8), unstuff_vec);
-      inc_sum = _mm_add_epi32(inc_sum, _mm_bslli_si128(inc_sum, 4));
-      inc_sum = _mm_add_epi32(inc_sum, _mm_bslli_si128(inc_sum, 8));
-      ui32 total_bits = (ui32)_mm_extract_epi32(inc_sum, 3);
-
-      __m128i final_shift = _mm_slli_si128(inc_sum, 4);
-      tmp_vec = _mm_sllv_epi32(tmp_vec, final_shift);
-      tmp_vec = _mm_or_si128(tmp_vec, _mm_bsrli_si128(tmp_vec, 8));
-
-      ui64 tmp = (ui32)_mm_cvtsi128_si32(tmp_vec) | (ui32)_mm_extract_epi32(tmp_vec, 1);
-
-      vlcp->unstuff = unstuff_next;
-      vlcp->tmp |= tmp << vlcp->bits;
-      vlcp->bits += total_bits;
-    }
-
-    //************************************************************************/
-    /** @brief Initiates the rev_struct structure and reads a few bytes to
-     *         move the read address to multiple of 4
-     *
-     *  There is another similar rev_init_mrp subroutine.  The difference is
-     *  that this one, rev_init, discards the first 12 bits (they have the
-     *  sum of the lengths of VLC and MEL segments), and first unstuff depends
-     *  on first 4 bits.
-     *
-     *  @param [in]  vlcp is a pointer to rev_struct structure
-     *  @param [in]  data is a pointer to byte at the start of the cleanup pass
-     *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
-     *  @param [in]  scup is the length of MEL+VLC segments
-     */
-    static inline
-    void rev_init(rev_struct *vlcp, ui8* data, int lcup, int scup)
-    {
-      //first byte has only the upper 4 bits
-      vlcp->data = data + lcup - 2;
-
-      //size can not be larger than this, in fact it should be smaller
-      vlcp->size = scup - 2;
-
-      ui32 d = *vlcp->data--; // read one byte (this is a half byte)
-      vlcp->tmp = d >> 4;    // both initialize and set
-      vlcp->bits = 4 - ((vlcp->tmp & 7) == 7); //check standard
-      vlcp->unstuff = (d | 0xF) > 0x8F; //this is useful for the next byte
-
-      //This code is designed for an architecture that read address should
-      // align to the read size (address multiple of 4 if read size is 4)
-      //These few lines take care of the case where data is not at a multiple
-      // of 4 boundary. It reads 1,2,3 up to 4 bytes from the VLC bitstream.
-      // To read 32 bits, read from (vlcp->data - 3)
-      int num = 1 + (int)(intptr_t(vlcp->data) & 0x3);
-      int tnum = num < vlcp->size ? num : vlcp->size;
-      for (int i = 0; i < tnum; ++i) {
-        ui64 d;
-        d = *vlcp->data--;  // read one byte and move read pointer
-        //check if the last byte was >0x8F (unstuff == true) and this is 0x7F
-        ui32 d_bits = 8 - ((vlcp->unstuff && ((d & 0x7F) == 0x7F)) ? 1 : 0);
-        vlcp->tmp |= d << vlcp->bits; // move data to vlcp->tmp
-        vlcp->bits += d_bits;
-        vlcp->unstuff = d > 0x8F; // for next byte
-      }
-      vlcp->size -= tnum;
-      rev_read(vlcp);  // read another 32 buts
-    }
-
-    //************************************************************************/
-    /** @brief Retrieves 32 bits from the head of a rev_struct structure
-     *
-     *  By the end of this call, vlcp->tmp must have no less than 33 bits
-     *
-     *  @param [in]  vlcp is a pointer to rev_struct structure
-     */
-    static inline
-    ui32 rev_fetch(rev_struct *vlcp)
-    {
-      if (vlcp->bits < 32)  // if there are less then 32 bits, read more
-      {
-        rev_read(vlcp);     // read 32 bits, but unstuffing might reduce this
-        if (vlcp->bits < 32)// if there is still space in vlcp->tmp for 32 bits
-          rev_read(vlcp);   // read another 32
-      }
-      return (ui32)vlcp->tmp; // return the head (bottom-most) of vlcp->tmp
-    }
-
-    //************************************************************************/
-    /** @brief Consumes num_bits from a rev_struct structure
-     *
-     *  @param [in]  vlcp is a pointer to rev_struct structure
-     *  @param [in]  num_bits is the number of bits to be removed
-     */
-    static inline
-    ui32 rev_advance(rev_struct *vlcp, ui32 num_bits)
-    {
-      assert(num_bits <= vlcp->bits); // vlcp->tmp must have more than num_bits
-      vlcp->tmp >>= num_bits;         // remove bits
-      vlcp->bits -= num_bits;         // decrement the number of bits
-      return (ui32)vlcp->tmp;
-    }
-
-    //************************************************************************/
-    /** @brief Reads and unstuffs from rev_struct
-     *
-     *  This is different than rev_read in that this fills in zeros when the
-     *  the available data is consumed.  The other does not care about the
-     *  values when all data is consumed.
-     *
-     *  See rev_read for more information about unstuffing
-     *
-     *  @param [in]  mrp is a pointer to rev_struct structure
-     */
-    static inline
-    void rev_read_mrp(rev_struct *mrp)
-    {
-      //process 4 bytes at a time
-      if (mrp->bits > 32)
-        return;
-      ui32 val = 0;
-      if (mrp->size > 3) // If there are 3 byte or more
-      { // (mrp->data - 3) move pointer back to read 32 bits at once
-        val = *(ui32*)(mrp->data - 3); // read 32 bits
-        mrp->data -= 4;                // move back pointer
-        mrp->size -= 4;                // reduce count
-      }
-      else if (mrp->size > 0)
-      {
-        int i = 24;
-        while (mrp->size > 0) {
-          ui32 v = *mrp->data--; // read one byte at a time
-          val |= (v << i);       // put byte in its correct location
-          --mrp->size;
-          i -= 8;
-        }
-      }
-
-      //accumulate in tmp, and keep count in bits
-      ui32 bits, tmp = val >> 24;
-
-      //test if the last byte > 0x8F (unstuff must be true) and this is 0x7F
-      bits = 8 - ((mrp->unstuff && (((val >> 24) & 0x7F) == 0x7F)) ? 1 : 0);
-      bool unstuff = (val >> 24) > 0x8F;
-
-      //process the next byte
-      tmp |= ((val >> 16) & 0xFF) << bits;
-      bits += 8 - ((unstuff && (((val >> 16) & 0x7F) == 0x7F)) ? 1 : 0);
-      unstuff = ((val >> 16) & 0xFF) > 0x8F;
-
-      tmp |= ((val >> 8) & 0xFF) << bits;
-      bits += 8 - ((unstuff && (((val >> 8) & 0x7F) == 0x7F)) ? 1 : 0);
-      unstuff = ((val >> 8) & 0xFF) > 0x8F;
-
-      tmp |= (val & 0xFF) << bits;
-      bits += 8 - ((unstuff && ((val & 0x7F) == 0x7F)) ? 1 : 0);
-      unstuff = (val & 0xFF) > 0x8F;
-
-      mrp->tmp |= (ui64)tmp << mrp->bits; // move data to mrp pointer
-      mrp->bits += bits;
-      mrp->unstuff = unstuff;             // next byte
-    }
-
-    //************************************************************************/
-    /** @brief Initialized rev_struct structure for MRP segment, and reads
-     *         a number of bytes such that the next 32 bits read are from
-     *         an address that is a multiple of 4. Note this is designed for
-     *         an architecture that read size must be compatible with the
-     *         alignment of the read address
-     *
-     *  There is another similar subroutine rev_init.  This subroutine does
-     *  NOT skip the first 12 bits, and starts with unstuff set to true.
-     *
-     *  @param [in]  mrp is a pointer to rev_struct structure
-     *  @param [in]  data is a pointer to byte at the start of the cleanup pass
-     *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
-     *  @param [in]  len2 is the length of SPP+MRP segments
-     */
-    static inline
-    void rev_init_mrp(rev_struct *mrp, ui8* data, int lcup, int len2)
-    {
-      mrp->data = data + lcup + len2 - 1;
-      mrp->size = len2;
-      mrp->unstuff = true;
-      mrp->bits = 0;
-      mrp->tmp = 0;
-
-      //This code is designed for an architecture that read address should
-      // align to the read size (address multiple of 4 if read size is 4)
-      //These few lines take care of the case where data is not at a multiple
-      // of 4 boundary.  It reads 1,2,3 up to 4 bytes from the MRP stream
-      int num = 1 + (int)(intptr_t(mrp->data) & 0x3);
-      for (int i = 0; i < num; ++i) {
-        ui64 d;
-        //read a byte, 0 if no more data
-        d = (mrp->size-- > 0) ? *mrp->data-- : 0;
-        //check if unstuffing is needed
-        ui32 d_bits = 8 - ((mrp->unstuff && ((d & 0x7F) == 0x7F)) ? 1 : 0);
-        mrp->tmp |= d << mrp->bits; // move data to vlcp->tmp
-        mrp->bits += d_bits;
-        mrp->unstuff = d > 0x8F; // for next byte
-      }
-      rev_read_mrp(mrp);
-    }
-
-    //************************************************************************/
-    /** @brief Retrieves 32 bits from the head of a rev_struct structure
-     *
-     *  By the end of this call, mrp->tmp must have no less than 33 bits
-     *
-     *  @param [in]  mrp is a pointer to rev_struct structure
-     */
-    static inline
-    ui32 rev_fetch_mrp(rev_struct *mrp)
-    {
-      if (mrp->bits < 32) // if there are less than 32 bits in mrp->tmp
-      {
-        rev_read_mrp(mrp);    // read 30-32 bits from mrp
-        if (mrp->bits < 32)   // if there is a space of 32 bits
-          rev_read_mrp(mrp);  // read more
-      }
-      return (ui32)mrp->tmp;  // return the head of mrp->tmp
-    }
-
-    //************************************************************************/
-    /** @brief Consumes num_bits from a rev_struct structure
-     *
-     *  @param [in]  mrp is a pointer to rev_struct structure
-     *  @param [in]  num_bits is the number of bits to be removed
-     */
-    inline ui32 rev_advance_mrp(rev_struct *mrp, ui32 num_bits)
-    {
-      assert(num_bits <= mrp->bits); // we must not consume more than mrp->bits
-      mrp->tmp >>= num_bits;  // discard the lowest num_bits bits
-      mrp->bits -= num_bits;
-      return (ui32)mrp->tmp;  // return data after consumption
-    }
 
     //************************************************************************/
     /** @brief De-stuffs a forward-growing bitstream into a flat buffer
@@ -713,6 +405,203 @@ namespace ojph {
       ui64 v;
       memcpy(&v, dbuf + off, 8);
       return v >> (pos & 7);
+    }
+
+    //************************************************************************/
+    /** @brief Branchless refill of a register-resident bit window
+     *
+     *  Loads 8 bytes from a destuffed buffer and inserts whole bytes
+     *  above the bits remaining in the window, leaving 56 to 63 valid
+     *  bits.  Because the inserted bits land above the remaining ones,
+     *  consumers of the low bits need not wait for the load, keeping it
+     *  off the critical dependency chain.  The pointer advances by at
+     *  most 8 bytes per call, and in total by no more than the consumed
+     *  bit count divided by 8, plus 8.
+     *
+     *  @param [in,out]  val is the bit window; its low bits are valid
+     *  @param [in,out]  bits is the number of valid bits in val
+     *  @param [in,out]  ptr is the read position in the destuffed buffer
+     */
+    OJPH_FORCE_INLINE
+    void drefill(ui64& val, ui32& bits, const ui8*& ptr)
+    {
+      ui64 v;
+      memcpy(&v, ptr, 8);
+      val |= v << bits;
+      ptr += (63 - bits) >> 3;
+      bits |= 56;
+    }
+
+    //************************************************************************/
+    /** @brief Consumes bits from a window refilled by drefill
+     *
+     *  @param [in,out]  val is the bit window
+     *  @param [in,out]  bits is the number of valid bits in val
+     *  @param [in]      num_bits is the number of bits to consume
+     */
+    OJPH_FORCE_INLINE
+    void dconsume(ui64& val, ui32& bits, ui32 num_bits)
+    {
+      val >>= num_bits;
+      bits -= num_bits;
+    }
+
+    //************************************************************************/
+    /** @brief De-stuffs a backward-growing bitstream into a flat buffer
+     *
+     *  This replicates the bit production of the rev_struct bitstream
+     *  reader used by the other block decoders, for both its VLC and MRP
+     *  variants: reading backward from p, a byte contributes only 7 bits
+     *  (its MSB -- guaranteed 0 by the encoder -- is OR'ed with the
+     *  following bit) when the byte after it in memory is greater than
+     *  0x8F and its own low 7 bits are all 1s.  Bits beyond the end of
+     *  the data read as 0s, matching both readers.  The first byte is
+     *  processed with the caller-provided unstuff state; after that the
+     *  state always equals (p[1] > 0x8F), so the fast path can detect
+     *  stuffing with a pairwise byte comparison within the segment.
+     *
+     *  Writes at most cap + 1 destuffed bytes followed by 64 bytes of
+     *  zero padding; dst must have room for cap + 65 bytes.  cap must be
+     *  no smaller than the maximum number of bits the decoder can consume
+     *  divided by 8, so clipping the data at cap loses no decodable bits.
+     *
+     *  @param [in]  p is a pointer to the last byte of the segment, where
+     *               backward reading starts
+     *  @param [in]  size is the number of bytes in the segment
+     *  @param [in]  unstuff is the initial unstuffing state
+     *  @param [in]  acc holds bits produced by initialization, low nb bits
+     *  @param [in]  nb is the number of valid bits in acc; less than 8
+     *  @param [in]  dst is the output buffer, of at least cap + 65 bytes
+     *  @param [in]  cap is the maximum number of destuffed bytes to write
+     *  @return ui32 clamp offset for dfetch/dfetch64; bytes at or beyond
+     *               this offset hold no stream bits (they read as 0s)
+     */
+    static inline
+    ui32 destuff_rev(const ui8* p, int size, bool unstuff,
+                     ui64 acc, ui32 nb, ui8* dst, ui32 cap)
+    {
+      ui8* o = dst;
+      ui8* o_end = dst + cap;
+
+      // process the first byte with the caller-provided unstuff state;
+      // afterwards the state is implied by the byte at p[1], which the
+      // fast path checks vectorially (and which stays inside the segment)
+      if (size > 0 && o < o_end)
+      {
+        ui32 d = *p--;
+        --size;
+        acc |= (ui64)d << nb;
+        nb += 8 - ((unstuff && ((d & 0x7F) == 0x7F)) ? 1u : 0u);
+        unstuff = d > 0x8F;
+        if (nb >= 8) { *o++ = (ui8)acc; acc >>= 8; nb -= 8; }
+      }
+
+      // fast path; 16 source bytes at a time when none needs unstuffing
+      while (size >= 16 && o + 24 <= o_end)
+      {
+        __m128i v = _mm_loadu_si128((const __m128i*)(p - 15));
+        __m128i nx = _mm_loadu_si128((const __m128i*)(p - 14));
+        __m128i is7f = _mm_cmpeq_epi8(
+            _mm_and_si128(v, _mm_set1_epi8(0x7F)), _mm_set1_epi8(0x7F));
+        // le8f is 0xFF where the byte after (in memory) is <= 0x8F
+        __m128i le8f = _mm_cmpeq_epi8(
+            _mm_subs_epu8(nx, _mm_set1_epi8((char)0x8F)),
+            _mm_setzero_si128());
+        __m128i stuff = _mm_andnot_si128(le8f, is7f);
+        if (!_mm_testz_si128(stuff, stuff))
+        { // process these 16 bytes one at a time
+          for (int i = 0; i < 16; ++i) {
+            ui32 d = *p--;
+            acc |= (ui64)d << nb;
+            nb += 8 - ((unstuff && ((d & 0x7F) == 0x7F)) ? 1u : 0u);
+            unstuff = d > 0x8F;
+            if (nb >= 8) { *o++ = (ui8)acc; acc >>= 8; nb -= 8; }
+          }
+          size -= 16;
+          continue;
+        }
+        __m128i r = _mm_shuffle_epi8(v,
+            _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7,
+                         8, 9, 10, 11, 12, 13, 14, 15)); // reverse bytes
+        ui64 v0 = (ui64)_mm_cvtsi128_si64(r);
+        ui64 v1 = (ui64)_mm_extract_epi64(r, 1);
+        ui64 w0 = acc | (v0 << nb);
+        ui64 w1 = (v1 << nb) | (nb ? (v0 >> (64 - nb)) : 0);
+        memcpy(o, &w0, 8);
+        memcpy(o + 8, &w1, 8);
+        acc = nb ? (v1 >> (64 - nb)) : 0;
+        o += 16;
+        p -= 16;
+        size -= 16;
+        unstuff = p[1] > 0x8F;
+      }
+      // tail; one byte at a time
+      while (size > 0 && o < o_end)
+      {
+        ui32 d = *p--;
+        --size;
+        acc |= (ui64)d << nb;
+        nb += 8 - ((unstuff && ((d & 0x7F) == 0x7F)) ? 1u : 0u);
+        unstuff = d > 0x8F;
+        if (nb >= 8) { *o++ = (ui8)acc; acc >>= 8; nb -= 8; }
+      }
+      // the bits above nb are already 0 = fill; pad with zero bytes
+      *o = (ui8)acc;
+      __m256i z = _mm256_setzero_si256();
+      _mm256_storeu_si256((__m256i*)(o + 1), z);
+      _mm256_storeu_si256((__m256i*)(o + 33), z);
+      return (ui32)(o - dst) + 1;
+    }
+
+    //************************************************************************/
+    /** @brief De-stuffs the VLC segment into a flat buffer
+     *
+     *  Performs the same initialization rev_init does -- the first byte
+     *  contributes only its upper 4 bits (3 bits if its lower 3 bits are
+     *  all 1s) -- then de-stuffs the remaining scup - 2 bytes backward;
+     *  see destuff_rev.
+     *
+     *  @param [in]  data is a pointer to byte at the start of the cleanup
+     *               pass
+     *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
+     *  @param [in]  scup is the length of MEL+VLC segments
+     *  @param [in]  dst is the output buffer, of at least cap + 65 bytes
+     *  @param [in]  cap is the maximum number of destuffed bytes to write
+     *  @return ui32 clamp offset for dfetch64
+     */
+    static inline
+    ui32 destuff_vlc(const ui8* data, int lcup, int scup,
+                     ui8* dst, ui32 cap)
+    {
+      const ui8* p = data + lcup - 2;
+      ui32 d = *p; // first byte, only the upper 4 bits are used
+      ui64 acc = d >> 4;
+      ui32 nb = 4 - ((acc & 7) == 7); // check standard
+      bool unstuff = (d | 0xF) > 0x8F;
+      return destuff_rev(p - 1, scup - 2, unstuff, acc, nb, dst, cap);
+    }
+
+    //************************************************************************/
+    /** @brief De-stuffs the MRP segment into a flat buffer
+     *
+     *  Performs the same initialization rev_init_mrp does -- reading
+     *  starts at the last byte of the SPP+MRP segments with the unstuff
+     *  state set -- then de-stuffs backward; see destuff_rev.
+     *
+     *  @param [in]  data is a pointer to byte at the start of the cleanup
+     *               pass
+     *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
+     *  @param [in]  len2 is the length of SPP+MRP segments
+     *  @param [in]  dst is the output buffer, of at least cap + 65 bytes
+     *  @param [in]  cap is the maximum number of destuffed bytes to write
+     *  @return ui32 clamp offset for dfetch64
+     */
+    static inline
+    ui32 destuff_mrp(const ui8* data, int lcup, int len2,
+                     ui8* dst, ui32 cap)
+    {
+      return destuff_rev(data + lcup + len2 - 1, len2, true, 0, 0,
+                         dst, cap);
     }
 
     //************************************************************************/
@@ -1562,8 +1451,13 @@ namespace ojph {
         // We perform Magnitude Refinement Pass here
         if (num_passes > 2)
         {
-          rev_struct magref;
-          rev_init_mrp(&magref, coded_data, (int)lengths1, (int)lengths2);
+          // de-stuff the MRP segment; consumption is at most 1 bit per
+          // sample = 512 bytes, so 1024 bytes always suffice
+          const ui32 mrp_cap = 1024;
+          ui8 mrp_buf[mrp_cap + 72];
+          ui32 mrp_limit = destuff_mrp(coded_data, (int)lengths1,
+                                       (int)lengths2, mrp_buf, mrp_cap);
+          ui32 mrp_pos = 0;
 
           for (ui32 y = 0; y < height; y += 4)
           {
@@ -1573,7 +1467,7 @@ namespace ojph {
             {
               //Process one entry from sigma array at a time
               // Each nibble (4 bits) in the sigma array represents 4 rows,
-              ui32 cwd = rev_fetch_mrp(&magref); // get 32 bit data
+              ui64 cwd = dfetch64(mrp_buf, mrp_limit, mrp_pos);
               ui16 sig = *cur_sig++; // 16 bit that will be processed now
               int total_bits = 0;
               if (sig) // if any of the 32 bits are set
@@ -1644,7 +1538,7 @@ namespace ojph {
                 }
               }
               // consume data according to the number of bits set
-              rev_advance_mrp(&magref, (ui32)total_bits);
+              mrp_pos += (ui32)total_bits;
             }
           }
         }
@@ -1663,14 +1557,21 @@ namespace ojph {
         // init structures
         dec_mel_st mel;
         mel_init(&mel, coded_data, lcup, scup);
-        rev_struct vlc;
-        rev_init(&vlc, coded_data, lcup, scup);
+
+        // de-stuff the VLC segment; its size is at most scup - 1 < 4095
+        // bytes (scup is a 12-bit value), and consumption per quad pair is
+        // at most 7 + 7 + 30 bits, so 4096 bytes always suffice
+        const ui32 vlc_cap = 4096;
+        ui8 vlc_buf[vlc_cap + 72];
+        destuff_vlc(coded_data, lcup, scup, vlc_buf, vlc_cap);
+        const ui8* vlc_ptr = vlc_buf;
+        ui32 vlc_bits = 0;
 
         int run = mel_get_run(&mel); // decode runs of events from MEL bitstrm
                                      // data represented as runs of 0 events
                                      // See mel_decode description
 
-        ui32 vlc_val;
+        ui64 vlc_val = 0;
         ui32 c_q = 0;
         ui16 *sp = scratch;
         //initial quad row
@@ -1680,7 +1581,7 @@ namespace ojph {
           /////////////
 
           // first quad
-          vlc_val = rev_fetch(&vlc);
+          drefill(vlc_val, vlc_bits, vlc_ptr);
 
           //decode VLC using the context c_q and the head of VLC bitstream
           ui16 t0 = vlc_tbl0[ c_q + (vlc_val & 0x7F) ];
@@ -1710,7 +1611,7 @@ namespace ojph {
           c_q = ((t0 & 0x10U) << 3) | ((t0 & 0xE0U) << 2);
 
           //remove data from vlc stream (0 bits are removed if vlc is not used)
-          vlc_val = rev_advance(&vlc, t0 & 0x7);
+          dconsume(vlc_val, vlc_bits, t0 & 0x7u);
 
           //second quad
           ui16 t1 = 0;
@@ -1741,7 +1642,7 @@ namespace ojph {
           c_q = ((t1 & 0x10U) << 3) | ((t1 & 0xE0U) << 2);
 
           //remove data from vlc stream, if qinf is not used, cwdlen is 0
-          vlc_val = rev_advance(&vlc, t1 & 0x7);
+          dconsume(vlc_val, vlc_bits, t1 & 0x7u);
 
           // decode u
           /////////////
@@ -1765,13 +1666,12 @@ namespace ojph {
           //decode uvlc_mode to get u for both quads
           ui32 uvlc_entry = uvlc_tbl0[uvlc_mode + (vlc_val & 0x3F)];
           //remove total prefix length
-          vlc_val = rev_advance(&vlc, uvlc_entry & 0x7);
+          dconsume(vlc_val, vlc_bits, uvlc_entry & 0x7u);
           uvlc_entry >>= 3;
           //extract suffixes for quad 0 and 1
           ui32 len = uvlc_entry & 0xF;           //suffix length for 2 quads
-          ui32 tmp = vlc_val & ((1 << len) - 1); //suffix value for 2 quads
-          vlc_val = rev_advance(&vlc, len);
-          ojph_unused(vlc_val); //static code analysis: unused value
+          ui32 tmp = (ui32)vlc_val & ((1u << len) - 1); //suffix value, 2 quads
+          dconsume(vlc_val, vlc_bits, len);
           uvlc_entry >>= 4;
           // quad 0 length
           len = uvlc_entry & 0x7; // quad 0 suffix length
@@ -1799,7 +1699,7 @@ namespace ojph {
             c_q |= ((sp[2 - (si32)sstr] & 0x20U) << 4);
 
             // first quad
-            vlc_val = rev_fetch(&vlc);
+            drefill(vlc_val, vlc_bits, vlc_ptr);
 
             //decode VLC using the context c_q and the head of VLC bitstream
             ui16 t0 = vlc_tbl1[ c_q + (vlc_val & 0x7F) ];
@@ -1835,7 +1735,7 @@ namespace ojph {
             c_q |= ((sp[4 - (si32)sstr] & 0x20U) << 4);
 
             //remove data from vlc stream (0 bits are removed if vlc is unused)
-            vlc_val = rev_advance(&vlc, t0 & 0x7);
+            dconsume(vlc_val, vlc_bits, t0 & 0x7u);
 
             //second quad
             ui16 t1 = 0;
@@ -1869,7 +1769,7 @@ namespace ojph {
             c_q |= sp[2 - (si32)sstr] & 0x80;
 
             //remove data from vlc stream, if qinf is not used, cwdlen is 0
-            vlc_val = rev_advance(&vlc, t1 & 0x7);
+            dconsume(vlc_val, vlc_bits, t1 & 0x7u);
 
             // decode u using wide UVLC table
             /////////////
@@ -1880,17 +1780,15 @@ namespace ojph {
             if (total_bits < 0x1F) {
               sp[1] = (ui16)((uvlc_entry >> 5) & 0xFF);
               sp[3] = (ui16)((uvlc_entry >> 13) & 0xFF);
-              vlc_val = rev_advance(&vlc, total_bits);
-              ojph_unused(vlc_val);
+              dconsume(vlc_val, vlc_bits, total_bits);
             } else {
               uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
               uvlc_entry = uvlc_tbl1[uvlc_mode + (vlc_val & 0x3F)];
-              vlc_val = rev_advance(&vlc, uvlc_entry & 0x7);
+              dconsume(vlc_val, vlc_bits, uvlc_entry & 0x7u);
               uvlc_entry >>= 3;
               ui32 len = uvlc_entry & 0xF;
-              ui32 tmp = vlc_val & ((1 << len) - 1);
-              vlc_val = rev_advance(&vlc, len);
-              ojph_unused(vlc_val);
+              ui32 tmp = (ui32)vlc_val & ((1u << len) - 1);
+              dconsume(vlc_val, vlc_bits, len);
               uvlc_entry >>= 4;
               len = uvlc_entry & 0x7;
               uvlc_entry >>= 3;

--- a/src/core/coding/ojph_block_encoder_avx2_apple.h
+++ b/src/core/coding/ojph_block_encoder_avx2_apple.h
@@ -35,14 +35,6 @@
 // File: ojph_block_encoder_avx2.cpp
 //***************************************************************************/
 
-// Apple Clang on Intel produces corrupt bitstreams with several of the
-// scalar optimizations below (branchless VLC drain, 64-bit MagSgn, etc.)
-// for reasons not yet identified. Since this file is x86-only, the guard
-// does not affect Apple Silicon builds (which use NEON, not AVX2).
-#if defined(__apple_build_version__)
-#include "ojph_block_encoder_avx2_apple.h"
-#else
-
 #include "ojph_arch.h"
 #if defined(OJPH_ARCH_I386) || defined(OJPH_ARCH_X86_64)
 
@@ -81,8 +73,6 @@ namespace ojph {
     static ui32 vlc_tbl1[2048];
 
     //UVLC encoding
-    static ui32 uvlc_tbl_pair1[33 * 33];
-    static ui32 uvlc_tbl_pair2[33 * 33];
     static ui32 ulvc_cwd_pre[33];
     static int ulvc_cwd_pre_len[33];
     static ui32 ulvc_cwd_suf[33];
@@ -233,56 +223,6 @@ namespace ojph {
     }
 
     /////////////////////////////////////////////////////////////////////////
-    static void uvlc_init_pair_tables()
-    {
-      for (int uq0 = 0; uq0 < 33; ++uq0) {
-        for (int uq1 = 0; uq1 < 33; ++uq1) {
-          ui32 cwd; int len;
-
-          cwd = 0; len = 0;
-          if (uq0 > 2 && uq1 > 2) {
-            cwd |= ulvc_cwd_pre[uq0 - 2];
-            len += ulvc_cwd_pre_len[uq0 - 2];
-            cwd |= ulvc_cwd_pre[uq1 - 2] << len;
-            len += ulvc_cwd_pre_len[uq1 - 2];
-            cwd |= ulvc_cwd_suf[uq0 - 2] << len;
-            len += ulvc_cwd_suf_len[uq0 - 2];
-            cwd |= ulvc_cwd_suf[uq1 - 2] << len;
-            len += ulvc_cwd_suf_len[uq1 - 2];
-          } else if (uq0 > 2 && uq1 > 0) {
-            cwd |= ulvc_cwd_pre[uq0];
-            len += ulvc_cwd_pre_len[uq0];
-            cwd |= (ui32)(uq1 - 1) << len;
-            len += 1;
-            cwd |= ulvc_cwd_suf[uq0] << len;
-            len += ulvc_cwd_suf_len[uq0];
-          } else {
-            cwd |= ulvc_cwd_pre[uq0];
-            len += ulvc_cwd_pre_len[uq0];
-            cwd |= ulvc_cwd_pre[uq1] << len;
-            len += ulvc_cwd_pre_len[uq1];
-            cwd |= ulvc_cwd_suf[uq0] << len;
-            len += ulvc_cwd_suf_len[uq0];
-            cwd |= ulvc_cwd_suf[uq1] << len;
-            len += ulvc_cwd_suf_len[uq1];
-          }
-          uvlc_tbl_pair1[uq0 * 33 + uq1] = (cwd << 5) | (ui32)len;
-
-          cwd = 0; len = 0;
-          cwd |= ulvc_cwd_pre[uq0];
-          len += ulvc_cwd_pre_len[uq0];
-          cwd |= ulvc_cwd_pre[uq1] << len;
-          len += ulvc_cwd_pre_len[uq1];
-          cwd |= ulvc_cwd_suf[uq0] << len;
-          len += ulvc_cwd_suf_len[uq0];
-          cwd |= ulvc_cwd_suf[uq1] << len;
-          len += ulvc_cwd_suf_len[uq1];
-          uvlc_tbl_pair2[uq0 * 33 + uq1] = (cwd << 5) | (ui32)len;
-        }
-      }
-    }
-
-    /////////////////////////////////////////////////////////////////////////
     bool initialize_block_encoder_tables_avx2() {
       static bool tables_initialized = false;
       static std::once_flag tables_initialized_flag;
@@ -291,7 +231,6 @@ namespace ojph {
         memset(vlc_tbl1, 0, 2048 * sizeof(ui32));
         tables_initialized = vlc_init_tables();
         tables_initialized = tables_initialized && uvlc_init_tables();
-        uvlc_init_pair_tables();
       });
       return tables_initialized;
     }
@@ -327,20 +266,16 @@ namespace ojph {
       melp->threshold = 1; // this is 1 << mel_exp[melp->k];
     }
 
-    static const int mel_exp[13] = {0,0,0,1,1,1,2,2,2,3,3,4,5};
-
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    mel_emit_bits(mel_struct* melp, ui32 bits, int num_bits)
+    mel_emit_bit(mel_struct* melp, int v)
     {
-      melp->tmp = (melp->tmp << num_bits) | (int)bits;
-      melp->remaining_bits -= num_bits;
-      if (melp->remaining_bits <= 0) {
-        int excess = -melp->remaining_bits;
-        ui8 byte = (ui8)(melp->tmp >> excess);
-        melp->buf[melp->pos++] = byte;
-        melp->tmp &= (1 << excess) - 1;
-        melp->remaining_bits += 8 - (byte == 0xFF);
+      melp->tmp = (melp->tmp << 1) + v;
+      melp->remaining_bits--;
+      if (melp->remaining_bits == 0) {
+        melp->buf[melp->pos++] = (ui8)melp->tmp;
+        melp->remaining_bits = (melp->tmp == 0xFF ? 7 : 8);
+        melp->tmp = 0;
       }
     }
 
@@ -348,59 +283,33 @@ namespace ojph {
     static inline void
     mel_encode(mel_struct* melp, bool bit)
     {
+      //MEL exponent
+      static const int mel_exp[13] = {0,0,0,1,1,1,2,2,2,3,3,4,5};
+
       if (bit == false) {
         ++melp->run;
         if (melp->run >= melp->threshold) {
-          mel_emit_bits(melp, 1, 1);
+          mel_emit_bit(melp, 1);
           melp->run = 0;
           melp->k = ojph_min(12, melp->k + 1);
           melp->threshold = 1 << mel_exp[melp->k];
         }
       } else {
+        mel_emit_bit(melp, 0);
         int t = mel_exp[melp->k];
-        mel_emit_bits(melp, melp->run & ((1u << t) - 1), t + 1);
+        while (t > 0) {
+          mel_emit_bit(melp, (melp->run >> --t) & 1);
+        }
         melp->run = 0;
         melp->k = ojph_max(0, melp->k - 1);
         melp->threshold = 1 << mel_exp[melp->k];
       }
     }
 
-    //////////////////////////////////////////////////////////////////////////
-    static inline void
-    mel_advance_run(mel_struct* melp, ui32 n)
-    {
-      ui32 remaining = n;
-      while (remaining > 0) {
-        ui32 space = (ui32)melp->threshold - (ui32)melp->run;
-        if (remaining >= space) {
-          remaining -= space;
-          mel_emit_bits(melp, 1, 1);
-          melp->run = 0;
-          melp->k = ojph_min(12, melp->k + 1);
-          melp->threshold = 1 << mel_exp[melp->k];
-        } else {
-          melp->run += (int)remaining;
-          remaining = 0;
-        }
-      }
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    static inline void
-    mel_encode_significance(mel_struct* melp)
-    {
-      int t = mel_exp[melp->k];
-      mel_emit_bits(melp, melp->run & ((1u << t) - 1), t + 1);
-      melp->run = 0;
-      melp->k = ojph_max(0, melp->k - 1);
-      melp->threshold = 1 << mel_exp[melp->k];
-    }
-
     /////////////////////////////////////////////////////////////////////////
     //
     /////////////////////////////////////////////////////////////////////////
-
-    struct vlc_struct {
+    struct vlc_struct_avx2 {
       //storage
       ui8* buf;      //pointer to data buffer
       ui32 pos;      //position of next writing within buf
@@ -413,7 +322,7 @@ namespace ojph {
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    vlc_init(vlc_struct* vlcp, ui32 buffer_size, ui8* data)
+    vlc_init(vlc_struct_avx2* vlcp, ui32 buffer_size, ui8* data)
     {
       vlcp->buf = data + buffer_size - 1; //points to last byte
       vlcp->pos = 1;                      //locations will be all -pos
@@ -427,39 +336,39 @@ namespace ojph {
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    vlc_drain(vlc_struct* vlcp)
+    vlc_encode(vlc_struct_avx2* vlcp, ui32 cwd, int cwd_len)
     {
+      vlcp->tmp |= (ui64)cwd << vlcp->used_bits;
+      vlcp->used_bits += cwd_len;
+
       while (vlcp->used_bits >= 8) {
-        int escape = (int)vlcp->last_greater_than_8F;
-        int is_7f = (int)((vlcp->tmp & 0x7F) == 0x7F);
-        int need_stuff = escape & is_7f;
-        int bits = 8 - need_stuff;
+          ui8 tmp;
 
-        ui8 byte = (ui8)(vlcp->tmp & ((1u << bits) - 1));
-        *(vlcp->buf - vlcp->pos) = byte;
-        vlcp->pos++;
-        vlcp->tmp >>= bits;
-        vlcp->used_bits -= bits;
-        vlcp->last_greater_than_8F = byte > 0x8F;
-      }
-    }
+          if (unlikely(vlcp->last_greater_than_8F)) {
+              tmp = vlcp->tmp & 0x7F;
 
-    //////////////////////////////////////////////////////////////////////////
-    static inline void
-    vlc_encode(vlc_struct* vlcp, ui64 cwd, int cwd_len)
-    {
-      while (true) {
-        int avail = 64 - vlcp->used_bits;
-        if (likely(cwd_len <= avail)) {
-          vlcp->tmp |= cwd << vlcp->used_bits;
-          vlcp->used_bits += cwd_len;
-          return;
-        }
-        vlcp->tmp |= (cwd & ((1ULL << avail) - 1)) << vlcp->used_bits;
-        vlcp->used_bits = 64;
-        vlc_drain(vlcp);
-        cwd >>= avail;
-        cwd_len -= avail;
+              if (likely(tmp != 0x7F)) {
+                  tmp = vlcp->tmp & 0xFF;
+                  *(vlcp->buf - vlcp->pos) = tmp;
+                  vlcp->last_greater_than_8F = tmp > 0x8F;
+                  vlcp->tmp >>= 8;
+                  vlcp->used_bits -= 8;
+              } else {
+                  *(vlcp->buf - vlcp->pos) = tmp;
+                  vlcp->last_greater_than_8F = false;
+                  vlcp->tmp >>= 7;
+                  vlcp->used_bits -= 7;
+              }
+
+          } else {
+              tmp = vlcp->tmp & 0xFF;
+              *(vlcp->buf - vlcp->pos) = tmp;
+              vlcp->last_greater_than_8F = tmp > 0x8F;
+              vlcp->tmp >>= 8;
+              vlcp->used_bits -= 8;
+          }
+
+          vlcp->pos++;
       }
     }
 
@@ -467,10 +376,10 @@ namespace ojph {
     //
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    terminate_mel_vlc(mel_struct* melp, vlc_struct* vlcp)
+    terminate_mel_vlc(mel_struct* melp, vlc_struct_avx2* vlcp)
     {
       if (melp->run > 0)
-        mel_emit_bits(melp, 1, 1);
+        mel_emit_bit(melp, 1);
 
       if (vlcp->last_greater_than_8F && (vlcp->tmp & 0x7f) == 0x7f) {
         *(vlcp->buf - vlcp->pos) = 0x7f;
@@ -508,16 +417,15 @@ namespace ojph {
 /////////////////////////////////////////////////////////////////////////
 //
 /////////////////////////////////////////////////////////////////////////
-
     struct ms_struct {
       //storage
-      ui8* buf;        //pointer to data buffer
-      ui32 pos;        //position of next writing within buf
-      ui32 buf_size;   //size of buffer, which we must not exceed
+      ui8* buf;      //pointer to data buffer
+      ui32 pos;      //position of next writing within buf
+      ui32 buf_size; //size of buffer, which we must not exceed
 
-      int used_bits;   //number of occupied bits in tmp
-      ui64 tmp;        //temporary storage of coded bits (64-bit accumulator)
-      bool last_was_ff;//true if the last written byte was 0xFF
+      int max_bits;  //maximum number of bits that can be store in tmp
+      int used_bits; //number of occupied bits in tmp
+      ui32 tmp;      //temporary storage of coded bits
     };
 
     //////////////////////////////////////////////////////////////////////////
@@ -527,128 +435,51 @@ namespace ojph {
       msp->buf = data;
       msp->pos = 0;
       msp->buf_size = buffer_size;
+      msp->max_bits = 8;
       msp->used_bits = 0;
       msp->tmp = 0;
-      msp->last_was_ff = false;
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    static inline void
-    ms_drain(ms_struct* msp)
-    {
-      if (msp->last_was_ff) {
-        if (msp->used_bits < 7)
-          return;
-        msp->buf[msp->pos++] = (ui8)(msp->tmp & 0x7F);
-        msp->tmp >>= 7;
-        msp->used_bits -= 7;
-        msp->last_was_ff = false;
-      }
-
-      while (msp->used_bits >= 8) {
-        int n_bytes = msp->used_bits >> 3;
-        if (n_bytes > 8) n_bytes = 8;
-
-        ui64 word = msp->tmp;
-        ui64 valid_mask = (n_bytes < 8)
-                        ? (1ULL << (n_bytes * 8)) - 1 : ~(ui64)0;
-
-        ui64 w = ~word;
-        ui64 ff_detect = (w - 0x0101010101010101ULL) & ~w
-                       & 0x8080808080808080ULL;
-        ff_detect &= valid_mask;
-
-        if (likely(ff_detect == 0)) {
-          memcpy(msp->buf + msp->pos, &word, (size_t)n_bytes);
-          msp->pos += (ui32)n_bytes;
-          if (n_bytes < 8)
-            msp->tmp >>= (n_bytes * 8);
-          else
-            msp->tmp = 0;
-          msp->used_bits -= n_bytes * 8;
-        } else {
-          int ff_pos = (int)(count_trailing_zeros(ff_detect) >> 3);
-          int safe = ff_pos + 1;
-          memcpy(msp->buf + msp->pos, &word, (size_t)safe);
-          msp->pos += (ui32)safe;
-          int bits = safe * 8;
-          if (bits < 64)
-            msp->tmp >>= bits;
-          else
-            msp->tmp = 0;
-          msp->used_bits -= bits;
-
-          if (msp->used_bits >= 7) {
-            msp->buf[msp->pos++] = (ui8)(msp->tmp & 0x7F);
-            msp->tmp >>= 7;
-            msp->used_bits -= 7;
-            msp->last_was_ff = false;
-          } else {
-            msp->last_was_ff = true;
-            return;
-          }
-        }
-      }
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    static inline void
-    ms_encode_nodefer(ms_struct* msp, ui64 cwd, int cwd_len)
-    {
-      while (true) {
-        int avail = 64 - msp->used_bits;
-        if (likely(cwd_len <= avail)) {
-          msp->tmp |= cwd << msp->used_bits;
-          msp->used_bits += cwd_len;
-          return;
-        }
-        msp->tmp |= (cwd & ((1ULL << avail) - 1)) << msp->used_bits;
-        msp->used_bits = 64;
-        ms_drain(msp);
-        cwd >>= avail;
-        cwd_len -= avail;
-      }
     }
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
     ms_encode(ms_struct* msp, ui64 cwd, int cwd_len)
     {
-      int avail = 64 - msp->used_bits;
-      if (likely(cwd_len <= avail)) {
-        msp->tmp |= cwd << msp->used_bits;
-        msp->used_bits += cwd_len;
-      } else {
-        msp->tmp |= (cwd & ((1ULL << avail) - 1)) << msp->used_bits;
-        msp->used_bits = 64;
-        ms_drain(msp);
-        cwd >>= avail;
-        cwd_len -= avail;
-        msp->tmp |= cwd << msp->used_bits;
-        msp->used_bits += cwd_len;
+      while (cwd_len > 0)
+      {
+        if (msp->pos >= msp->buf_size)
+          OJPH_ERROR(0x00020005, "magnitude sign encoder's buffer is full");
+        int t = ojph_min(msp->max_bits - msp->used_bits, cwd_len);
+        msp->tmp |= ((ui32)(cwd & ((1U << t) - 1))) << msp->used_bits;
+        msp->used_bits += t;
+        cwd >>= t;
+        cwd_len -= t;
+        if (msp->used_bits >= msp->max_bits)
+        {
+          msp->buf[msp->pos++] = (ui8)msp->tmp;
+          msp->max_bits = (msp->tmp == 0xFF) ? 7 : 8;
+          msp->tmp = 0;
+          msp->used_bits = 0;
+        }
       }
-      ms_drain(msp);
     }
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
     ms_terminate(ms_struct* msp)
     {
-      ms_drain(msp);
       if (msp->used_bits)
       {
-        int max_bits = msp->last_was_ff ? 7 : 8;
-        int t = max_bits - msp->used_bits;
-        ui32 byte = (ui32)(msp->tmp & ((1ULL << msp->used_bits) - 1));
-        byte |= (0xFFu & ((1u << t) - 1)) << msp->used_bits;
-        if (byte != 0xFF)
+        int t = msp->max_bits - msp->used_bits; //unused bits
+        msp->tmp |= (0xFF & ((1U << t) - 1)) << msp->used_bits;
+        msp->used_bits += t;
+        if (msp->tmp != 0xFF)
         {
           if (msp->pos >= msp->buf_size)
             OJPH_ERROR(0x00020006, "magnitude sign encoder's buffer is full");
-          msp->buf[msp->pos++] = (ui8)byte;
+          msp->buf[msp->pos++] = (ui8)msp->tmp;
         }
       }
-      else if (msp->last_was_ff)
+      else if (msp->max_bits == 7)
         msp->pos--;
     }
 
@@ -835,10 +666,23 @@ static void proc_ms_encode(ms_struct *msp,
     m_vec[3] = _mm256_and_si256(mask, tmp);
 
     rotate_matrix(m_vec);
+    /* s_vec from
+     * s_vec[0]:[0, 0], [0, 2] ... [0,14], [0, 16], [0, 18] ... [0,30]
+     * s_vec[1]:[1, 0], [1, 2] ... [1,14], [1, 16], [1, 18] ... [1,30]
+     * s_vec[2]:[0, 1], [0, 3] ... [0,15], [0, 17], [0, 19] ... [0,31]
+     * s_vec[3]:[1, 1], [1, 3] ... [1,15], [1, 17], [1, 19] ... [1,31]
+     * to
+     * s_vec[0]:[0, 0], [1, 0], [0, 1], [1, 1], [0, 2], [1, 2]...[0, 7], [1, 7]
+     * s_vec[1]:[0, 8], [1, 8], [0, 9], [1, 9], [0,10], [1,10]...[0,15], [1,15]
+     * s_vec[2]:[0,16], [1,16], [0,17], [1,17], [0,18], [1,18]...[0,23], [1,23]
+     * s_vec[3]:[0,24], [1,24], [0,25], [1,25], [0,26], [1,26]...[0,31], [1,31]
+     */
     rotate_matrix(s_vec);
 
     ui32 cwd[8];
     int cwd_len[8];
+    ui64 _cwd = 0;
+    int _cwd_len = 0;
 
     /* Each iteration process 8 bytes * 2 lines */
     for (ui32 i = 0; i < 4; ++i) {
@@ -851,32 +695,15 @@ static void proc_ms_encode(ms_struct *msp,
         tmp = _mm256_and_si256(tmp, s_vec[i]);
         _mm256_storeu_si256((__m256i*)cwd, tmp);
 
-        for (ui32 j = 0; j < 4; j += 2) {
-            ui32 idx0 = j * 2;
-            ui64 _cwd     = cwd[idx0];
-            int  _cwd_len = cwd_len[idx0];
-            _cwd     |= ((ui64)cwd[idx0 + 1]) << _cwd_len;
-            _cwd_len += cwd_len[idx0 + 1];
-
-            ui32 idx1 = (j + 1) * 2;
-            int len1 = cwd_len[idx1] + cwd_len[idx1 + 1];
-            if (likely(_cwd_len + len1 <= 64)) {
-                _cwd     |= ((ui64)cwd[idx1]) << _cwd_len;
-                _cwd_len += cwd_len[idx1];
-                _cwd     |= ((ui64)cwd[idx1 + 1]) << _cwd_len;
-                _cwd_len += cwd_len[idx1 + 1];
-                ms_encode_nodefer(msp, _cwd, _cwd_len);
-            } else {
-                ms_encode_nodefer(msp, _cwd, _cwd_len);
-                _cwd     = cwd[idx1];
-                _cwd_len = cwd_len[idx1];
-                _cwd     |= ((ui64)cwd[idx1 + 1]) << _cwd_len;
-                _cwd_len += cwd_len[idx1 + 1];
-                ms_encode_nodefer(msp, _cwd, _cwd_len);
-            }
+        for (ui32 j = 0; j < 4; ++j) {
+            ui32 idx = j * 2;
+            _cwd     = cwd[idx];
+            _cwd_len = cwd_len[idx];
+            _cwd     |= ((ui64)cwd[idx + 1]) << _cwd_len;
+            _cwd_len += cwd_len[idx + 1];
+            ms_encode(msp, _cwd, _cwd_len);
         }
     }
-    ms_drain(msp);
 }
 
 static __m256i cal_eps_vec(__m256i *eq_vec, __m256i &u_q_vec,
@@ -980,7 +807,7 @@ static __m256i proc_cq2(ui32 x, __m256i *cx_val_vec, __m256i &rho_vec,
     auto tmp = _mm256_permutevar8x32_epi32(lcxp1_vec, right_shift);
 
 #ifdef OJPH_ARCH_X86_64
-    tmp = _mm256_insert_epi64(tmp,
+    tmp = _mm256_insert_epi64(tmp, 
       _mm_cvtsi128_si64(_mm256_castsi256_si128(cx_val_vec[x + 1])), 3);
 #elif (defined OJPH_ARCH_I386)
     int lsb = _mm_cvtsi128_si32(_mm256_castsi256_si128(cx_val_vec[x + 1]));
@@ -991,7 +818,7 @@ static __m256i proc_cq2(ui32 x, __m256i *cx_val_vec, __m256i &rho_vec,
     #error Error unsupport compiler
 #endif
     tmp = _mm256_slli_epi32(tmp, 2);
-    auto tmp1 = _mm256_insert_epi32(lcxp1_vec,
+    auto tmp1 = _mm256_insert_epi32(lcxp1_vec, 
       _mm_cvtsi128_si32(_mm256_castsi256_si128(cx_val_vec[x + 1])), 7);
     tmp = _mm256_add_epi32(tmp1, tmp);
 
@@ -1004,6 +831,8 @@ static __m256i proc_cq2(ui32 x, __m256i *cx_val_vec, __m256i &rho_vec,
 
     return _mm256_or_si256(tmp, tmp1);
 }
+
+using fn_proc_cq = __m256i (*)(ui32, __m256i *, __m256i &, const __m256i);
 
 static void proc_mel_encode1(mel_struct *melp, __m256i &cq_vec,
                              __m256i &rho_vec, __m256i u_q_vec, ui32 ignore,
@@ -1054,183 +883,133 @@ static void proc_mel_encode2(mel_struct *melp, __m256i &cq_vec,
 {
     ojph_unused(u_q_vec);
     ojph_unused(right_shift);
+    int32_t mel_need_encode[8];
+    int32_t mel_bit[8];
 
-    __m256i need = _mm256_cmpeq_epi32(cq_vec, ZERO);
-    ui32 mask = (ui32)_mm256_movemask_epi8(need);
-    mask &= 0x88888888;
+    /* Prepare mel_encode params */
+    /* if (c_q[i] == 0) { */
+    _mm256_storeu_si256((__m256i*)mel_need_encode, _mm256_cmpeq_epi32(cq_vec, ZERO));
+    /*   mel_encode(&mel, rho[i] != 0); */
+    _mm256_storeu_si256((__m256i*)mel_bit, _mm256_srli_epi32(avx2_cmpneq_epi32(rho_vec, ZERO), 31));
+    /* } */
 
     ui32 i_max = 8 - (ignore / 2);
-    if (i_max < 8)
-        mask &= (1u << (i_max * 4)) - 1;
 
-    if (mask == 0)
-        return;
-
-    int32_t mel_bit[8];
-    _mm256_storeu_si256((__m256i*)mel_bit,
-        _mm256_srli_epi32(avx2_cmpneq_epi32(rho_vec, ZERO), 31));
-
-    while (mask) {
-        ui32 bit_pos = (ui32)count_trailing_zeros(mask);
-        ui32 i = bit_pos / 4;
-        mel_encode(melp, mel_bit[i]);
-        mask &= mask - 1;
+    for (ui32 i = 0; i < i_max; ++i) {
+        if (mel_need_encode[i]) {
+            mel_encode(melp, mel_bit[i]);
+        }
     }
 }
 
 using fn_proc_mel_encode = void (*)(mel_struct *, __m256i &, __m256i &,
                                     __m256i, ui32, const __m256i);
 
-static inline void
-build_vlc_uvlc_pair(ui32 *tuple, ui32 *u_q, ui32 i,
-                    const ui32 *uvlc_tbl, ui64 &val, int &size)
-{
-    val = tuple[i + 0] >> 4;
-    size = tuple[i + 0] & 7;
-
-    val |= (ui64)(tuple[i + 1] >> 4) << size;
-    size += tuple[i + 1] & 7;
-
-    ui32 entry = uvlc_tbl[u_q[i] * 33 + u_q[i + 1]];
-    val |= (ui64)(entry >> 5) << size;
-    size += entry & 0x1F;
-}
-
-static void proc_vlc_encode(vlc_struct *vlcp, ui32 *tuple,
-                            ui32 *u_q, ui32 ignore, const ui32 *uvlc_tbl)
+static void proc_vlc_encode1(vlc_struct_avx2 *vlcp, ui32 *tuple,
+                             ui32 *u_q, ui32 ignore)
 {
     ui32 i_max = 8 - (ignore / 2);
 
-    ui32 i = 0;
-    for (; i + 2 < i_max; i += 4) {
-        ui64 val1; int size1;
-        build_vlc_uvlc_pair(tuple, u_q, i, uvlc_tbl, val1, size1);
-        ui64 val2; int size2;
-        build_vlc_uvlc_pair(tuple, u_q, i + 2, uvlc_tbl, val2, size2);
-        vlc_encode(vlcp, val1 | (val2 << size1), size1 + size2);
-    }
-    if (i < i_max) {
-        ui64 val; int size;
-        build_vlc_uvlc_pair(tuple, u_q, i, uvlc_tbl, val, size);
+    for (ui32 i = 0; i < i_max; i += 2) {
+        /* 7 bits */
+        ui32 val = tuple[i + 0] >> 4;
+        int size = tuple[i + 0] & 7;
+
+        if (i + 1 < i_max) {
+            /* 7 bits */
+            val |= (tuple[i + 1] >> 4) << size;
+            size += tuple[i + 1] & 7;
+        }
+
+        if (u_q[i] > 2 && u_q[i + 1] > 2) {
+            /* 3 bits */
+            val |= (ulvc_cwd_pre[u_q[i] - 2]) << size;
+            size += ulvc_cwd_pre_len[u_q[i] - 2];
+
+            /* 3 bits */
+            val |= (ulvc_cwd_pre[u_q[i + 1] - 2]) << size;
+            size += ulvc_cwd_pre_len[u_q[i + 1] - 2];
+
+            /* 5 bits */
+            val |= (ulvc_cwd_suf[u_q[i] - 2]) << size;
+            size += ulvc_cwd_suf_len[u_q[i] - 2];
+
+            /* 5 bits */
+            val |= (ulvc_cwd_suf[u_q[i + 1] - 2]) << size;
+            size += ulvc_cwd_suf_len[u_q[i + 1] - 2];
+
+        } else if (u_q[i] > 2 && u_q[i + 1] > 0) {
+            /* 3 bits */
+            val |= (ulvc_cwd_pre[u_q[i]]) << size;
+            size += ulvc_cwd_pre_len[u_q[i]];
+
+            /* 1 bit */
+            val |= (u_q[i + 1] - 1) << size;
+            size += 1;
+
+            /* 5 bits */
+            val |= (ulvc_cwd_suf[u_q[i]]) << size;
+            size += ulvc_cwd_suf_len[u_q[i]];
+
+        } else {
+            /* 3 bits */
+            val |= (ulvc_cwd_pre[u_q[i]]) << size;
+            size += ulvc_cwd_pre_len[u_q[i]];
+
+            /* 3 bits */
+            val |= (ulvc_cwd_pre[u_q[i + 1]]) << size;
+            size += ulvc_cwd_pre_len[u_q[i + 1]];
+
+            /* 5 bits */
+            val |= (ulvc_cwd_suf[u_q[i]]) << size;
+            size += ulvc_cwd_suf_len[u_q[i]];
+
+            /* 5 bits */
+            val |= (ulvc_cwd_suf[u_q[i + 1]]) << size;
+            size += ulvc_cwd_suf_len[u_q[i + 1]];
+        }
+
         vlc_encode(vlcp, val, size);
     }
 }
 
-template<int PASS>
-OJPH_FORCE_INLINE void encode_x_loop(
-    ui32 *sp, ui32 stride, ui32 height, ui32 y,
-    ui32 n_loop, ui32 _width, ui32 ignore, ui32 p,
-    mel_struct &mel, vlc_struct &vlc, ms_struct &ms,
-    __m256i *e_val_vec, __m256i &prev_e_val_vec,
-    __m256i *cx_val_vec, __m256i &prev_cx_val_vec,
-    ui32 &prev_cq,
-    const __m256i &right_shift, const __m256i &left_shift)
+static void proc_vlc_encode2(vlc_struct_avx2 *vlcp, ui32 *tuple,
+                             ui32 *u_q, ui32 ignore)
 {
-    ui32 *vlc_tbl = (PASS == 1) ? vlc_tbl0 : vlc_tbl1;
+    ui32 i_max = 8 - (ignore / 2);
 
-    __m256i tmp, tmp1;
-    __m256i eq_vec[4];
-    __m256i s_vec[4];
-    __m256i src_vec[4];
+    for (ui32 i = 0; i < i_max; i += 2) {
+        /* 7 bits */
+        ui32 val = tuple[i + 0] >> 4;
+        int size = tuple[i + 0] & 7;
 
-    /* 16 bytes per iteration */
-    for (ui32 x = 0; x < n_loop; ++x) {
-
-        /* t = sp[i]; */
-        if ((x == (n_loop - 1)) && (_width % 16)) {
-            ui32 tmp_buf[16] = { 0 };
-            memcpy(tmp_buf, sp, (_width % 16) * sizeof(ui32));
-            src_vec[0] = _mm256_loadu_si256((__m256i*)(tmp_buf));
-            src_vec[2] = _mm256_loadu_si256((__m256i*)(tmp_buf + 8));
-            if (y + 1 < height) {
-                memcpy(tmp_buf, sp + stride, (_width % 16) * sizeof(ui32));
-                src_vec[1] = _mm256_loadu_si256((__m256i*)(tmp_buf));
-                src_vec[3] = _mm256_loadu_si256((__m256i*)(tmp_buf + 8));
-            }
-            else {
-                src_vec[1] = ZERO;
-                src_vec[3] = ZERO;
-            }
-        }
-        else {
-            src_vec[0] = _mm256_loadu_si256((__m256i*)(sp));
-            src_vec[2] = _mm256_loadu_si256((__m256i*)(sp + 8));
-
-            if (y + 1 < height) {
-                src_vec[1] = _mm256_loadu_si256((__m256i*)(sp + stride));
-                src_vec[3] = _mm256_loadu_si256((__m256i*)(sp + 8 + stride));
-            }
-            else {
-                src_vec[1] = ZERO;
-                src_vec[3] = ZERO;
-            }
-            sp += 16;
+        if (i + 1 < i_max) {
+            /* 7 bits */
+            val |= (tuple[i + 1] >> 4) << size;
+            size += tuple[i + 1] & 7;
         }
 
-        __m256i rho_vec, e_qmax_vec;
-        proc_pixel(src_vec, p, eq_vec, s_vec, rho_vec, e_qmax_vec);
+        /* 3 bits */
+        val |= ulvc_cwd_pre[u_q[i]] << size;
+        size += ulvc_cwd_pre_len[u_q[i]];
 
-        // max_e[(i + 1) % num] = ojph_max(lep[i + 1], lep[i + 2]) - 1;
-        tmp = _mm256_permutevar8x32_epi32(e_val_vec[x], right_shift);
-        tmp = _mm256_insert_epi32(tmp, _mm_cvtsi128_si32(_mm256_castsi256_si128(e_val_vec[x + 1])), 7);
+        /* 3 bits */
+        val |= (ulvc_cwd_pre[u_q[i + 1]]) << size;
+        size += ulvc_cwd_pre_len[u_q[i + 1]];
 
-        auto max_e_vec = _mm256_max_epi32(tmp, e_val_vec[x]);
-        max_e_vec = _mm256_sub_epi32(max_e_vec, ONE);
+        /* 5 bits */
+        val |= (ulvc_cwd_suf[u_q[i + 0]]) << size;
+        size += ulvc_cwd_suf_len[u_q[i + 0]];
 
-        // kappa[i] = (rho[i] & (rho[i] - 1)) ? ojph_max(1, max_e[i]) : 1;
-        tmp = _mm256_max_epi32(max_e_vec, ONE);
-        tmp1 = _mm256_sub_epi32(rho_vec, ONE);
-        tmp1 = _mm256_and_si256(rho_vec, tmp1);
+        /* 5 bits */
+        val |= (ulvc_cwd_suf[u_q[i + 1]]) << size;
+        size += ulvc_cwd_suf_len[u_q[i + 1]];
 
-        auto cmp = _mm256_cmpeq_epi32(tmp1, ZERO);
-        auto kappa_vec1_ = _mm256_and_si256(cmp, ONE);
-        auto kappa_vec2_ = _mm256_and_si256(_mm256_xor_si256(cmp, _mm256_set1_epi32((int32_t)0xffffffff)), tmp);
-        const __m256i kappa_vec = _mm256_max_epi32(kappa_vec1_, kappa_vec2_);
-
-        if (PASS == 1)
-            tmp = proc_cq1(x, cx_val_vec, rho_vec, right_shift);
-        else
-            tmp = proc_cq2(x, cx_val_vec, rho_vec, right_shift);
-
-        auto cq_vec = _mm256_permutevar8x32_epi32(tmp, left_shift);
-        cq_vec = _mm256_insert_epi32(cq_vec, prev_cq, 0);
-        prev_cq = (ui32)_mm256_extract_epi32(tmp, 7);
-
-        update_lep(x, prev_e_val_vec, eq_vec, e_val_vec, left_shift);
-        update_lcxp(x, prev_cx_val_vec, rho_vec, cx_val_vec, left_shift);
-
-        /* Uq[i] = ojph_max(e_qmax[i], kappa[i]); */
-        /* u_q[i] = Uq[i] - kappa[i]; */
-        auto uq_vec = _mm256_max_epi32(kappa_vec, e_qmax_vec);
-        auto u_q_vec = _mm256_sub_epi32(uq_vec, kappa_vec);
-
-        auto eps_vec = cal_eps_vec(eq_vec, u_q_vec, e_qmax_vec);
-        __m256i tuple_vec = cal_tuple(cq_vec, rho_vec, eps_vec, vlc_tbl);
-        ui32 _ignore = ((n_loop - 1) == x) ? ignore : 0;
-
-        if (PASS == 1)
-            proc_mel_encode1(&mel, cq_vec, rho_vec, u_q_vec, _ignore,
-                             right_shift);
-        else
-            proc_mel_encode2(&mel, cq_vec, rho_vec, u_q_vec, _ignore,
-                             right_shift);
-
-        proc_ms_encode(&ms, tuple_vec, uq_vec, rho_vec, s_vec);
-
-        ui32 u_q[10];
-        ui32 tuple[10];
-        tuple_vec = _mm256_srli_epi32(tuple_vec, 4);
-        _mm256_storeu_si256((__m256i*)tuple, tuple_vec);
-        _mm256_storeu_si256((__m256i*)u_q, u_q_vec);
-        {
-            ui32 i_max = 8 - (_ignore / 2);
-            if (i_max & 1) { tuple[i_max] = 0; u_q[i_max] = 0; }
-            tuple[8] = 0; u_q[8] = 0;
-        }
-        proc_vlc_encode(&vlc, tuple, u_q, _ignore,
-            (PASS == 1) ? uvlc_tbl_pair1 : uvlc_tbl_pair2);
+        vlc_encode(vlcp, val, size);
     }
 }
+
+using fn_proc_vlc_encode = void (*)(vlc_struct_avx2 *, ui32 *, ui32 *, ui32);
 
 void ojph_encode_codeblock_avx2(ui32* buf, ui32 missing_msbs,
                                 ui32 num_passes, ui32 _width, ui32 height,
@@ -1254,7 +1033,7 @@ void ojph_encode_codeblock_avx2(ui32* buf, ui32 missing_msbs,
 
     mel_struct mel;
     mel_init(&mel, mel_size, mel_buf);
-    vlc_struct vlc;
+    vlc_struct_avx2 vlc;
     vlc_init(&vlc, vlc_size, vlc_buf);
     ms_struct ms;
     ms_init(&ms, ms_size, ms_buf);
@@ -1291,14 +1070,21 @@ void ojph_encode_codeblock_avx2(ui32* buf, ui32 missing_msbs,
 
     ui32 prev_cq = 0;
 
-    __m256i tmp;
+    __m256i eq_vec[4];
+    __m256i s_vec[4];
+    __m256i src_vec[4];
+
+    ui32 *vlc_tbl = vlc_tbl0;
+    fn_proc_cq proc_cq = proc_cq1;
+    fn_proc_mel_encode proc_mel_encode = proc_mel_encode1;
+    fn_proc_vlc_encode proc_vlc_encode = proc_vlc_encode1;
 
     /* 2 lines per iteration */
     for (ui32 y = 0; y < height; y += 2)
     {
         e_val_vec[n_loop] = prev_e_val_vec;
         /* lcxp[0] = (ui8)((rho[0] & 8) >> 3); */
-        tmp = _mm256_and_si256(prev_cx_val_vec, _mm256_set1_epi32(8));
+        __m256i tmp = _mm256_and_si256(prev_cx_val_vec, _mm256_set1_epi32(8));
         cx_val_vec[n_loop] = _mm256_srli_epi32(tmp, 3);
 
         prev_e_val_vec = ZERO;
@@ -1306,27 +1092,119 @@ void ojph_encode_codeblock_avx2(ui32* buf, ui32 missing_msbs,
 
         ui32 *sp = buf + y * stride;
 
-        if (y == 0)
-            encode_x_loop<1>(sp, stride, height, y, n_loop, _width,
-                             ignore, p, mel, vlc, ms,
-                             e_val_vec, prev_e_val_vec,
-                             cx_val_vec, prev_cx_val_vec, prev_cq,
-                             right_shift, left_shift);
-        else
-            encode_x_loop<2>(sp, stride, height, y, n_loop, _width,
-                             ignore, p, mel, vlc, ms,
-                             e_val_vec, prev_e_val_vec,
-                             cx_val_vec, prev_cx_val_vec, prev_cq,
-                             right_shift, left_shift);
+        /* 16 bytes per iteration */
+        for (ui32 x = 0; x < n_loop; ++x) {
+
+            /* t = sp[i]; */
+            if ((x == (n_loop - 1)) && (_width % 16)) {
+                ui32 tmp_buf[16] = { 0 };
+                memcpy(tmp_buf, sp, (_width % 16) * sizeof(ui32));
+                src_vec[0] = _mm256_loadu_si256((__m256i*)(tmp_buf));
+                src_vec[2] = _mm256_loadu_si256((__m256i*)(tmp_buf + 8));
+                if (y + 1 < height) {
+                    memcpy(tmp_buf, sp + stride, (_width % 16) * sizeof(ui32));
+                    src_vec[1] = _mm256_loadu_si256((__m256i*)(tmp_buf));
+                    src_vec[3] = _mm256_loadu_si256((__m256i*)(tmp_buf + 8));
+                }
+                else {
+                    src_vec[1] = ZERO;
+                    src_vec[3] = ZERO;
+                }
+            }
+            else {
+                src_vec[0] = _mm256_loadu_si256((__m256i*)(sp));
+                src_vec[2] = _mm256_loadu_si256((__m256i*)(sp + 8));
+
+                if (y + 1 < height) {
+                    src_vec[1] = _mm256_loadu_si256((__m256i*)(sp + stride));
+                    src_vec[3] = _mm256_loadu_si256((__m256i*)(sp + 8 + stride));
+                }
+                else {
+                    src_vec[1] = ZERO;
+                    src_vec[3] = ZERO;
+                }
+                sp += 16;
+            }
+
+            /* src_vec layout:
+             * src_vec[0]:[0, 0],[0, 1],[0, 2],[0, 3],[0, 4],[0, 5],.[0, 6],.[0, 7]
+             * src_vec[1]:[1, 0],[1, 1],[1, 2],[1, 3],[1, 4],[1, 5],.[1, 6],.[1, 7]
+             * src_vec[2]:[0, 8],[0, 9],[0,10],[0,11],[0,12],[0,13],.[0,14], [0,15]
+             * src_vec[3]:[1, 8],[1, 9],[1,10],[1,11],[1,12],[1,13],.[1,14], [1,15]
+             */
+            __m256i rho_vec, e_qmax_vec;
+            proc_pixel(src_vec, p, eq_vec, s_vec, rho_vec, e_qmax_vec);
+
+            // max_e[(i + 1) % num] = ojph_max(lep[i + 1], lep[i + 2]) - 1;
+            tmp = _mm256_permutevar8x32_epi32(e_val_vec[x], right_shift);
+            tmp = _mm256_insert_epi32(tmp, _mm_cvtsi128_si32(_mm256_castsi256_si128(e_val_vec[x + 1])), 7);
+
+            auto max_e_vec = _mm256_max_epi32(tmp, e_val_vec[x]);
+            max_e_vec = _mm256_sub_epi32(max_e_vec, ONE);
+
+            // kappa[i] = (rho[i] & (rho[i] - 1)) ? ojph_max(1, max_e[i]) : 1;
+            tmp = _mm256_max_epi32(max_e_vec, ONE);
+            __m256i tmp1 = _mm256_sub_epi32(rho_vec, ONE);
+            tmp1 = _mm256_and_si256(rho_vec, tmp1);
+
+            auto cmp = _mm256_cmpeq_epi32(tmp1, ZERO);
+            auto kappa_vec1_ = _mm256_and_si256(cmp, ONE);
+            auto kappa_vec2_ = _mm256_and_si256(_mm256_xor_si256(cmp, _mm256_set1_epi32((int32_t)0xffffffff)), tmp);
+            const __m256i kappa_vec = _mm256_max_epi32(kappa_vec1_, kappa_vec2_);
+
+            /* cq[1 - 16] = cq_vec
+             * cq[0] = prev_cq_vec[0]
+             */
+            tmp = proc_cq(x, cx_val_vec, rho_vec, right_shift);
+
+            auto cq_vec = _mm256_permutevar8x32_epi32(tmp, left_shift);
+            cq_vec = _mm256_insert_epi32(cq_vec, prev_cq, 0);
+            prev_cq = (ui32)_mm256_extract_epi32(tmp, 7);
+
+            update_lep(x, prev_e_val_vec, eq_vec, e_val_vec, left_shift);
+            update_lcxp(x, prev_cx_val_vec, rho_vec, cx_val_vec, left_shift);
+
+            /* Uq[i] = ojph_max(e_qmax[i], kappa[i]); */
+            /* u_q[i] = Uq[i] - kappa[i]; */
+            auto uq_vec = _mm256_max_epi32(kappa_vec, e_qmax_vec);
+            auto u_q_vec = _mm256_sub_epi32(uq_vec, kappa_vec);
+
+            auto eps_vec = cal_eps_vec(eq_vec, u_q_vec, e_qmax_vec);
+            __m256i tuple_vec = cal_tuple(cq_vec, rho_vec, eps_vec, vlc_tbl);
+            ui32 _ignore = ((n_loop - 1) == x) ? ignore : 0;
+
+            proc_mel_encode(&mel, cq_vec, rho_vec, u_q_vec, _ignore,
+                            right_shift);
+
+            proc_ms_encode(&ms, tuple_vec, uq_vec, rho_vec, s_vec);
+
+            // vlc_encode(&vlc, tuple[i*2+0] >> 8, (tuple[i*2+0] >> 4) & 7);
+            // vlc_encode(&vlc, tuple[i*2+1] >> 8, (tuple[i*2+1] >> 4) & 7);
+            ui32 u_q[8];
+            ui32 tuple[8];
+            /* The tuple is scaled by 4 due to:
+             * vlc_encode(&vlc, tuple0 >> 8, (tuple0 >> 4) & 7, true);
+             * So in the vlc_encode, the tuple will only be scaled by 2.
+             */
+            tuple_vec = _mm256_srli_epi32(tuple_vec, 4);
+            _mm256_storeu_si256((__m256i*)tuple, tuple_vec);
+            _mm256_storeu_si256((__m256i*)u_q, u_q_vec);
+
+            proc_vlc_encode(&vlc, tuple, u_q, _ignore);
+        }
 
         tmp = _mm256_permutevar8x32_epi32(cx_val_vec[0], right_shift);
         tmp = _mm256_slli_epi32(tmp, 2);
         tmp = _mm256_add_epi32(tmp, cx_val_vec[0]);
         prev_cq = (ui32)_mm_cvtsi128_si32(_mm256_castsi256_si128(tmp));
+
+        proc_cq = proc_cq2;
+        vlc_tbl = vlc_tbl1;
+        proc_mel_encode = proc_mel_encode2;
+        proc_vlc_encode = proc_vlc_encode2;
     }
 
     ms_terminate(&ms);
-    vlc_drain(&vlc);
     terminate_mel_vlc(&mel, &vlc);
 
     //copy to elastic
@@ -1350,4 +1228,3 @@ void ojph_encode_codeblock_avx2(ui32* buf, ui32 missing_msbs,
 } /* namespace ojph */
 
 #endif
-#endif // !defined(__apple_build_version__)

--- a/src/core/openjph/ojph_arch.h
+++ b/src/core/openjph/ojph_arch.h
@@ -5,6 +5,7 @@
 // Copyright (c) 2019, Aous Naman
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
+// Copyright (c) 2026, Osamu Watanabe
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -61,6 +62,17 @@
 
 #ifdef OJPH_COMPILER_MSVC
 #include <intrin.h>
+#endif
+
+  /////////////////////////////////////////////////////////////////////////////
+  // portable force-inline / no-inline function qualifiers
+  /////////////////////////////////////////////////////////////////////////////
+#ifdef OJPH_COMPILER_MSVC
+  #define OJPH_FORCE_INLINE static __forceinline
+  #define OJPH_NO_INLINE    static __declspec(noinline)
+#else
+  #define OJPH_FORCE_INLINE static inline __attribute__((always_inline))
+  #define OJPH_NO_INLINE    static __attribute__((noinline))
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/core/openjph/ojph_arch.h
+++ b/src/core/openjph/ojph_arch.h
@@ -267,6 +267,35 @@ namespace ojph {
   #endif
   }
 
+  /////////////////////////////////////////////////////////////////////////////
+#ifdef OJPH_COMPILER_MSVC
+  #pragma intrinsic(_BitScanForward64)
+#endif
+  static inline ui32 count_trailing_zeros(ui64 val)
+  {
+  #ifdef OJPH_COMPILER_MSVC
+    unsigned long result = 0;
+    #if (defined OJPH_ARCH_X86_64) || (defined OJPH_ARCH_ARM)
+      _BitScanForward64(&result, val);
+    #elif (defined OJPH_ARCH_I386)
+      ui32 lsb = (ui32)val, msb = (ui32)(val >> 32);
+      if (lsb != 0)
+        _BitScanForward(&result, lsb);
+      else {
+        _BitScanForward(&result, msb);
+        result += 32;
+      }
+    #endif
+    return (ui32)result;
+  #elif (defined OJPH_COMPILER_GNUC)
+    return (ui32)__builtin_ctzll(val);
+  #else
+    if ((ui32)val != 0)
+      return count_trailing_zeros((ui32)val);
+    return 32 + count_trailing_zeros((ui32)(val >> 32));
+  #endif
+  }
+
   ////////////////////////////////////////////////////////////////////////////
   static inline si32 ojph_round(float val)
   {

--- a/src/core/others/ojph_arch.cpp
+++ b/src/core/others/ojph_arch.cpp
@@ -5,7 +5,8 @@
 // Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-// 
+// Copyright (c) 2026, Osamu Watanabe
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -143,8 +144,12 @@ namespace ojph {
                           osxsave_avail && ((xcr_val & 0xE0) == 0xE0);
                         bool avx512f_avail = (avx2_abcd[1] & 0x10000) != 0;
                         bool avx512cd_avail = (avx2_abcd[1] & 0x10000000) != 0;
-                        bool avx512_avail = 
-                          zmm_avail && avx512f_avail && avx512cd_avail;
+                        bool avx512bw_avail = (avx2_abcd[1] & 0x40000000) != 0;
+                        bool avx512vl_avail =
+                          (avx2_abcd[1] & 0x80000000u) != 0;
+                        bool avx512_avail = zmm_avail && avx512f_avail
+                          && avx512cd_avail && avx512bw_avail
+                          && avx512vl_avail;
                         if (avx512_avail)
                           level = X86_CPU_EXT_LEVEL_AVX512;
                       }


### PR DESCRIPTION
## Overview

Draft PR collecting a series of AVX2 optimizations to the HTJ2K block coder
(encoder and decoder), plus supporting architecture-detection and CI changes.
Opening as a draft for early feedback.

Organized into logical commits — generic/arch, AVX2 decoder, AVX2 encoder,
followed by a second round of decoder work (bitstream de-stuffing) and two
fixes (CI runner image, strict-aliasing) — rebased on the current `master`.

## What's included

**AVX2 block decoder** (`ojph_block_decoder_avx2.cpp`, `ojph_block_common.*`)
- Wide UVLC table for non-initial quad rows, combined with a merged dual
  MagSgn fetch and a widened `frwd_advance`; reduced `memset` of the scratch
  buffer.
- Force-inline `decode_two_quad32_avx2` (MSVC-guarded `__forceinline`).
- Decompose the ~770-line `ojph_decode_codeblock_avx2` into a thin dispatcher
  over four `noinline` helpers (`decode_cb_step1_vlc`, `decode_cb_step2_32bit`,
  `decode_cb_step2_16bit`, `decode_cb_spp_mrp`). This isolates each pass's
  register allocation and cuts spilling in the hot step-1 VLC loop.
- **De-stuffed bitstream readers** (second round): each codeblock's MagSgn,
  SPP, VLC, and MRP segments are un-stuffed once into a flat buffer, from
  which bits are fetched at absolute positions (MagSgn/SPP) or through a
  branchless register-resident window (VLC). Since the per-quad bit counts
  depend only on VLC outputs, the loop-carried dependency in the MagSgn pass
  collapses to a single scalar add, and all refill/unstuffing branches leave
  the hot loops. Full-decode branch misses drop ~50–75% and IPC rises from
  ~3.0 to ~3.3–3.5; the stateful `frwd`/`rev` reader machinery is deleted
  from this file. Also replaces the 14-instruction `_mm256_sllv_epi16`
  emulation with a 6-instruction pshufb power-of-two lookup + 16-bit
  multiply.
- Fix pre-existing strict-aliasing violations in this file (type-punned
  `*(ui32*)` accesses in the SPP/MRP and MEL readers, now `memcpy`): GCC
  15/16 on MinGW started miscompiling the SPP pass via TBAA-driven
  dead-store elimination once surrounding code changed. The same punned
  patterns still exist in the other (non-AVX2) block decoder files — see
  #279.

**AVX2 block encoder** (`ojph_block_encoder_avx2.cpp`, `ojph_block_encoder_avx2_apple.h`)
- Branch-overhead reductions in the MEL, MagSgn, and VLC paths.
- Apple-Clang/Intel fallback in a separate header to work around a codegen
  issue observed on that toolchain.

**Architecture / build** (`ojph_arch.*`, CI workflow)
- 64-bit `count_trailing_zeros`, tightened AVX-512 detection, Release CI build.
- CI: `windows-latest` now resolves to the `windows-2025-vs2026` image
  (no Visual Studio 17 2022); the x64 Windows jobs let CMake auto-detect
  the installed Visual Studio instead of hardcoding the generator.

## Correctness & testing

- Decoder output is **byte-identical** to the pre-change build across 8-bit
  (64×64 and 512×8 code-blocks), 16-bit, and lossy inputs, including
  Kakadu-encoded multipass HT codestreams (CUP+SPP+MRP), truncated-stream
  and corrupted-byte cases (identical output or identical error).
- Full `ctest` suite passes (82/82) on Linux/GCC 14 and Windows-MSYS2/GCC 16;
  ASAN and valgrind clean.
- Cross-platform CI is green on the fork: Windows/MSVC, Windows-MSYS2/MinGW,
  macOS Intel + ARM (Apple Clang), Windows-on-ARM, Ubuntu, and EMCC.

## Performance (AMD Zen 5 / GCC, Release, AVX2 tier)

Measured with `-DOJPH_DISABLE_AVX512=ON` so the AVX2 paths are the active
tier. (On AVX-512 hardware the runtime otherwise dispatches to the existing
AVX-512 code in *both* builds, leaving these AVX2 changes dormant; AVX-512
ports of these optimizations are planned as a separate follow-up.) Baseline
is upstream `master`; figures are the median of 11 pinned single-core runs of
the full `ojph_compress` / `ojph_expand`. **Encoded bitstreams and decoded
outputs are byte-identical** between master and this PR — these are pure
performance changes.

| Workload (4K, reversible 5/3 unless noted) | Encode | Decode |
|---|--:|--:|
| 8-bit, 64×64 code-blocks    | **1.91×** | **1.19×** |
| 8-bit, 512×8 code-blocks    | **1.94×** | **1.17×** |
| 8-bit, lossy (qstep 0.005)  | 1.49×     | 1.15×     |
| 16-bit, 64×64 code-blocks   | **1.80×** | **1.29×** |

The encoder gains come from the reduced branch overhead in the MEL / MagSgn /
VLC paths; the decoder gains from the wide UVLC table + merged MagSgn fetch,
the cleanup-pass decomposition, and (second round) the de-stuffed bitstream
readers that remove the serial fetch/advance state and its branches from all
hot loops.

## Status

Draft — opened for early feedback; rebased on the current `master`.
