### PR TITLE
Fix: raw_in reads every .raw file as signed, and zero-extends signed 16-bit samples

### DIFF
--- a/src/apps/ojph_compress/ojph_compress.cpp
+++ b/src/apps/ojph_compress/ojph_compress.cpp
@@ -1049,7 +1049,7 @@ int main(int argc, char * argv[]) {
           OJPH_ERROR(0x01000085,
             "-downsamp option is missing and must be provided\n");
 
-        raw.set_img_props(dims, bit_depth[0], is_signed);
+        raw.set_img_props(dims, bit_depth[0], is_signed[0] == 1);
 
         siz.set_num_components(num_components);
         siz.set_component(0, comp_downsampling[0], bit_depth[0], is_signed[0]);

--- a/src/apps/others/ojph_img_io.cpp
+++ b/src/apps/others/ojph_img_io.cpp
@@ -1586,7 +1586,7 @@ namespace ojph {
       if (is_signed) {
         const si16* sp = (si16*)buffer;
         for (ui32 i = width; i > 0; --i, ++sp)
-          *dp++ = swap_bytes_if_be((ui16)*sp);
+          *dp++ = (si32)(si16)swap_bytes_if_be((ui16)*sp);
       }
       else {
         const ui16* sp = (ui16*)buffer;

--- a/src/apps/others/ojph_img_io.cpp
+++ b/src/apps/others/ojph_img_io.cpp
@@ -1591,7 +1591,7 @@ namespace ojph {
       else {
         const ui16* sp = (ui16*)buffer;
         for (ui32 i = width; i > 0; --i, ++sp)
-          *dp++ = swap_bytes_if_be(*sp);
+          *dp++ = (si32)swap_bytes_if_be(*sp);
       }
     }
     else

--- a/src/core/shared/ojph_simd_vsx.h
+++ b/src/core/shared/ojph_simd_vsx.h
@@ -266,8 +266,10 @@ static inline v128_t vsx_i64x2_extend_low_i32x4(v128_t a)
   // return (v128_t)__builtin_convertvector(
   //   __builtin_shufflevector(v, v, 0, 1), vsx_v_i64);
 
-  // Unpacks and sign-extends elements 0 and 1 on Little Endian
-  return (v128_t)vec_unpackl((vsx_v_i32)a);
+  // vec_unpackh's "high" half is the one holding elements 0 and 1; the
+  // compiler keeps that mapping on both endiannesses, so this sign-extends
+  // elements 0 and 1.
+  return (v128_t)vec_unpackh((vsx_v_i32)a);
 }
 static inline v128_t vsx_i64x2_extend_high_i32x4(v128_t a)
 {
@@ -275,8 +277,10 @@ static inline v128_t vsx_i64x2_extend_high_i32x4(v128_t a)
   // return (v128_t)__builtin_convertvector(
   //   __builtin_shufflevector(v, v, 2, 3), vsx_v_i64);
 
-  // Unpacks and sign-extends elements 2 and 3 on Little Endian
-  return (v128_t)vec_unpackh((vsx_v_i32)a);
+  // vec_unpackl's "low" half is the one holding elements 2 and 3; the
+  // compiler keeps that mapping on both endiannesses, so this sign-extends
+  // elements 2 and 3.
+  return (v128_t)vec_unpackl((vsx_v_i32)a);
 }
 
 //---------------------------------------------------------------------------

--- a/tests/test_executables.cpp
+++ b/tests/test_executables.cpp
@@ -257,6 +257,174 @@ void compare_files(const std::string& base_filename,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+//                          run_ojph_compress_raw
+////////////////////////////////////////////////////////////////////////////////
+// Same as run_ojph_compress, but the input file is one the test generated in
+// OUT_FILE_DIR rather than one of the reference files.
+void run_ojph_compress_raw(const std::string& src_filename,
+  const std::string& base_filename,
+  const std::string& out_ext,
+  const std::string& extra_options)
+{
+  try {
+    std::string result, command;
+    command = std::string(COMPRESS_EXECUTABLE)
+      + " -i " + OUT_FILE_DIR + src_filename
+      + " -o " + OUT_FILE_DIR + base_filename + "." + out_ext
+      + " " + extra_options;
+    EXPECT_EQ(execute(command, result), 0);
+  }
+  catch (const std::runtime_error& error) {
+    FAIL() << error.what();
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//                             raw_test_sample
+////////////////////////////////////////////////////////////////////////////////
+// The .raw tests below all use one frame shape, RAW_TEST_WIDTH by
+// RAW_TEST_HEIGHT, and fill it with a ramp that starts at the smallest and
+// ends at the largest sample the component can hold.  The two dimensions
+// multiply to 65536, so for a 16 bit component the ramp's step is exactly 1
+// and one frame sweeps every value a 16 bit sample can take, exactly once;
+// for the other widths the ramp covers the whole range in even steps, and the
+// two ends of the range are always included.
+#define RAW_TEST_WIDTH        256
+#define RAW_TEST_HEIGHT       256
+#define RAW_TEST_NUM_SAMPLES  (RAW_TEST_WIDTH * RAW_TEST_HEIGHT)
+
+static
+ojph::si64 raw_test_sample(ojph::ui32 idx, ojph::ui32 bit_depth,
+                           bool is_signed)
+{
+  ojph::si64 lower, upper;
+  if (is_signed) {
+    upper = ((ojph::si64)1 << (bit_depth - 1)) - 1;
+    lower = -((ojph::si64)1 << (bit_depth - 1));
+  }
+  else {
+    upper = ((ojph::si64)1 << bit_depth) - 1;
+    lower = 0;
+  }
+  return lower
+    + (ojph::si64)idx * (upper - lower) / (RAW_TEST_NUM_SAMPLES - 1);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//                           write_raw_test_file
+////////////////////////////////////////////////////////////////////////////////
+// Writes the frame described above to OUT_FILE_DIR as a one component .raw
+// file.  .raw files hold samples least significant byte first; the bytes are
+// composed with shifts rather than by copying a wider integer, so that the
+// file this writes is identical on little- and big-endian machines.
+void write_raw_test_file(const std::string& filename, ojph::ui32 bit_depth,
+  bool is_signed)
+{
+  std::string name = std::string(OUT_FILE_DIR) + filename;
+  FILE* f = fopen(name.c_str(), "wb");
+  if (f == NULL) {
+    FAIL() << "Unable to open file " << name << " for writing.";
+    return;
+  }
+
+  ojph::ui32 bytes_per_sample = (bit_depth + 7) >> 3;
+  ojph::ui8 line[RAW_TEST_WIDTH * 4];
+  size_t line_size = (size_t)RAW_TEST_WIDTH * bytes_per_sample;
+  for (ojph::ui32 y = 0; y < RAW_TEST_HEIGHT; ++y) {
+    ojph::ui8* dp = line;
+    for (ojph::ui32 x = 0; x < RAW_TEST_WIDTH; ++x) {
+      ojph::ui32 idx = y * RAW_TEST_WIDTH + x;
+      ojph::ui64 val = (ojph::ui64)raw_test_sample(idx, bit_depth, is_signed);
+      for (ojph::ui32 b = 0; b < bytes_per_sample; ++b)
+        *dp++ = (ojph::ui8)((val >> (8 * b)) & 0xFFu);
+    }
+    EXPECT_EQ(fwrite(line, 1, line_size, f), line_size);
+  }
+  fclose(f);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//                          compare_raw_test_file
+////////////////////////////////////////////////////////////////////////////////
+// Checks a decoded one component .raw file against the frame that
+// write_raw_test_file() wrote, sample by sample.  The sign of a negative
+// sample is recovered with an explicit subtraction, so that this reads the
+// file the same way on little- and big-endian machines.
+void compare_raw_test_file(const std::string& filename, ojph::ui32 bit_depth,
+  bool is_signed)
+{
+  std::string name = std::string(OUT_FILE_DIR) + filename;
+  FILE* f = fopen(name.c_str(), "rb");
+  if (f == NULL) {
+    FAIL() << "Unable to open file " << name << " for reading.";
+    return;
+  }
+
+  ojph::ui32 bytes_per_sample = (bit_depth + 7) >> 3;
+  ojph::ui64 sign_bit = (ojph::ui64)1 << (8 * bytes_per_sample - 1);
+  ojph::ui32 num_mismatches = 0, first_idx = 0;
+  ojph::si64 first_expected = 0, first_found = 0;
+  ojph::ui8 line[RAW_TEST_WIDTH * 4];
+  size_t line_size = (size_t)RAW_TEST_WIDTH * bytes_per_sample;
+  for (ojph::ui32 y = 0; y < RAW_TEST_HEIGHT; ++y) {
+    if (fread(line, 1, line_size, f) != line_size) {
+      fclose(f);
+      FAIL() << "Not enough data in file " << name << ".";
+      return;
+    }
+    const ojph::ui8* sp = line;
+    for (ojph::ui32 x = 0; x < RAW_TEST_WIDTH; ++x) {
+      ojph::ui64 val = 0;
+      for (ojph::ui32 b = 0; b < bytes_per_sample; ++b)
+        val |= (ojph::ui64)*sp++ << (8 * b);
+      ojph::si64 found = (ojph::si64)val;
+      if (is_signed && (val & sign_bit))
+        found -= (ojph::si64)sign_bit << 1;
+
+      ojph::ui32 idx = y * RAW_TEST_WIDTH + x;
+      ojph::si64 expected = raw_test_sample(idx, bit_depth, is_signed);
+      if (found != expected) {
+        if (num_mismatches == 0) {
+          first_idx = idx;
+          first_expected = expected;
+          first_found = found;
+        }
+        ++num_mismatches;
+      }
+    }
+  }
+  fclose(f);
+
+  EXPECT_EQ(num_mismatches, 0u) << num_mismatches << " of "
+    << RAW_TEST_NUM_SAMPLES << " samples do not survive the round trip; the "
+    "first is sample " << first_idx << ", which should be " << first_expected
+    << " but is " << first_found << ".";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//                          run_raw_round_trip_test
+////////////////////////////////////////////////////////////////////////////////
+// Writes a .raw file of the given width and signedness, encodes it
+// reversibly, decodes it, and requires the round trip to be bit exact.
+void run_raw_round_trip_test(const std::string& base_filename,
+  ojph::ui32 bit_depth, bool is_signed)
+{
+  std::string src_filename = base_filename + "_src.raw";
+  std::string signedness = is_signed ? "true" : "false";
+  char bit_depth_str[16];
+  snprintf(bit_depth_str, sizeof(bit_depth_str), "%d", (int)bit_depth);
+
+  write_raw_test_file(src_filename, bit_depth, is_signed);
+  run_ojph_compress_raw(src_filename, base_filename, "j2c",
+                        "-reversible true -dims \"{256,256}\" -num_comps 1"
+                        " -downsamp \"{1,1}\" -bit_depth "
+                        + std::string(bit_depth_str)
+                        + " -signed " + signedness);
+  run_ojph_compress_expand(base_filename, "j2c", "raw");
+  compare_raw_test_file(base_filename + ".raw", bit_depth, is_signed);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 //                                  tests
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -1510,6 +1678,53 @@ TEST(TestExecutables, SimpleEncIrv97Qfactor50Gray) {
   run_ojph_compress_expand("simple_enc_irv97_qfactor50_gray", "j2c", "pgm");
   run_mse_pae("simple_enc_irv97_qfactor50_gray", "pgm",
               "monarch.pgm", "", 1, mse, pae);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Test ojph_compress and ojph_expand on .raw files, which are the only input
+// for which the readers are told the signedness of the samples rather than
+// deriving it from the file, and the only input that can carry signed
+// samples.  Each test encodes one frame reversibly and requires the decoded
+// frame to be bit exact; there is one test per sample width that
+// raw_in::read() and raw_out::write() handle separately, in both
+// signednesses, because each of those branches extends samples in its own
+// way.  The 16 bit frames sweep all 65536 sample values, so at the width
+// where the reader regressed the negative half of the range is covered
+// exhaustively.
+// The compressed files are obtained using these command-line options:
+// -o simple_enc_rev53_raw<width>_<signedness>.j2c -reversible true
+// -dims {256,256} -num_comps 1 -downsamp {1,1} -bit_depth <width>
+// -signed <signedness>
+TEST(TestExecutables, SimpleEncRev53Raw8Signed) {
+  run_raw_round_trip_test("simple_enc_rev53_raw8_signed", 8, true);
+}
+
+TEST(TestExecutables, SimpleEncRev53Raw8Unsigned) {
+  run_raw_round_trip_test("simple_enc_rev53_raw8_unsigned", 8, false);
+}
+
+TEST(TestExecutables, SimpleEncRev53Raw16Signed) {
+  run_raw_round_trip_test("simple_enc_rev53_raw16_signed", 16, true);
+}
+
+TEST(TestExecutables, SimpleEncRev53Raw16Unsigned) {
+  run_raw_round_trip_test("simple_enc_rev53_raw16_unsigned", 16, false);
+}
+
+TEST(TestExecutables, SimpleEncRev53Raw24Signed) {
+  run_raw_round_trip_test("simple_enc_rev53_raw24_signed", 24, true);
+}
+
+TEST(TestExecutables, SimpleEncRev53Raw24Unsigned) {
+  run_raw_round_trip_test("simple_enc_rev53_raw24_unsigned", 24, false);
+}
+
+TEST(TestExecutables, SimpleEncRev53Raw32Signed) {
+  run_raw_round_trip_test("simple_enc_rev53_raw32_signed", 32, true);
+}
+
+TEST(TestExecutables, SimpleEncRev53Raw32Unsigned) {
+  run_raw_round_trip_test("simple_enc_rev53_raw32_unsigned", 32, false);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #335 (signed 2-byte raw samples zero-extended on encode — every negative 16-bit signed raw input sample corrupts, regression window 0.28.1 → 0.29.0).

Two defects in the `.raw` input path. They are entangled: fixing either one on its own leaves the other kind of `.raw` input corrupt, which is why this PR grew past the one-liner it started as. Tests covering all eight sample width / signedness combinations are included, and the whole thing is verified on a big-endian host.

### 1. `raw_in::read()` zero-extends signed 16-bit samples

The `bytes_per_sample > 1` (9–16 bit) `is_signed` branch changed in 0.29.0, alongside that release's big-endian/S390x byte-swap support, from:
```cpp
*dp++ = *sp;
```
to:
```cpp
*dp++ = swap_bytes_if_be((ui16)*sp);
```
`swap_bytes_if_be(ui16)` returns `ui16`; the implicit `ui16 → si32` conversion on assignment to `dp` (`si32*`) zero-extends instead of sign-extending. The codestream is therefore encoded wrong (not misread later) — it reproduces identically via `ojph_expand` and third-party decoders (imagecodecs/OpenJPEG).

Fixed by reinterpreting the (possibly byte-swapped) bits as `si16` — recovering the sign at the 16-bit width — before widening. This mirrors the `bytes_per_sample > 3` (32-bit) `is_signed` branch's explicit outer cast (`(si32)swap_bytes_if_be((ui32)*sp)`), which was not affected, and it mirrors `raw_out::write()`'s 16-bit signed branch, which already writes `(si16)swap_bytes_if_be((ui16)(si16)val)`. The reader was the only half of that pair missing the cast. The 24-bit branch sign-extends manually and is likewise unaffected, as are all `is_signed == false` branches, which correctly want zero extension.

### 2. `raw_in` is never told the signedness that `-signed` requested

`ojph_compress`'s `is_signed` is a `si32*` holding one entry per component, and it was passed straight to:
```cpp
void raw_in::set_img_props(const size& s, ui32 bit_depth, bool is_signed);
```
The pointer converts to `bool`, which is always `true`, so **every** `.raw` file is read through the reader's *signed* branches whatever `-signed` said. Fixed by passing `is_signed[0] == 1`, the way the `.yuv` branch already reads that same array.

### Why both are needed

With the reader locked in its signed branch by (2), the zero extension of (1) was also exactly what kept unsigned 16-bit input intact. Fixing (1) alone moves the corruption from signed input to unsigned input; fixing (2) alone leaves #335 unfixed. Fixing (2) additionally repairs unsigned 8-bit and unsigned 24-bit `.raw` input, which are broken on master today for the same reason: the wrongly chosen signed branch sign-extends any sample whose top bit is set, and `raw_out::write()` then clamps the resulting negative value to 0.

`-reversible true`, one 256x256 component, decoded frame compared to the input sample by sample. Identical results on little- and big-endian:

| `-bit_depth` / `-signed` | master (`b44e3d8`) | commit 1 only | this PR |
|---|---|---|---|
| 8 signed | pass | pass | pass |
| 8 unsigned | **fail** | **fail** | pass |
| 16 signed | **fail** (#335) | pass | pass |
| 16 unsigned | pass | **fail** | pass |
| 24 signed | pass | pass | pass |
| 24 unsigned | **fail** | **fail** | pass |
| 32 signed | pass | pass | pass |
| 32 unsigned | pass | pass | pass |

32-bit is unaffected in both directions because that branch's explicit `(si32)` outer cast makes the signed and unsigned reads produce identical bit patterns.

### Tests

`tests/test_executables.cpp` gains eight `.raw` round trips, one per sample width and signedness — the eight combinations `raw_in::read()` and `raw_out::write()` each branch on, none of which had coverage before (the existing raw tests all go through `yuv_in` with 8-bit unsigned samples).

Each writes one 256x256 single-component frame, encodes it reversibly, decodes it, and requires the result to be bit exact. The frame ramps from the smallest to the largest sample the component can hold, so at 16 bits the step is exactly 1 and one frame sweeps all 65536 sample values: the negative half of the range, where the reader regressed, is covered exhaustively rather than sampled. Sample bytes are composed and read back with explicit shifts, so the fixture and the comparison are byte-identical on either endianness and neither depends on the code under test.

Against `b44e3d8` these tests fail for 8-bit unsigned, 16-bit signed and 24-bit unsigned samples.

### Verification

- **Little-endian** — macOS arm64, AppleClang: `ctest` 94/94, no new compiler warnings under `-Wall -Wextra -Wconversion`.
- **Big-endian** — s390x, Ubuntu 22.04, g++ 11.4.0, under the same QEMU emulation the `test_s390x` job uses, with `byte order: BIG ENDIAN` asserted in-process at the start of the run: `ctest` 94/94 (103 s).
- The same eight tests against `b44e3d8`'s apps fail for 8-bit unsigned, 16-bit signed and 24-bit unsigned on **both** hosts, with byte-identical failure signatures — same mismatch counts, same first differing sample, same values. That is what a defect in the widening rather than in the swap should look like; the fix composes with `swap_bytes_if_be()` instead of bypassing it.
- #335's minimal repro round trips bit exact: `(100, -1, 200, -32768)`.
- Exhaustive 16-bit signed sweep, all 65536 values, checked through `ojph_expand` and independently through imagecodecs: 0 mismatches.
