### PR TITLE
AVX2 decoder: N-way codeblock interleave for the step-1 VLC/MEL decode

### DIFF
--- a/src/core/codestream/ojph_codeblock.cpp
+++ b/src/core/codestream/ojph_codeblock.cpp
@@ -223,6 +223,85 @@ namespace ojph {
         zero_block = true;
     }
 
+    //////////////////////////////////////////////////////////////////////////
+    void codeblock::decode_row(codeblock* blocks, ui32 count)
+    {
+      if (count == 0)
+        return;
+
+      // No batched path (the active ISA provides none, or 64-bit codeblocks):
+      // decode each block individually, preserving the exact 1-way behaviour.
+      codeblock_fun& f = blocks[0].codeblock_functions;
+      if (f.decode_cb32_batch == NULL || blocks[0].precision != BUF32)
+      {
+        for (ui32 i = 0; i < count; ++i)
+          blocks[i].decode();
+        return;
+      }
+
+      // Gather the decodable blocks of this row into parallel arrays and hand
+      // them to the batched decoder in windows. All blocks in a subband row
+      // share height (cb_size.h) and stride; only width and the coded data
+      // differ. Zero blocks (no coded passes) are marked directly and left
+      // out of the batch.
+      const ui32 WIN = 64;
+      ui8*  coded[WIN];
+      ui32* dec[WIN];
+      ui32  mmsb[WIN], npass[WIN], len1[WIN], len2[WIN], wid[WIN], orig[WIN];
+      bool  res[WIN];
+
+      const ui32 height = blocks[0].cb_size.h;
+      const ui32 stride = blocks[0].stride;
+      const bool sc     = blocks[0].stripe_causal;
+      ui32 filled = 0;
+
+      for (ui32 i = 0; i <= count; ++i)
+      {
+        if (i < count)
+        {
+          codeblock& cb = blocks[i];
+          coded_cb_header* cc = cb.coded_cb;
+          if (cc->pass_length[0] > 0 && cc->num_passes > 0 &&
+              cc->next_coded != NULL)
+          {
+            coded[filled] = cc->next_coded->buf +
+                            coded_cb_header::prefix_buf_size;
+            dec[filled]   = cb.buf32;
+            mmsb[filled]  = cc->missing_msbs;
+            npass[filled] = cc->num_passes;
+            len1[filled]  = cc->pass_length[0];
+            len2[filled]  = cc->pass_length[1];
+            wid[filled]   = cb.cb_size.w;
+            orig[filled]  = i;
+            ++filled;
+          }
+          else
+            cb.zero_block = true;
+        }
+
+        // Flush when the window is full or at the end of the row.
+        if (filled == WIN || (i == count && filled > 0))
+        {
+          f.decode_cb32_batch(filled, coded, dec, mmsb, npass, len1, len2,
+                              wid, height, stride, sc, res);
+          for (ui32 j = 0; j < filled; ++j)
+          {
+            if (!res[j])
+            {
+              codeblock& cb = blocks[orig[j]];
+              if (cb.resilient == true) {
+                OJPH_INFO(0x000300A2, "Error decoding a codeblock.");
+                cb.zero_block = true;
+              }
+              else
+                OJPH_ERROR(0x000300A2, "Error decoding a codeblock.");
+            }
+          }
+          filled = 0;
+        }
+      }
+    }
+
 
     //////////////////////////////////////////////////////////////////////////
     void codeblock::pull_line(line_buf *line)

