### PR TITLE
Makes qfactor a floating-point number

### DIFF
--- a/src/apps/ojph_compress/ojph_compress.cpp
+++ b/src/apps/ojph_compress/ojph_compress.cpp
@@ -361,7 +361,7 @@ static
 bool get_arguments(int argc, char *argv[], char *&input_filename,
                    char *&output_filename, char *&progression_order,
                    char *&profile_string, ojph::ui32 &num_decompositions,
-                   float &quantization_step, int &qfactor, bool &reversible,
+                   float &quantization_step, float &qfactor, bool &reversible,
                    int &employ_color_transform,
                    const int max_num_precincts, int &num_precincts,
                    ojph::size *precinct_size, ojph::size& block_size,
@@ -499,7 +499,7 @@ int main(int argc, char * argv[]) {
   char *com_string = NULL;
   ojph::ui32 num_decompositions = 5;
   float quantization_step = -1.0f;
-  int qfactor = -1;
+  float qfactor = -1.0f;
   bool reversible = false;
   int employ_color_transform = -1;
 
@@ -641,10 +641,10 @@ int main(int argc, char * argv[]) {
     return -1;
   }
 
-  if (qfactor != -1 && quantization_step != -1.0f)
+  if (qfactor != -1.0f && quantization_step != -1.0f)
     OJPH_ERROR(0x010000A1,
       "-qfactor and -qstep cannot be used together\n");
-  if (qfactor != -1 && (qfactor < 1 || qfactor > 100))
+  if (qfactor != -1.0f && (qfactor < 1.0f || qfactor > 100.0f))
     OJPH_ERROR(0x010000A2,
       "-qfactor must be between 1 and 100\n");
 
@@ -700,8 +700,8 @@ int main(int argc, char * argv[]) {
         cod.set_reversible(reversible);
         if (!reversible && quantization_step != -1.0f)
           codestream.access_qcd().set_irrev_quant(quantization_step);
-        if (!reversible && qfactor != -1)
-          codestream.access_qcd().set_qfactor((ojph::ui8)qfactor);
+        if (!reversible && qfactor != -1.0f)
+          codestream.access_qcd().set_qfactor(qfactor);
         if (profile_string[0] != '\0')
           codestream.set_profile(profile_string);
         codestream.set_tilepart_divisions(tileparts_at_resolutions,
@@ -758,8 +758,8 @@ int main(int argc, char * argv[]) {
         cod.set_reversible(reversible);
         if (!reversible && quantization_step != -1.0f)
           codestream.access_qcd().set_irrev_quant(quantization_step);
-        if (!reversible && qfactor != -1)
-          codestream.access_qcd().set_qfactor((ojph::ui8)qfactor);
+        if (!reversible && qfactor != -1.0f)
+          codestream.access_qcd().set_qfactor(qfactor);
         codestream.set_planar(false);
         if (profile_string[0] != '\0')
           codestream.set_profile(profile_string);
@@ -838,8 +838,8 @@ int main(int argc, char * argv[]) {
             cod.set_color_transform(employ_color_transform == 1);
         }
         cod.set_reversible(reversible);
-        if (!reversible && qfactor != -1)
-          codestream.access_qcd().set_qfactor((ojph::ui8)qfactor);
+        if (!reversible && qfactor != -1.0f)
+          codestream.access_qcd().set_qfactor(qfactor);
         else if (!reversible) {
           const float min_step = 1.0f / 16384.0f;
           if (quantization_step == -1.0f)
@@ -918,12 +918,12 @@ int main(int argc, char * argv[]) {
         cod.set_reversible(reversible);
         if (!reversible && quantization_step != -1)
           codestream.access_qcd().set_irrev_quant(quantization_step);
-        if (!reversible && qfactor != -1) {
+        if (!reversible && qfactor != -1.0f) {
           if (num_comps != 1 && num_comps != 3)
             OJPH_ERROR(0x010000A3,
               "-qfactor is only supported for images with 1 or 3 "
               "components\n");
-          codestream.access_qcd().set_qfactor((ojph::ui8)qfactor);
+          codestream.access_qcd().set_qfactor(qfactor);
 
         }
         codestream.set_planar(false);
@@ -1011,12 +1011,12 @@ int main(int argc, char * argv[]) {
         cod.set_reversible(reversible);
         if (!reversible && quantization_step != -1.0f)
           codestream.access_qcd().set_irrev_quant(quantization_step);
-        if (!reversible && qfactor != -1) {
+        if (!reversible && qfactor != -1.0f) {
           if (num_components != 1 && num_components != 3)
             OJPH_ERROR(0x010000A4,
               "-qfactor is only supported for images with 1 or 3 "
               "components\n");
-          codestream.access_qcd().set_qfactor((ojph::ui8)qfactor);
+          codestream.access_qcd().set_qfactor(qfactor);
         }
         codestream.set_planar(true);
         if (profile_string[0] != '\0')
@@ -1070,8 +1070,8 @@ int main(int argc, char * argv[]) {
         cod.set_reversible(reversible);
         if (!reversible && quantization_step != -1.0f)
           codestream.access_qcd().set_irrev_quant(quantization_step);
-        if (!reversible && qfactor != -1)
-          codestream.access_qcd().set_qfactor((ojph::ui8)qfactor);
+        if (!reversible && qfactor != -1.0f)
+          codestream.access_qcd().set_qfactor(qfactor);
         codestream.set_planar(true);
         if (profile_string[0] != '\0')
           codestream.set_profile(profile_string);
@@ -1112,12 +1112,12 @@ int main(int argc, char * argv[]) {
         cod.set_reversible(reversible);
         if (!reversible && quantization_step != -1)
           codestream.access_qcd().set_irrev_quant(quantization_step);
-        if (!reversible && qfactor != -1) {
+        if (!reversible && qfactor != -1.0f) {
           if (num_comps != 1 && num_comps != 3)
             OJPH_ERROR(0x010000A5,
               "-qfactor is only supported for images with 1 or 3 "
               "components\n");
-          codestream.access_qcd().set_qfactor((ojph::ui8)qfactor);
+          codestream.access_qcd().set_qfactor(qfactor);
         }
         codestream.set_planar(false);
         if (profile_string[0] != '\0')

--- a/src/core/codestream/ojph_params.cpp
+++ b/src/core/codestream/ojph_params.cpp
@@ -414,7 +414,7 @@ namespace ojph {
   }
 
   //////////////////////////////////////////////////////////////////////////
-  void param_qcd::set_qfactor(ui8 qfactor) {
+  void param_qcd::set_qfactor(float qfactor) {
     state->set_qfactor(qfactor);
   }
 
@@ -425,7 +425,8 @@ namespace ojph {
   }
 
   //////////////////////////////////////////////////////////////////////////
-  void param_qcd::set_qfactor(ui32 comp_idx, comp_type ctype, ui8 qfactor) {
+  void param_qcd::set_qfactor(ui32 comp_idx, comp_type ctype, float qfactor)
+  {
     state->set_qfactor(comp_idx, ctype, qfactor);
   }
 
@@ -687,20 +688,21 @@ namespace ojph {
       }
 
       //////////////////////////
-      static float get_delta_ref(ui32 qfactor, ui32 bit_depth,
+      static float get_delta_ref(float qfactor, ui32 bit_depth,
                                  float& power)
       {
         // returns delta_ref & power to be used with visual weights
-        constexpr uint8_t t0     = 65, t1 = 97;
+        constexpr float t0       = 65.0f;
+        constexpr float t1       = 97.0f;
         constexpr float alpha_t0 = 0.04f, alpha_t1 = 0.10f;
         constexpr float m_t0     = 2.0f * (1.0f - t0 / 100.0f);
         constexpr float m_t1     = 2.0f * (1.0f - t1 / 100.0f);
 
         float m_q;
-        if (qfactor < 50)
-          m_q = 50.0f / (float)qfactor;
+        if (qfactor < 50.0f)
+          m_q = 50.0f / qfactor;
         else
-          m_q = 2.0f * (1.0f - (float)qfactor / 100.0f);
+          m_q = 2.0f * (1.0f - qfactor / 100.0f);
 
         float alpha_q;
         if (qfactor <= t0)
@@ -1481,10 +1483,10 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void param_qcd::set_qfactor(ui8 qfactor) {
+    void param_qcd::set_qfactor(float qfactor) {
       assert(this->type == QCD_MAIN);
 
-      if (qfactor < 1 || qfactor > 100)
+      if (qfactor < 1.0f || qfactor > 100.0f)
         OJPH_ERROR(0x00050181, "Qfactor must be between 1 and 100, "
           "but was set to %i.", qfactor);
 
@@ -2018,11 +2020,11 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void param_qcd::set_qfactor(ui32 comp_idx, comp_type ctype, ui8 qfactor)
+    void param_qcd::set_qfactor(ui32 comp_idx, comp_type ctype, float qfactor)
     {
       assert(this->type == QCD_MAIN);
 
-      if (qfactor < 1 || qfactor > 100)
+      if (qfactor < 1.0f || qfactor > 100.0f)
         OJPH_ERROR(0x00050191, "Qfactor must be between 1 and 100, "
           "but was set to %i.", qfactor);
 

--- a/src/core/codestream/ojph_params_local.h
+++ b/src/core/codestream/ojph_params_local.h
@@ -702,9 +702,7 @@ namespace ojph {
       };
 
       ////////////////////////////////////////
-      enum qfactor_const : ui8 {
-        QFACTOR_UNSET = 0
-      };
+      const float QFACTOR_UNSET = 0.0f;
 
       ////////////////////////////////////////
       using comp_type = ojph::param_qcd::comp_type;
@@ -730,7 +728,7 @@ namespace ojph {
       bool is_qcc_needed(ui32 comp_num, const param_cod &cod,
                          const param_siz &siz);
       void set_delta(float delta) { base_delta = delta; }
-      void set_qfactor(ui8 qfactor);
+      void set_qfactor(float qfactor);
       ui32 get_num_guard_bits() const;
       ui32 get_MAGB() const;
       ui32 get_Kmax(const param_dfs* dfs, ui32 num_decompositions,
@@ -745,7 +743,7 @@ namespace ojph {
       void read_qcc(infile_base *file, ui32 num_comps);
 
       void set_delta(ui32 comp_idx, float delta);
-      void set_qfactor(ui32 comp_idx, comp_type ctype, ui8 qfactor);
+      void set_qfactor(ui32 comp_idx, comp_type ctype, float qfactor);
       param_qcd* get_qcc(ui32 comp_idx);
       const param_qcd* get_qcc(ui32 comp_idx) const;
       param_qcd* add_qcc_object(ui32 comp_idx);
@@ -814,7 +812,7 @@ namespace ojph {
       // variables used to generate the quantization step sizes
       float base_delta;   // base quantization step size -- all other
                           // step sizes are derived from it.
-      ui8 qfactor;
+      float qfactor;
       comp_type ctype;
       bool is_color_trans;
       ui32 num_decomps;

--- a/src/core/openjph/ojph_params.h
+++ b/src/core/openjph/ojph_params.h
@@ -205,7 +205,7 @@ namespace ojph {
      * If that does not match the desired behaviour; then do not set the
      * top level qfactor, but set the Qfactor for individual channels
      * according to desired visual weighting type, using
-     * set_qfactor(ui32 comp_idx, comp_type ctype, ui8 qfactor);
+     * set_qfactor(ui32 comp_idx, comp_type ctype, float qfactor);
      *
      * Note that setting Qfactor takes precedence over setting an
      * irreversible quantization base delta.
@@ -213,7 +213,7 @@ namespace ojph {
      * @param qfactor Compression quality as an integer between
      *                1 (worst quality) and 100 (best quality)
      */
-    void set_qfactor(ui8 qfactor);
+    void set_qfactor(float qfactor);
 
     /**
      * @brief Set the irreversible quantization base delta for a specific
@@ -240,7 +240,7 @@ namespace ojph {
      * @param qfactor Compression quality as an integer between
      *                1 (worst quality) and 100 (best quality)
      */
-    void set_qfactor(ui32 comp_idx, comp_type ctype, ui8 qfactor);
+    void set_qfactor(ui32 comp_idx, comp_type ctype, float qfactor);
 
   private:
     local::param_qcd* state;


### PR DESCRIPTION
We realized that it might be a good idea to make qfactor a floating-point number.
This is only useful for qfactor close to 100.  If one needs finer quantization than what 100 produce, perhaps, they should consider using lossless.