### PR TITLE
Bug fix

### DIFF
--- a/src/core/codestream/ojph_codeblock.cpp
+++ b/src/core/codestream/ojph_codeblock.cpp
@@ -3,21 +3,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman 
+// Copyright (c) 2019, Aous Naman
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -53,7 +53,7 @@ namespace ojph {
   {
 
     //////////////////////////////////////////////////////////////////////////
-    void codeblock::pre_alloc(codestream *codestream, const size& nominal, 
+    void codeblock::pre_alloc(codestream *codestream, const size& nominal,
                               ui32 precision)
     {
       mem_fixed_allocator* allocator = codestream->get_allocator();
@@ -61,7 +61,7 @@ namespace ojph {
       assert(byte_alignment / sizeof(ui32) > 1);
       const ui32 f = byte_alignment / sizeof(ui32) - 1;
       ui32 stride = (nominal.w + f) & ~f; // a multiple of 8
-      
+
       if (precision <= 32)
         allocator->pre_alloc_data<ui32>(nominal.h * (size_t)stride, 0);
       else
@@ -114,23 +114,23 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     void codeblock::push(line_buf *line)
     {
-      // convert to sign and magnitude and keep max_val      
+      // convert to sign and magnitude and keep max_val
       if (precision == BUF32)
       {
         assert(line->flags & line_buf::LFT_32BIT);
         const si32 *sp = line->i32 + line_offset;
         ui32 *dp = buf32 + cur_line * stride;
-        this->codeblock_functions.tx_to_cb32(sp, dp, K_max, delta_inv, 
+        this->codeblock_functions.tx_to_cb32(sp, dp, K_max, delta_inv,
                                              cb_size.w, max_val32);
         ++cur_line;
       }
-      else 
+      else
       {
         assert(precision == BUF64);
         assert(line->flags & line_buf::LFT_64BIT);
         const si64 *sp = line->i64 + line_offset;
         ui64 *dp = buf64 + cur_line * stride;
-        this->codeblock_functions.tx_to_cb64(sp, dp, K_max, delta_inv, 
+        this->codeblock_functions.tx_to_cb64(sp, dp, K_max, delta_inv,
                                              cb_size.w, max_val64);
         ++cur_line;
       }
@@ -148,7 +148,7 @@ namespace ojph {
           assert(coded_cb->missing_msbs > 0);
           assert(coded_cb->missing_msbs < K_max);
           coded_cb->num_passes = 1;
-          
+
           this->codeblock_functions.encode_cb32(buf32, K_max-1, 1,
             cb_size.w, cb_size.h, stride, coded_cb->pass_length,
             elastic, coded_cb->next_coded);
@@ -164,7 +164,7 @@ namespace ojph {
           assert(coded_cb->missing_msbs > 0);
           assert(coded_cb->missing_msbs < K_max);
           coded_cb->num_passes = 1;
-          
+
           this->codeblock_functions.encode_cb64(buf64, K_max-1, 1,
             cb_size.w, cb_size.h, stride, coded_cb->pass_length,
             elastic, coded_cb->next_coded);
@@ -199,7 +199,7 @@ namespace ojph {
             coded_cb->pass_length[0], coded_cb->pass_length[1],
             cb_size.w, cb_size.h, stride, stripe_causal);
         }
-        else 
+        else
         {
           assert(precision == BUF64);
           result = this->codeblock_functions.decode_cb64(
@@ -235,7 +235,7 @@ namespace ojph {
         if (!zero_block)
         {
           const ui32 *sp = buf32 + cur_line * stride;
-          this->codeblock_functions.tx_from_cb32(sp, dp, K_max, delta, 
+          this->codeblock_functions.tx_from_cb32(sp, dp, K_max, delta,
                                                  cb_size.w);
         }
         else
@@ -244,12 +244,13 @@ namespace ojph {
       else
       {
         assert(precision == BUF64);
-        assert(line->flags & line_buf::LFT_64BIT);
+        assert((reversible && (line->flags & line_buf::LFT_64BIT))
+               || (!reversible && (line->flags & line_buf::LFT_32BIT)));
         si64 *dp = line->i64 + line_offset;
         if (!zero_block)
         {
           const ui64 *sp = buf64 + cur_line * stride;
-          this->codeblock_functions.tx_from_cb64(sp, dp, K_max, delta, 
+          this->codeblock_functions.tx_from_cb64(sp, dp, K_max, delta,
                                                  cb_size.w);
         }
         else

--- a/src/core/codestream/ojph_codeblock_fun.cpp
+++ b/src/core/codestream/ojph_codeblock_fun.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman 
+// Copyright (c) 2019, Aous Naman
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -124,8 +124,10 @@ namespace ojph {
                                float delta, ui32 count);
     void avx2_rev_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max,
                                float delta, ui32 count);
+    void gen_irv_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max,
+                              float delta, ui32 count);
     void wasm_rev_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max,
-                               float delta, ui32 count);                               
+                               float delta, ui32 count);
 
     void codeblock_fun::init(bool reversible) {
 
@@ -155,11 +157,11 @@ namespace ojph {
       else
       {
         tx_to_cb64 = NULL;
-        tx_from_cb64 = NULL;
+        tx_from_cb64 = gen_irv_tx_from_cb64;
       }
       encode_cb64 = ojph_encode_codeblock64;
       bool result = initialize_block_encoder_tables();
-      assert(result); ojph_unused(result);      
+      assert(result); ojph_unused(result);
 
   #ifndef OJPH_DISABLE_SIMD
 
@@ -190,7 +192,7 @@ namespace ojph {
           else
           {
             tx_to_cb64 = NULL;
-            tx_from_cb64 = NULL;
+            tx_from_cb64 = gen_irv_tx_from_cb64;
           }
         }
       #endif // !OJPH_DISABLE_SSE2
@@ -229,7 +231,7 @@ namespace ojph {
           else
           {
             tx_to_cb64 = NULL;
-            tx_from_cb64 = NULL;
+            tx_from_cb64 = gen_irv_tx_from_cb64;
           }
         }
       #endif // !OJPH_DISABLE_AVX2
@@ -243,7 +245,7 @@ namespace ojph {
       #endif // !OJPH_DISABLE_AVX512
 
     #elif defined(OJPH_ARCH_ARM)
-    
+
     #endif // !(defined(OJPH_ARCH_X86_64) || defined(OJPH_ARCH_I386))
 
   #endif // !OJPH_DISABLE_SIMD
@@ -273,11 +275,11 @@ namespace ojph {
       else
       {
         tx_to_cb64 = NULL;
-        tx_from_cb64 = NULL;
+        tx_from_cb64 = gen_irv_tx_from_cb64;
       }
       encode_cb64 = ojph_encode_codeblock64;
       bool result = initialize_block_encoder_tables();
-      assert(result); ojph_unused(result);      
+      assert(result); ojph_unused(result);
 
 #endif // !OJPH_ENABLE_WASM_SIMD
 

--- a/src/core/codestream/ojph_codestream_gen.cpp
+++ b/src/core/codestream/ojph_codestream_gen.cpp
@@ -35,6 +35,8 @@
 // Date: 15 May 2022
 //***************************************************************************/
 
+#include <climits>
+
 #include "ojph_defs.h"
 #include "ojph_arch.h"
 

--- a/src/core/codestream/ojph_codestream_gen.cpp
+++ b/src/core/codestream/ojph_codestream_gen.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2022, Aous Naman 
+// Copyright (c) 2022, Aous Naman
 // Copyright (c) 2022, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2022, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -56,8 +56,8 @@ namespace ojph {
     ui64 gen_find_max_val64(ui64* addr) { return addr[0]; }
 
     //////////////////////////////////////////////////////////////////////////
-    void gen_rev_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max, 
-                            float delta_inv, ui32 count, 
+    void gen_rev_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
+                            float delta_inv, ui32 count,
                             ui32* max_val)
     {
       ojph_unused(delta_inv);
@@ -78,8 +78,8 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void gen_rev_tx_to_cb64(const void *sp, ui64 *dp, ui32 K_max, 
-                            float delta_inv, ui32 count, 
+    void gen_rev_tx_to_cb64(const void *sp, ui64 *dp, ui32 K_max,
+                            float delta_inv, ui32 count,
                             ui64* max_val)
     {
       ojph_unused(delta_inv);
@@ -101,7 +101,7 @@ namespace ojph {
 
     //////////////////////////////////////////////////////////////////////////
     void gen_irv_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
-                            float delta_inv, ui32 count, 
+                            float delta_inv, ui32 count,
                             ui32* max_val)
     {
       ojph_unused(K_max);
@@ -166,6 +166,21 @@ namespace ojph {
         *p++ = (v & 0x80000000U) ? -val : val;
       }
     }
-    
+
+    //////////////////////////////////////////////////////////////////////////
+    void gen_irv_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max,
+                              float delta, ui32 count)
+    {
+      ojph_unused(K_max);
+      //convert to sign and magnitude
+      float *p = (float*)dp;
+      for (ui32 i = count; i > 0; --i)
+      {
+        ui64 v = *sp++;
+        float val = (float)(v & LLONG_MAX) * delta;
+        *p++ = (v & LLONG_MIN) ? -val : val;
+      }
+    }
+
  }
 }

--- a/src/core/codestream/ojph_codestream_gen.cpp
+++ b/src/core/codestream/ojph_codestream_gen.cpp
@@ -180,7 +180,7 @@ namespace ojph {
       {
         ui64 v = *sp++;
         float val = (float)(v & LLONG_MAX) * delta;
-        *p++ = (v & LLONG_MIN) != 0 ? -val : val;
+        *p++ = (v & (ui64)LLONG_MIN) ? -val : val;
       }
     }
 

--- a/src/core/codestream/ojph_codestream_gen.cpp
+++ b/src/core/codestream/ojph_codestream_gen.cpp
@@ -180,7 +180,7 @@ namespace ojph {
       {
         ui64 v = *sp++;
         float val = (float)(v & LLONG_MAX) * delta;
-        *p++ = (v & LLONG_MIN) ? -val : val;
+        *p++ = (v & LLONG_MIN) != 0 ? -val : val;
       }
     }
 

--- a/src/core/codestream/ojph_params.cpp
+++ b/src/core/codestream/ojph_params.cpp
@@ -2649,7 +2649,7 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     param_atk* param_atk::add_object()
     {
-      assert(top_atk = NULL);
+      assert(top_atk == NULL);
       param_atk *p = this;
       while (p->next != NULL)
         p = p->next;


### PR DESCRIPTION
This has two bug fixes.
1. It defines the function `gen_irv_tx_from_cb64`, which should be rarely called -- it makes little sense that someone creates a lossy bitstream, and then uses a needlessly fine quantization.  For this reason, I did not bother defining corresponding sse2, avx2, or wasm variants; some of these accelerated functions require work.
2. There was a bug in one assert function `assert(top_atk == NULL);`.