--- a/src/core/codestream/ojph_codeblock.h
+++ b/src/core/codestream/ojph_codeblock.h
@@ -82,6 +82,10 @@ namespace ojph {
       void recreate(const size& cb_size, coded_cb_header* coded_cb);
 
       void decode();
+      // Decode a whole subband row of codeblocks. Uses the batched (N-way
+      // interleaved) block decoder when the active ISA provides one, else
+      // decodes each block individually.
+      static void decode_row(codeblock* blocks, ui32 count);
       void pull_line(line_buf *line);
 
     private:

--- a/src/core/codestream/ojph_codeblock_fun.cpp
+++ b/src/core/codestream/ojph_codeblock_fun.cpp
@@ -135,6 +135,7 @@ namespace ojph {
 
       // Default path, no acceleration.  We may change this later
       decode_cb32 = ojph_decode_codeblock32;
+      decode_cb32_batch = NULL; // set only by ISAs that provide a batch path
       find_max_val32 = gen_find_max_val32;
       mem_clear = gen_mem_clear;
       if (reversible) {

--- a/src/core/codestream/ojph_codeblock_fun.cpp
+++ b/src/core/codestream/ojph_codeblock_fun.cpp
@@ -211,6 +211,7 @@ namespace ojph {
       #ifndef OJPH_DISABLE_AVX2
         if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_AVX2) {
           decode_cb32 = ojph_decode_codeblock_avx2;
+          decode_cb32_batch = ojph_decode_codeblock_avx2_batch;
           find_max_val32 = avx2_find_max_val32;
           if (reversible) {
             tx_to_cb32 = avx2_rev_tx_to_cb32;

--- a/src/core/codestream/ojph_codeblock_fun.h
+++ b/src/core/codestream/ojph_codeblock_fun.h
@@ -74,6 +74,14 @@ namespace ojph {
       ui32 missing_msbs, ui32 num_passes, ui32 lengths1, ui32 lengths2,
       ui32 width, ui32 height, ui32 stride, bool stripe_causal);
 
+    // define the batched (multi-codeblock) decoder function signature
+    typedef void (*cb_decoder_batch_fun32)(ui32 n,
+      ui8* const* coded_data, ui32* const* decoded_data,
+      const ui32* missing_msbs, const ui32* num_passes,
+      const ui32* lengths1, const ui32* lengths2,
+      const ui32* widths, ui32 height, ui32 stride,
+      bool stripe_causal, bool* results);
+
     typedef bool (*cb_decoder_fun64)(ui8* coded_data, ui64* decoded_data,
       ui32 missing_msbs, ui32 num_passes, ui32 lengths1, ui32 lengths2,
       ui32 width, ui32 height, ui32 stride, bool stripe_causal);
@@ -112,6 +120,9 @@ namespace ojph {
       // a pointer to the decoder function
       cb_decoder_fun32 decode_cb32;
       cb_decoder_fun64 decode_cb64;
+
+      // optional batched 32-bit decoder (NULL if the active ISA has none)
+      cb_decoder_batch_fun32 decode_cb32_batch;
 
       // a pointer to the encoder function
       cb_encoder_fun32 encode_cb32;

--- a/src/core/codestream/ojph_subband.cpp
+++ b/src/core/codestream/ojph_subband.cpp
@@ -364,8 +364,10 @@ namespace ojph {
             cb_size.w = cbx1 - cbx0;
             blocks[i].recreate(cb_size,
                                coded_cbs + i + cur_cb_row * num_blocks.w);
-            blocks[i].decode();
           }
+          // Decode the whole row at once so the batched (N-way interleaved)
+          // block decoder can overlap independent codeblocks' VLC/MEL chains.
+          codeblock::decode_row(blocks, num_blocks.w);
           ++cur_cb_row;
         }
       }

--- a/src/core/coding/ojph_block_decoder.h
+++ b/src/core/coding/ojph_block_decoder.h
@@ -71,6 +71,17 @@ namespace ojph {
         ui32 missing_msbs, ui32 num_passes, ui32 lengths1, ui32 lengths2,
         ui32 width, ui32 height, ui32 stride, bool stripe_causal);
 
+    // AVX2 batched decoder: N-way interleaves the step-1 VLC/MEL chains of
+    // same-width codeblocks in a subband row. Parallel arrays of length n;
+    // height/stride shared. results[k] receives each block's success flag.
+    void
+      ojph_decode_codeblock_avx2_batch(ui32 n,
+        ui8* const* coded_data, ui32* const* decoded_data,
+        const ui32* missing_msbs, const ui32* num_passes,
+        const ui32* lengths1, const ui32* lengths2,
+        const ui32* widths, ui32 height, ui32 stride,
+        bool stripe_causal, bool* results);
+
     // WASM SIMD-accelerated decoder
     bool
       ojph_decode_codeblock_wasm(ui8* coded_data, ui32* decoded_data,

--- a/src/core/coding/ojph_block_decoder_avx2.cpp
+++ b/src/core/coding/ojph_block_decoder_avx2.cpp
@@ -1816,30 +1816,209 @@ namespace ojph {
         }
     }
 
-    bool ojph_decode_codeblock_avx2(ui8* coded_data, ui32* decoded_data,
-                                    ui32 missing_msbs, ui32 num_passes,
-                                    ui32 lengths1, ui32 lengths2,
-                                    ui32 width, ui32 height, ui32 stride,
-                                    bool stripe_causal)
+    //************************************************************************/
+    /** @brief N-way interleaved step-1 VLC/MEL decode.
+     *
+     *  Decodes N independent codeblocks of identical width/height/sstr in
+     *  lockstep. The per-stream serial state lives in N-element arrays and
+     *  every per-stream step is a fully-unrolled loop, so the out-of-order
+     *  engine overlaps the N otherwise-serial VLC/MEL dependency chains.
+     *  Byte-identical to N invocations of decode_cb_step1_vlc. The step-1
+     *  kernel is pure scalar and shared verbatim with the AVX-512 decoder,
+     *  where N=4 measured IPC 3.25 -> 4.90 / -24% kernel cycles on Zen 5.
+     */
+    template<int N>
+    OJPH_NO_INLINE
+    void decode_cb_step1_vlc_nway(
+        ui16* const scr[N], ui8* const cd[N],
+        const int lcup[N], const int scup[N],
+        ui32 width, ui32 height, ui32 sstr)
+    {
+        const ui32 vlc_cap = 4096;
+        dec_mel_st mel[N];
+        ui8 vlc_buf[N][vlc_cap + 72];
+        ui32 vlc_limit[N], vlc_off[N], vlc_bits[N];
+        ui64 vlc_val[N];
+        int run[N];
+        ui32 c_q[N];
+        ui16* sp[N];
+
+        for (int s = 0; s < N; ++s) {
+            mel_init(&mel[s], cd[s], lcup[s], scup[s]);
+            vlc_limit[s] = destuff_vlc(cd[s], lcup[s], scup[s],
+                                       vlc_buf[s], vlc_cap);
+            vlc_off[s] = 0; vlc_bits[s] = 0; vlc_val[s] = 0;
+            run[s] = mel_get_run(&mel[s]);
+            c_q[s] = 0; sp[s] = scr[s];
+        }
+
+        // initial quad row
+        for (ui32 x = 0; x < width; )
+        {
+          ui16 t0[N], t1[N];
+          OJPH_UNROLL
+          for (int s = 0; s < N; ++s)
+            drefill(vlc_val[s], vlc_bits[s], vlc_off[s], vlc_buf[s],
+                    vlc_limit[s]);
+          OJPH_UNROLL
+          for (int s = 0; s < N; ++s) {
+            t0[s] = vlc_tbl0[ c_q[s] + (vlc_val[s] & 0x7F) ];
+            if (c_q[s] == 0) { run[s] -= 2; t0[s] = (run[s]==-1)?t0[s]:0;
+              if (run[s] < 0) run[s] = mel_get_run(&mel[s]); }
+            sp[s][0] = t0[s];
+            c_q[s] = ((t0[s] & 0x10U) << 3) | ((t0[s] & 0xE0U) << 2);
+            dconsume(vlc_val[s], vlc_bits[s], t0[s] & 0x7u);
+          }
+          x += 2;
+          bool xlt = x < width;
+          OJPH_UNROLL
+          for (int s = 0; s < N; ++s) {
+            t1[s] = vlc_tbl0[c_q[s] + (vlc_val[s] & 0x7F)];
+            if (c_q[s] == 0 && xlt) { run[s] -= 2; t1[s] = (run[s]==-1)?t1[s]:0;
+              if (run[s] < 0) run[s] = mel_get_run(&mel[s]); }
+            t1[s] = xlt ? t1[s] : 0;
+            sp[s][2] = t1[s];
+            c_q[s] = ((t1[s] & 0x10U) << 3) | ((t1[s] & 0xE0U) << 2);
+            dconsume(vlc_val[s], vlc_bits[s], t1[s] & 0x7u);
+          }
+          x += 2;
+          OJPH_UNROLL
+          for (int s = 0; s < N; ++s) {
+            ui32 um = ((t0[s] & 0x8U) << 3) | ((t1[s] & 0x8U) << 4);
+            if (um == 0xc0) { run[s] -= 2; um += (run[s]==-1)?0x40:0;
+              if (run[s] < 0) run[s] = mel_get_run(&mel[s]); }
+            ui32 ue = uvlc_tbl0[um + (vlc_val[s] & 0x3F)];
+            dconsume(vlc_val[s], vlc_bits[s], ue & 0x7u);
+            ue >>= 3;
+            ui32 len = ue & 0xF;
+            ui32 tmp = (ui32)vlc_val[s] & ((1u << len) - 1);
+            dconsume(vlc_val[s], vlc_bits[s], len);
+            ue >>= 4;
+            len = ue & 0x7; ue >>= 3;
+            sp[s][1] = (ui16)(1 + (ue&7) + (tmp&~(0xFFU<<len)));
+            sp[s][3] = (ui16)(1 + (ue >> 3) + (tmp >> len));
+            sp[s] += 4;
+          }
+        }
+        OJPH_UNROLL
+        for (int s = 0; s < N; ++s) { sp[s][0] = sp[s][1] = 0; }
+
+        // non-initial quad rows
+        for (ui32 y = 2; y < height; y += 2)
+        {
+          ui16* rp[N];
+          OJPH_UNROLL
+          for (int s = 0; s < N; ++s) {
+            c_q[s] = 0; rp[s] = scr[s] + (y >> 1) * sstr;
+          }
+          for (ui32 x = 0; x < width; )
+          {
+            ui16 t0[N], t1[N];
+            OJPH_UNROLL
+            for (int s = 0; s < N; ++s) {
+              c_q[s] |= ((rp[s][0 - (si32)sstr] & 0xA0U) << 2);
+              c_q[s] |= ((rp[s][2 - (si32)sstr] & 0x20U) << 4);
+              drefill(vlc_val[s], vlc_bits[s], vlc_off[s], vlc_buf[s],
+                      vlc_limit[s]);
+            }
+            OJPH_UNROLL
+            for (int s = 0; s < N; ++s) {
+              t0[s] = vlc_tbl1[ c_q[s] + (vlc_val[s] & 0x7F) ];
+              if (c_q[s] == 0) { run[s] -= 2; t0[s] = (run[s]==-1)?t0[s]:0;
+                if (run[s] < 0) run[s] = mel_get_run(&mel[s]); }
+              rp[s][0] = t0[s];
+            }
+            x += 2;
+            OJPH_UNROLL
+            for (int s = 0; s < N; ++s) {
+              c_q[s] = ((t0[s] & 0x40U) << 2) | ((t0[s] & 0x80U) << 1);
+              c_q[s] |= rp[s][0 - (si32)sstr] & 0x80;
+              c_q[s] |= ((rp[s][2 - (si32)sstr] & 0xA0U) << 2);
+              c_q[s] |= ((rp[s][4 - (si32)sstr] & 0x20U) << 4);
+              dconsume(vlc_val[s], vlc_bits[s], t0[s] & 0x7u);
+            }
+            bool xlt = x < width;
+            OJPH_UNROLL
+            for (int s = 0; s < N; ++s) {
+              t1[s] = vlc_tbl1[ c_q[s] + (vlc_val[s] & 0x7F)];
+              if (c_q[s] == 0 && xlt) { run[s] -= 2; t1[s] = (run[s]==-1)?t1[s]:0;
+                if (run[s] < 0) run[s] = mel_get_run(&mel[s]); }
+              t1[s] = xlt ? t1[s] : 0;
+              rp[s][2] = t1[s];
+            }
+            x += 2;
+            OJPH_UNROLL
+            for (int s = 0; s < N; ++s) {
+              c_q[s] = ((t1[s] & 0x40U) << 2) | ((t1[s] & 0x80U) << 1);
+              c_q[s] |= rp[s][2 - (si32)sstr] & 0x80;
+              dconsume(vlc_val[s], vlc_bits[s], t1[s] & 0x7u);
+
+              ui32 um = (((t0[s] >> 3) & 1) | (((t1[s] >> 3) & 1) << 1));
+              ui32 ue = uvlc_tbl1_wide[(um << 10) | (vlc_val[s] & 0x3FF)];
+              ui32 tb = ue & 0x1F;
+              if (tb < 0x1F) {
+                rp[s][1] = (ui16)((ue >> 5) & 0xFF);
+                rp[s][3] = (ui16)((ue >> 13) & 0xFF);
+                dconsume(vlc_val[s], vlc_bits[s], tb);
+              } else {
+                um = ((t0[s] & 0x8U) << 3) | ((t1[s] & 0x8U) << 4);
+                ue = uvlc_tbl1[um + (vlc_val[s] & 0x3F)];
+                dconsume(vlc_val[s], vlc_bits[s], ue & 0x7u);
+                ue >>= 3;
+                ui32 len = ue & 0xF;
+                ui32 tmp = (ui32)vlc_val[s] & ((1u << len) - 1);
+                dconsume(vlc_val[s], vlc_bits[s], len);
+                ue >>= 4;
+                len = ue & 0x7; ue >>= 3;
+                rp[s][1] = (ui16)((ue & 7) + (tmp & ~(0xFFU << len)));
+                rp[s][3] = (ui16)((ue >> 3) + (tmp >> len));
+              }
+              rp[s] += 4;
+            }
+          }
+          OJPH_UNROLL
+          for (int s = 0; s < N; ++s) { rp[s][0] = rp[s][1] = 0; }
+        }
+    }
+
+    //************************************************************************/
+    /** @brief Per-codeblock decode setup: validation + lcup/scup/p/mmsbp2.
+     *  Shared by the 1-way entry and the batched entry so there is a single
+     *  source of truth. ok=false means the block must not be decoded (the
+     *  caller treats it as a failed/zero block), matching the original
+     *  early-return behaviour of ojph_decode_codeblock_avx2.
+     */
+    struct cb_dec_params {
+      int lcup, scup;
+      ui32 p, mmsbp2, sstr, num_passes;
+      bool ok;
+    };
+
+    static cb_dec_params cb_decode_setup(ui8* coded_data, ui32 missing_msbs,
+                                         ui32 num_passes, ui32 lengths1,
+                                         ui32 lengths2, ui32 width)
     {
       static bool insufficient_precision = false;
       static bool modify_code = false;
       static bool truncate_spp_mrp = false;
+
+      cb_dec_params r;
+      r.ok = false;
+      r.num_passes = num_passes;
 
       if (num_passes > 1 && lengths2 == 0)
       {
         OJPH_WARN(0x00010001, "A malformed codeblock that has more than "
                               "one coding pass, but zero length for "
                               "2nd and potential 3rd pass.");
-        num_passes = 1;
+        r.num_passes = num_passes = 1;
       }
 
       if (num_passes > 3)
       {
         OJPH_WARN(0x00010002, "We do not support more than 3 coding passes; "
-                              "This codeblocks has %d passes.",
-                              num_passes);
-        return false;
+                              "This codeblocks has %d passes.", num_passes);
+        return r;
       }
 
       if (missing_msbs > 30) // p < 0
@@ -1851,10 +2030,10 @@ namespace ojph {
                                 "codeblock. This message will not be "
                                 "displayed again.");
         }
-        return false;
+        return r;
       }
       else if (missing_msbs == 30) // p == 0
-      { // not enough precision to decode and set the bin center to 1
+      {
         if (modify_code == false) {
           modify_code = true;
           OJPH_WARN(0x00010004, "Not enough precision to decode the cleanup "
@@ -1862,12 +2041,12 @@ namespace ojph {
                                 "this case. This message will not be "
                                 "displayed again.");
         }
-         return false;         // 32 bits are not enough to decode this
-       }
+        return r;
+      }
       else if (missing_msbs == 29) // if p is 1, then num_passes must be 1
       {
         if (num_passes > 1) {
-          num_passes = 1;
+          r.num_passes = num_passes = 1;
           if (truncate_spp_mrp == false) {
             truncate_spp_mrp = true;
             OJPH_WARN(0x00010005, "Not enough precision to decode the SgnProp "
@@ -1877,98 +2056,190 @@ namespace ojph {
           }
         }
       }
-      ui32 p = 30 - missing_msbs; // The least significant bitplane for CUP
-      // There is a way to handle the case of p == 0, but a different path
-      // is required
+      r.p = 30 - missing_msbs;
 
       if (lengths1 < 2)
       {
         OJPH_WARN(0x00010006, "Wrong codeblock length.");
-        return false;
+        return r;
       }
 
-      // read scup and fix the bytes there
       int lcup, scup;
-      lcup = (int)lengths1;  // length of CUP
-      //scup is the length of MEL + VLC
+      lcup = (int)lengths1;
       scup = (((int)coded_data[lcup-1]) << 4) + (coded_data[lcup-2] & 0xF);
-      if (scup < 2 || scup > lcup || scup > 4079) //something is wrong
-        return false;
+      if (scup < 2 || scup > lcup || scup > 4079)
+        return r;
 
-      // The temporary storage scratch holds two types of data in an
-      // interleaved fashion. The interleaving allows us to use one
-      // memory pointer.
-      // We have one entry for a decoded VLC code, and one entry for UVLC.
-      // Entries are 16 bits each, corresponding to one quad,
-      // but since we want to use XMM registers of the SSE family
-      // of SIMD; we allocated 16 bytes or more per quad row; that is,
-      // the width is no smaller than 16 bytes (or 8 entries), and the
-      // height is 512 quads
-      // Each VLC entry contains, in the following order, starting
-      // from MSB
-      // e_k (4bits), e_1 (4bits), rho (4bits), useless for step 2 (4bits)
-      // Each entry in UVLC contains u_q
-      // One extra row to handle the case of SPP propagating downwards
-      // when codeblock width is 4
-      // We need an extra two entries (one inf and one u_q) beyond
-      // the last column.
-      // If the block width is 4 (2 quads), then we use sstr of 8
-      // (enough for 4 quads). If width is 8 (4 quads) we use
-      // sstr is 16 (enough for 8 quads). For a width of 16 (8
-      // quads), we use 24 (enough for 12 quads).
-      ui32 sstr = ((width + 2u) + 7u) & ~7u; // multiples of 8
+      r.lcup = lcup;
+      r.scup = scup;
+      r.sstr = ((width + 2u) + 7u) & ~7u; // multiples of 8
+      r.mmsbp2 = missing_msbs + 2;
+      r.ok = true;
+      return r;
+    }
 
+    //************************************************************************/
+    /** @brief Per-codeblock decode finish: step-2 MagSgn + optional SPP/MRP.
+     *  Shared by the 1-way and batched entries. scratch must already hold the
+     *  step-1 output for this block.
+     */
+    static bool cb_decode_finish(ui16* scratch, ui32* decoded_data,
+                                 ui8* coded_data, ui32 width, ui32 height,
+                                 ui32 stride, const cb_dec_params& pr,
+                                 ui32 lengths1, ui32 lengths2,
+                                 bool stripe_causal)
+    {
+      if (pr.mmsbp2 >= 16)
+      {
+        if (!decode_cb_step2_32bit(scratch, decoded_data, coded_data,
+                                   width, height, stride, pr.sstr, pr.p,
+                                   pr.mmsbp2, pr.lcup, pr.scup))
+          return false;
+      }
+      else {
+        if (!decode_cb_step2_16bit(scratch, decoded_data, coded_data,
+                                   width, height, stride, pr.sstr, pr.p,
+                                   pr.mmsbp2, pr.lcup, pr.scup))
+          return false;
+      }
+
+      if (pr.num_passes > 1)
+        decode_cb_spp_mrp(scratch, decoded_data, coded_data, width, height,
+                          stride, pr.sstr, pr.p, pr.num_passes, lengths1,
+                          lengths2, stripe_causal);
+      return true;
+    }
+
+    //************************************************************************/
+    /** @brief Zero a step-1 scratch buffer for a codeblock of given height. */
+    static inline void cb_zero_scratch(ui16* scratch, ui32 height, ui32 sstr)
+    {
 #ifdef __MINGW64__
-      ui16 scratch[8 * 513] = {0};
+      memset(scratch, 0, 8 * 513 * sizeof(ui16));
+      (void)height; (void)sstr;
 #else
-      ui16 scratch[8 * 513];
       ui32 quad_rows = (height + 1u) >> 1;
       size_t scratch_zero = (size_t)(quad_rows + 1) * sstr;
       if (scratch_zero > 8 * 513) scratch_zero = 8 * 513;
       memset(scratch, 0, scratch_zero * sizeof(ui16));
 #endif
+    }
+
+    bool ojph_decode_codeblock_avx2(ui8* coded_data, ui32* decoded_data,
+                                    ui32 missing_msbs, ui32 num_passes,
+                                    ui32 lengths1, ui32 lengths2,
+                                    ui32 width, ui32 height, ui32 stride,
+                                    bool stripe_causal)
+    {
+      // Validate and derive per-block parameters (see cb_decode_setup).
+      cb_dec_params pr = cb_decode_setup(coded_data, missing_msbs, num_passes,
+                                         lengths1, lengths2, width);
+      if (!pr.ok)
+        return false;
 
       assert((stride & 0x3) == 0);
 
-      ui32 mmsbp2 = missing_msbs + 2;
-
-      // The cleanup pass is decoded in two steps; in step one,
-      // the VLC and MEL segments are decoded, generating a record that
-      // has 2 bytes per quad. The 2 bytes contain, u, rho, e^1 & e^k.
-      // This information should be sufficient for the next step.
-      // In step 2, we decode the MagSgn segment.
+      // The temporary storage scratch holds two types of data in an
+      // interleaved fashion (one decoded-VLC entry and one UVLC entry per
+      // quad, 16 bits each). See cb_zero_scratch for the zeroed extent.
+      ui16 scratch[8 * 513];
+      cb_zero_scratch(scratch, height, pr.sstr);
 
       // step 1: decode VLC and MEL segments into scratch
-      decode_cb_step1_vlc(scratch, coded_data, lcup, scup, width, height, sstr);
+      decode_cb_step1_vlc(scratch, coded_data, pr.lcup, pr.scup,
+                          width, height, pr.sstr);
 
-      // step2 we decode magsgn
-      // mmsbp2 equals K_max + 1 (we decode up to K_max bits + 1 sign bit)
-      // The 32 bit path decode 16 bits data, for which one would think
-      // 16 bits are enough, because we want to put in the center of the
-      // bin.
-      // If you have mmsbp2 equals 16 bit, and reversible coding, and
-      // no bitplanes are missing, then we can decoding using the 16 bit
-      // path, but we are not doing this here.
-      if (mmsbp2 >= 16)
+      // step 2 (MagSgn) + optional SPP/MRP
+      return cb_decode_finish(scratch, decoded_data, coded_data, width, height,
+                              stride, pr, lengths1, lengths2, stripe_causal);
+    }
+
+    //************************************************************************/
+    /** @brief Batched codeblock decode: N-way interleaves the step-1 VLC/MEL
+     *  chains of same-width neighbouring codeblocks to expose ILP, then runs
+     *  the per-block step-2 / SPP-MRP. Byte-identical to calling
+     *  ojph_decode_codeblock_avx2 on each block in turn.
+     *
+     *  Inputs are parallel arrays of length n (one entry per codeblock in a
+     *  subband row); height/stride are shared across the row. Blocks that
+     *  fail validation or whose width breaks a run are decoded 1-way.
+     */
+// Interleave depth for the batched step-1 kernel. N=2 is the AVX2 sweet spot
+// on Zen 5 (whole-decode -8 to -10% lossless): with the bulkier AVX2 step-2
+// running between batches, N=4's ~48KB step-1 working set saturates the 48KB
+// L1d and thrashes, and N=2 keeps the unrolled per-stream state in registers
+// even for the 32-bit (i386) build. The AVX-512 decoder, x86-64-only and with
+// a leaner native step-2, uses N=4.
+#ifndef OJPH_DEC_BATCH_N
+#define OJPH_DEC_BATCH_N 2
+#endif
+
+    void ojph_decode_codeblock_avx2_batch(ui32 n,
+        ui8* const* coded_data, ui32* const* decoded_data,
+        const ui32* missing_msbs, const ui32* num_passes,
+        const ui32* lengths1, const ui32* lengths2,
+        const ui32* widths, ui32 height, ui32 stride,
+        bool stripe_causal, bool* results)
+    {
+      const int BN = OJPH_DEC_BATCH_N;
+      ui16 scratch[OJPH_DEC_BATCH_N][8 * 513];
+
+      ui32 i = 0;
+      while (i < n)
       {
-        if (!decode_cb_step2_32bit(scratch, decoded_data, coded_data,
-                                   width, height, stride, sstr, p, mmsbp2,
-                                   lcup, scup))
-          return false;
-      }
-      else {
-        if (!decode_cb_step2_16bit(scratch, decoded_data, coded_data,
-                                   width, height, stride, sstr, p, mmsbp2,
-                                   lcup, scup))
-          return false;
-      }
+        // Try to form a full N-way group: BN consecutive blocks of equal
+        // width that all pass validation.
+        bool grouped = false;
+        if ((int)(n - i) >= BN)
+        {
+          ui32 w0 = widths[i];
+          cb_dec_params pr[OJPH_DEC_BATCH_N];
+          bool ok = true;
+          for (int k = 0; k < BN; ++k) {
+            if (widths[i + k] != w0) { ok = false; break; }
+            pr[k] = cb_decode_setup(coded_data[i + k], missing_msbs[i + k],
+                                    num_passes[i + k], lengths1[i + k],
+                                    lengths2[i + k], w0);
+            if (!pr[k].ok) { ok = false; break; }
+          }
+          if (ok)
+          {
+            ui16* scr[OJPH_DEC_BATCH_N];
+            ui8*  cd[OJPH_DEC_BATCH_N];
+            int   lc[OJPH_DEC_BATCH_N], sc[OJPH_DEC_BATCH_N];
+            for (int k = 0; k < BN; ++k) {
+              cb_zero_scratch(scratch[k], height, pr[k].sstr);
+              scr[k] = scratch[k];
+              cd[k]  = coded_data[i + k];
+              lc[k]  = pr[k].lcup;
+              sc[k]  = pr[k].scup;
+            }
+            decode_cb_step1_vlc_nway<OJPH_DEC_BATCH_N>(
+                scr, cd, lc, sc, w0, height, pr[0].sstr);
+            for (int k = 0; k < BN; ++k)
+              results[i + k] = cb_decode_finish(scratch[k],
+                  decoded_data[i + k], coded_data[i + k], w0, height, stride,
+                  pr[k], lengths1[i + k], lengths2[i + k], stripe_causal);
+            i += BN;
+            grouped = true;
+          }
+        }
+        if (grouped)
+          continue;
 
-      if (num_passes > 1)
-        decode_cb_spp_mrp(scratch, decoded_data, coded_data, width, height,
-                          stride, sstr, p, num_passes, lengths1, lengths2,
-                          stripe_causal);
-
-      return true;
+        // 1-way fallback for block i.
+        cb_dec_params pr = cb_decode_setup(coded_data[i], missing_msbs[i],
+                                           num_passes[i], lengths1[i],
+                                           lengths2[i], widths[i]);
+        if (!pr.ok) { results[i] = false; ++i; continue; }
+        cb_zero_scratch(scratch[0], height, pr.sstr);
+        decode_cb_step1_vlc(scratch[0], coded_data[i], pr.lcup, pr.scup,
+                            widths[i], height, pr.sstr);
+        results[i] = cb_decode_finish(scratch[0], decoded_data[i],
+            coded_data[i], widths[i], height, stride, pr, lengths1[i],
+            lengths2[i], stripe_causal);
+        ++i;
+      }
     }
   }
 }

--- a/src/core/openjph/ojph_arch.h
+++ b/src/core/openjph/ojph_arch.h
@@ -70,9 +70,13 @@
 #ifdef OJPH_COMPILER_MSVC
   #define OJPH_FORCE_INLINE static __forceinline
   #define OJPH_NO_INLINE    static __declspec(noinline)
+  // MSVC has no GCC-style loop-unroll pragma; leave it to the optimizer
+  #define OJPH_UNROLL
 #else
   #define OJPH_FORCE_INLINE static inline __attribute__((always_inline))
   #define OJPH_NO_INLINE    static __attribute__((noinline))
+  // fully unroll a short, compile-time-bounded loop (GCC/Clang)
+  #define OJPH_UNROLL       _Pragma("GCC unroll 8")
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Follow-up to #276. The first step of decoding a codeblock — recovering the VLC and MEL segments of the HTJ2K cleanup pass (this decoder's "step 1") — is a serial dependency chain and the single hottest decode kernel (~42% of 8-bit AVX2 decode, IPC ~2.8). Codeblocks are independent, so decoding several in lockstep lets the out-of-order engine overlap their chains.

## Two commits

1. **ISA-agnostic plumbing.** That interleaving can't live inside the per-block SIMD decoder, which by definition sees only one codeblock — the code that knows about "a row of codeblocks in a subband" sits one level up, in `subband::pull_line`, so the seam belongs there. This adds an optional `decode_cb32_batch` pointer (next to `decode_cb32`/`decode_cb64`, selected by the same CPU-feature dispatch) and a `codeblock::decode_row` that gathers a row and either calls the batch or falls back to the exact 1-way `decode()` (when no batch is registered, or for 64-bit blocks). **No functional change on its own** — that shared code is touched in just one place, future ISAs plug in with only a kernel + one dispatch line, and current output can't change.

2. **AVX2 kernel.** A templated N-way step-1 kernel (`decode_cb_step1_vlc_nway<N>`) that decodes N same-width codeblocks in lockstep, driven by `ojph_decode_codeblock_avx2_batch`, which groups a subband row's same-width blocks N-at-a-time and falls back to 1-way for edge/odd/invalid blocks. Per-block validation and the second step (MagSgn + optional SgnProp/MagRef) are factored into shared helpers so the 1-way and batched paths stay in sync.

## Performance

Single-thread, `ojph_expand` → tmpfs, `taskset -c0`, best-of-15, vs a 1-way reference build (Zen 5):

| condition | whole-process wall |
|---|---|
| 8-bit lossless | **−9.5%** |
| 16-bit lossless | **−8.6%** |
| 8-bit lossy | **−8.6%** |

Whole-process includes the PPM write, so the decode-kernel gain is larger. `OJPH_DEC_BATCH_N` defaults to 2 — the measured Zen 5 sweet spot (the bulkier AVX2 step-2 between batches makes N=4's larger step-1 working set thrash L1; N=2 also keeps the unrolled per-stream state in registers for 32-bit builds). It's compile-overridable, and it can never regress: anything not batched takes the unchanged 1-way path.

## Correctness

Byte-identical to the 1-way path on 8/16-bit lossless, lossy, the 512×8 streaming shape, and a Kakadu multipass stream (SgnProp/MagRef coverage); 82/82 ctest.

Built clean (0 warnings) locally across GCC on Linux (AVX2-only, AVX-512-enabled, and no-SIMD configs), MSVC VS2022 (x64 + Win32/32-bit), and MinGW UCRT64 GCC 16.

---

@palemieux — would you mind running this against the lossless benchmark round-trip, as you did on #276? Marking draft until that and CI are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
