### PR TITLE
fix: size precinct_scratch from per-component (COC) geometry

### DIFF
--- a/src/core/codestream/ojph_codestream_local.cpp
+++ b/src/core/codestream/ojph_codestream_local.cpp
@@ -182,15 +182,25 @@ namespace ojph {
         allocator->pre_alloc_obj<param_tlm::Ttlm_Ptlm_pair>(num_tileparts);
 
       //precinct scratch buffer
-      ui32 num_decomps = cod.get_num_decompositions();
-      size log_cb = cod.get_log_block_dims();
-
+      // The precinct scratch is shared by all components, but each component
+      // may override the codeblock/precinct geometry via a COC marker.  The
+      // per-component tag-tree storage (resolution.cpp) is derived from that
+      // component's effective params, so size the shared buffer from the
+      // largest ratio across every component (the main COD and all COC
+      // overrides).  Sizing from the COD alone under-reserves the buffer for
+      // any component whose COC declares a smaller codeblock than the COD.
       size ratio;
-      for (ui32 r = 0; r <= num_decomps; ++r)
+      for (ui32 c = 0; c < num_comps; ++c)
       {
-        size log_PP = cod.get_log_precinct_size(r);
-        ratio.w = ojph_max(ratio.w, log_PP.w - ojph_min(log_cb.w, log_PP.w));
-        ratio.h = ojph_max(ratio.h, log_PP.h - ojph_min(log_cb.h, log_PP.h));
+        const param_cod* cdp = cod.get_coc(c);
+        ui32 num_decomps = cdp->get_num_decompositions();
+        size log_cb = cdp->get_log_block_dims();
+        for (ui32 r = 0; r <= num_decomps; ++r)
+        {
+          size log_PP = cdp->get_log_precinct_size(r);
+          ratio.w = ojph_max(ratio.w, log_PP.w - ojph_min(log_cb.w, log_PP.w));
+          ratio.h = ojph_max(ratio.h, log_PP.h - ojph_min(log_cb.h, log_PP.h));
+        }
       }
       ui32 max_ratio = ojph_max(ratio.w, ratio.h);
       max_ratio = 1 << max_ratio;


### PR DESCRIPTION
## Size `precinct_scratch` from per-component (COC) geometry, not the COD alone

`codestream::pre_alloc` sizes the single shared `precinct_scratch` buffer from
the main COD codeblock geometry only, but the buffer is consumed using each
component's effective (possibly COC-overridden) geometry. A COC that declares a
smaller codeblock than the COD causes the tag-tree init to write past the end of
the buffer.

### Bug

`codestream::pre_alloc` (`ojph_codestream_local.cpp:184-205`) derives the
scratch reservation from the main COD:

```cpp
ui32 num_decomps = cod.get_num_decompositions();
size log_cb = cod.get_log_block_dims();           // COD only

size ratio;
for (ui32 r = 0; r <= num_decomps; ++r)
{
  size log_PP = cod.get_log_precinct_size(r);     // COD only
  ratio.w = ojph_max(ratio.w, log_PP.w - ojph_min(log_cb.w, log_PP.w));
  ratio.h = ojph_max(ratio.h, log_PP.h - ojph_min(log_cb.h, log_PP.h));
}
```

`resolution::finalize_alloc` (`ojph_resolution.cpp:446-454`) consumes the buffer
using the per-component params — `cdp = get_coc(comp_num)`:

```cpp
size log_cb = cdp->get_log_block_dims();          // per-component COC
...
max_num_levels = max(ratio.w, ratio.h);
tag_tree_size = ((1u<<(max_num_levels<<1))*4 + 2)/3;
```

`precinct::prepare_precinct` / `precinct::parse` (`ojph_precinct.cpp:115-121`,
`:362-370`) then lays four tag-tree tables into the shared scratch at offsets
`0, 1, 2, 3 × tag_tree_size`. Total write extent: `4 × tag_tree_size`.

A COC may declare a smaller codeblock than the COD — `read_coc`
(`ojph_params.cpp:1044-1080`) only checks `block_w, block_h ≤ 8` and
`block_w + block_h ≤ 8`; it is not compared against the COD. The codeblock-dim
clamps to [5,7]/==5 are gated to IMF/broadcast profiles (`ojph_codestream_local.cpp:361`, `:498`). A generic codestream has no such guard.

A smaller codeblock means a larger ratio, so the per-component `tag_tree_size`
exceeds what was reserved → out-of-bounds **write** into `precinct_scratch`
during `tag_tree::init`.

| COD / COC dims | `log_cb` | `ratio` (default precincts, `log_PP=15`) | `tag_tree_size` |
|---|---|---|---|
| COD 64×64 (main) | 6 | 9 | ~350 K |
| COC 4×4 (comp 1) | 2 | 13 | ~89 M |

Buffer sized for the COD (~1.4 MB for 4 tables); tag-tree init writes at the
COC-derived offsets (~356 MB for 4 tables). 256× over-write.

### Reproduction

`poc/coc_oob.j2c` (976 B). Built by `poc/make_poc.py` from `poc/base.j2c`, a
clean 3-component HTJ2K codestream produced by `ojph_compress` (default 64×64
codeblocks). The script injects one COC marker right after the COD:

```
FF53 0009 01 00 05 00 00 40 00
└COC ┘Lcoc┘C ┘S ┘nd┘bw┘bh┘sty┘wav
```

Component 1, default precincts, codeblock 4×4 (`bw=bh=0` → log 2). All fields
satisfy `read_coc` constraints, and nothing checks the COC codeblock against the
COD. Legal per ISO/IEC 15444-1.

```bash
cmake -S . -B build-asan -DCMAKE_BUILD_TYPE=asan && cmake --build build-asan -j
python3 poc/make_poc.py poc/base.j2c poc/coc_oob.j2c
./build-asan/src/apps/ojph_expand/ojph_expand -i poc/coc_oob.j2c -o /tmp/o.ppm
```

Pre-patch (HEAD `6d810a8`):

```
AddressSanitizer:DEADLYSIGNAL
==76925==ERROR: AddressSanitizer: SEGV on unknown address 0x7fe1af435800
==76925==The signal is caused by a WRITE memory access.
    #0 ojph::local::tag_tree::init        ojph_precinct.cpp:73
    #1 ojph::local::precinct::parse       ojph_precinct.cpp:362
    #2 ojph::local::resolution::parse_one_precinct  ojph_resolution.cpp:1028
    #3 ojph::local::tile_comp::parse_one_precinct   ojph_tile_comp.cpp:191
    #4 ojph::local::tile::parse_tile_header         ojph_tile.cpp:836
    #5 ojph::local::codestream::read                ojph_codestream_local.cpp:1078
SUMMARY: AddressSanitizer: SEGV ojph_precinct.cpp:73 in ojph::local::tag_tree::init
```



### Verification

Built unpatched `6d810a8` and patched tree, both `cmake -DCMAKE_BUILD_TYPE=asan`.

| Input | Pre-patch | Post-patch |
|---|---|---|
| `coc_oob.j2c` (COC 4×4 vs COD 64×64) | ASan SEGV — WRITE in `tag_tree::init` at `:73` | `ojph error 0x000300A1` — no memory violation |
| `base.j2c` (clean 3-comp, COD-only) | decodes (exit 0) | decodes (exit 0) — bit-identical output |
