### PR TITLE
Fix 32-bit x86 build of the AVX2 block decoder

### DIFF
--- a/src/core/coding/ojph_block_decoder_avx2.cpp
+++ b/src/core/coding/ojph_block_decoder_avx2.cpp
@@ -529,8 +529,15 @@ namespace ojph {
         __m128i r = _mm_shuffle_epi8(v,
             _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7,
                          8, 9, 10, 11, 12, 13, 14, 15)); // reverse bytes
+#ifdef OJPH_ARCH_X86_64
         ui64 v0 = (ui64)_mm_cvtsi128_si64(r);
         ui64 v1 = (ui64)_mm_extract_epi64(r, 1);
+#else // 32-bit x86 lacks the 64-bit extract intrinsics
+        ui64 v0 = (ui32)_mm_cvtsi128_si32(r)
+                | ((ui64)(ui32)_mm_extract_epi32(r, 1) << 32);
+        ui64 v1 = (ui32)_mm_extract_epi32(r, 2)
+                | ((ui64)(ui32)_mm_extract_epi32(r, 3) << 32);
+#endif
         ui64 w0 = acc | (v0 << nb);
         ui64 w1 = (v1 << nb) | (nb ? (v0 >> (64 - nb)) : 0);
         memcpy(o, &w0, 8);


### PR DESCRIPTION
Fixes #280.

## Problem

The destuffing fast path added in #276 (released in 0.28.0) uses `_mm_cvtsi128_si64` and `_mm_extract_epi64` in `ojph_block_decoder_avx2.cpp`. These intrinsics only exist when targeting x86-64, so the file no longer compiles on 32-bit x86 (e.g. MSYS2 MinGW32 with `-march=pentium4`, as reported in #280).

## Fix

On i386, assemble the two 64-bit halves from 32-bit extracts instead (`_mm_cvtsi128_si32` / `_mm_extract_epi32`, both available in a `-mavx2` TU). This mirrors the `OJPH_ARCH_X86_64` / i386 split that `proc_cq2` in `ojph_block_encoder_avx2.cpp` already uses for the same reason — the decoder was the one place that missed the guard. I checked the whole tree for other 64-bit-only intrinsics; these two lines are the only occurrence, so this should be the complete fix for #280.

Note this is a compile-time issue only: at runtime the AVX2 path is gated by CPU dispatch, so a `-march=pentium4` build never executes it on hardware without AVX2.

## Verification

- The exact i386 fallback pattern compiles cleanly with GCC `-m32 -mavx2 -Wall -Wextra` (I don't have a full 32-bit MinGW toolchain at hand, so the complete TU was not built for 32-bit — confirmation from @kmilos's environment would be welcome).
- The x86-64 path is unchanged: disassembly of the TU before/after is byte-identical except for `__LINE__` constants in assert strings.
- Full test suite passes (82/82) on Linux x86-64 GCC 14, Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)