### PR TITLE
Add reversible predict-only (1/3) wavelet via Part 2 ATK signaling

### DIFF
--- a/src/core/codestream/ojph_codestream_local.cpp
+++ b/src/core/codestream/ojph_codestream_local.cpp
@@ -570,6 +570,18 @@ namespace ojph {
       }
       siz.check_validity();
       cod.check_validity(siz);
+      if (cod.get_wavelet_kern() > local::param_cod::DWT_REV53)
+      {
+        // kernels beyond those of Part 1 need an ATK marker segment, and
+        // the SIZ marker must signal the use of Part 2 extensions
+        if (cod.get_wavelet_kern() != local::param_cod::DWT_REV13)
+          OJPH_ERROR(0x00030030, "Only the predict-only reversible 1/3 "
+            "kernel (index %d) is supported beyond the Part 1 kernels.",
+            local::param_cod::DWT_REV13);
+        atk.init_rev13();
+        siz.set_Rsiz_flag((ui16)(local::param_siz::RSIZ_EXT_FLAG |
+                                 local::param_siz::RSIZ_WS_KERN_FLAG));
+      }
       cod.update_atk(&atk);
       qcd.check_validity(siz, cod);
       cap.check_validity(cod, qcd);
@@ -649,6 +661,12 @@ namespace ojph {
 
       if (!cap.write(file))
         OJPH_ERROR(0x00030024, "Error writing to file");
+
+      // The kernels of Part 1 (indices 0 and 1) are implied by the COD
+      // marker and must not be written to an ATK marker segment.
+      if (cod.get_wavelet_kern() > local::param_cod::DWT_REV53 &&
+          !atk.write(file))
+        OJPH_ERROR(0x00030031, "Error writing to file");
 
       if (!cod.write(file))
         OJPH_ERROR(0x00030025, "Error writing to file");

--- a/src/core/codestream/ojph_params.cpp
+++ b/src/core/codestream/ojph_params.cpp
@@ -741,8 +741,10 @@ namespace ojph {
           OJPH_ERROR(0x00050056, "Wrong SIZ-YRsiz value of %d", cptr[c].YRsiz);
       }
 
-      ws_kern_support_needed = (Rsiz & 0x20) != 0;
-      dfs_support_needed = (Rsiz & 0x80) != 0;
+      // T.801 Table A.2: bit 5 (0x20) signals arbitrary decomposition
+      // styles, and bit 7 (0x80) signals whole-sample symmetric kernels
+      ws_kern_support_needed = (Rsiz & 0x80) != 0;
+      dfs_support_needed = (Rsiz & 0x20) != 0;
 
       check_validity();
     }
@@ -2623,10 +2625,10 @@ namespace ojph {
           if (file->read(&d[s].rev.Eatk, 1) != 1)
             OJPH_ERROR(0x000500E9, "error reading ATK-Eatk parameter");
           bytes -= 1;
-          if (file->read(&d[s].rev.Batk, 2) != 2)
+          // Batk has the size of the coefficient type Coeff_Typ
+          // (T.801 Table A.27)
+          if (read_coefficient(file, d[s].rev.Batk, bytes) == false)
             OJPH_ERROR(0x000500EA, "error reading ATK-Batk parameter");
-          bytes -= 2;
-          d[s].rev.Batk = (si16)swap_bytes_if_le((ui16)d[s].rev.Batk);
           ui8 LCatk;
           if (file->read(&LCatk, 1) != 1)
             OJPH_ERROR(0x000500EB, "error reading ATK-LCatk parameter");
@@ -2693,11 +2695,15 @@ namespace ojph {
       // an even number of steps.
       // Indices 0 and 1 are reserved for the 9/7 and 5/3 kernels, so this
       // kernel is signaled with an ATK marker segment of index 2.
-      Satk = 0x5800 | param_cod::DWT_REV13;
+      // 16-bit coefficients (Coeff_Typ = 1) are used because widely
+      // deployed decoders read Batk as a 16-bit field for all coefficient
+      // types, while T.801 Table A.27 sizes Batk by Coeff_Typ; with
+      // Coeff_Typ = 1 both interpretations coincide.
+      Satk = 0x5900 | param_cod::DWT_REV13;
       Natk = 2;
       // Latk(2) + Satk(2) + Natk(1), then Eatk(1) + Batk(2) + LCatk(1) +
-      // Aatk(1, 8-bit coefficients) per step
-      Latk = (ui16)(5 + 5 * Natk);
+      // Aatk(2) per step, with 16-bit Batk and Aatk (Coeff_Typ = 1)
+      Latk = (ui16)(5 + 6 * Natk);
       d[0].rev.Aatk = 0;  // update: s[n] += (0 * (d[n-1] + d[n]) + 0) >> 0,
       d[0].rev.Batk = 0;  // i.e., a no-op
       d[0].rev.Eatk = 0;
@@ -2751,8 +2757,16 @@ namespace ojph {
       for (int s = 0; s < Natk; ++s)
       {
         result &= file->write(&d[s].rev.Eatk, 1) == 1;
-        buf2 = swap_bytes_if_le((ui16)d[s].rev.Batk);
-        result &= file->write(&buf2, 2) == 2;
+        // Batk has the size of the coefficient type Coeff_Typ
+        // (T.801 Table A.27)
+        if (coeff_type == 0) {
+          si8 v = (si8)d[s].rev.Batk;
+          result &= file->write(&v, 1) == 1;
+        }
+        else {
+          buf2 = swap_bytes_if_le((ui16)d[s].rev.Batk);
+          result &= file->write(&buf2, 2) == 2;
+        }
         ui8 LCatk = 1; // one coefficient per lifting step
         result &= file->write(&LCatk, 1) == 1;
         if (coeff_type == 0) {

--- a/src/core/codestream/ojph_params.cpp
+++ b/src/core/codestream/ojph_params.cpp
@@ -253,6 +253,28 @@ namespace ojph {
   }
 
   ////////////////////////////////////////////////////////////////////////////
+  void param_cod::set_wavelet_kern(ui32 kernel)
+  {
+    if (kernel > OJPH_WAVELET_REV13)
+      OJPH_ERROR(0x000500F4, "Unsupported wavelet kernel %d; supported "
+        "kernels are 0 (irreversible 9/7), 1 (reversible 5/3), and "
+        "2 (reversible predict-only 1/3).", kernel);
+    state->set_wavelet_kern((ui8)kernel);
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  ui32 param_cod::get_wavelet_kern() const
+  {
+    return state->get_wavelet_kern();
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  bool param_cod::is_predict_only() const
+  {
+    return state->is_predict_only();
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
   void param_cod::set_num_decomposition(ui32 comp_idx, ui32 num_decompositions)
   {
     local::param_cod* cdp = state->get_or_add_coc(comp_idx);
@@ -830,6 +852,22 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
+    bool param_cod::is_predict_only() const
+    {
+      // This decision is based on the lifting steps of the kernel actually
+      // employed, read from the ATK marker segment -- not on the kernel
+      // index, which carries no meaning of its own beyond identifying an
+      // ATK marker segment within this codestream.
+      if (SPcod.wavelet_trans <= 1)
+        return false; // the Part 1 kernels both employ update steps
+      if (atk == NULL)
+        // encoding, before an ATK object is associated with this COD;
+        // the only kernel the encoder can employ beyond Part 1 is rev13
+        return get_wavelet_kern() == DWT_REV13;
+      return atk->is_predict_only();
+    }
+
+    //////////////////////////////////////////////////////////////////////////
     bool param_cod::write(outfile_base *file)
     {
       assert(type == COD_MAIN);
@@ -1213,10 +1251,13 @@ namespace ojph {
       this->sampling = siz.get_downsampling(comp_num);
       this->num_subbands = 1 + 3 * this->num_decomps;
 
-      if (this->wavelet_kern == param_cod::DWT_REV53)
+      // for wavelet_kern values above DWT_REV53, reversibility is
+      // decided by the ATK marker segment associated with the COD marker;
+      // this requires cod.update_atk() to have been called already.
+      if (cod.is_reversible())
         this->set_rev_quant(this->num_decomps, this->bit_depth,
                             comp_num < 3 ? this->is_color_trans : false);
-      else if (this->wavelet_kern == param_cod::DWT_IRV97)
+      else
       {
         if (this->base_delta == -1.0f)
         {
@@ -2637,6 +2678,93 @@ namespace ojph {
       d[1].irv.Aatk = (float)0.882911075530934;
       d[2].irv.Aatk = (float)-0.052980118572961;
       d[3].irv.Aatk = (float)-1.586134342059924;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void param_atk::init_rev13()
+    {
+      // A reversible kernel derived from the 5/3 kernel by nulling the
+      // update step (zero lifting coefficient), keeping only the prediction
+      // step; the low-pass subband holds the even-indexed samples, untouched
+      // by any filtering.  The null update step is kept, rather than dropped,
+      // so that the kernel has the step structure of the 5/3 kernel; with
+      // m_init = 0, the first synthesis step operates on the even-indexed
+      // subsequence, and therefore a kernel with prediction only must have
+      // an even number of steps.
+      // Indices 0 and 1 are reserved for the 9/7 and 5/3 kernels, so this
+      // kernel is signaled with an ATK marker segment of index 2.
+      Satk = 0x5800 | param_cod::DWT_REV13;
+      Natk = 2;
+      // Latk(2) + Satk(2) + Natk(1), then Eatk(1) + Batk(2) + LCatk(1) +
+      // Aatk(1, 8-bit coefficients) per step
+      Latk = (ui16)(5 + 5 * Natk);
+      d[0].rev.Aatk = 0;  // update: s[n] += (0 * (d[n-1] + d[n]) + 0) >> 0,
+      d[0].rev.Batk = 0;  // i.e., a no-op
+      d[0].rev.Eatk = 0;
+      d[1].rev.Aatk = -1; // predict: identical to the 5/3 kernel
+      d[1].rev.Batk = 1;
+      d[1].rev.Eatk = 1;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    bool param_atk::is_predict_only() const
+    {
+      // True when the kernel never modifies the low-pass (even-indexed)
+      // subsequence.  With m_init = 0, the even-indexed lifting steps
+      // operate on the even-indexed subsequence (they are the update
+      // steps); the kernel is predict-only when every one of them is a
+      // no-op.  For a reversible kernel, a step adds
+      // (Batk + Aatk * (x1 + x2)) >> Eatk, which is identically zero when
+      // Aatk == 0 and Batk >> Eatk == 0.
+      // For such a reversible kernel, the low-pass subband of each
+      // decomposition holds the even-indexed samples of its input
+      // untouched, and resolution level r of a losslessly-coded image
+      // decodes to the image subsampled by 2^r in each direction.
+      if (!is_reversible() || !is_m_init0())
+        return false;
+      for (ui32 s = 0; s < Natk; s += 2)
+        if (d[s].rev.Aatk != 0 || (d[s].rev.Batk >> d[s].rev.Eatk) != 0)
+          return false;
+      return true;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    bool param_atk::write(outfile_base *file)
+    {
+      // Only whole-sample symmetric reversible kernels, with one
+      // coefficient per lifting step and 8- or 16-bit coefficients, can be
+      // written; these are the only kernels the encoder can employ.
+      assert(is_reversible() && is_whole_sample() && is_m_init0());
+      int coeff_type = get_coeff_type();
+      assert(coeff_type == 0 || coeff_type == 1);
+
+      bool result = true;
+      ui16 buf2;
+
+      buf2 = swap_bytes_if_le((ui16)JP2K_MARKER::ATK);
+      result &= file->write(&buf2, 2) == 2;
+      buf2 = swap_bytes_if_le(Latk);
+      result &= file->write(&buf2, 2) == 2;
+      buf2 = swap_bytes_if_le(Satk);
+      result &= file->write(&buf2, 2) == 2;
+      result &= file->write(&Natk, 1) == 1;
+      for (int s = 0; s < Natk; ++s)
+      {
+        result &= file->write(&d[s].rev.Eatk, 1) == 1;
+        buf2 = swap_bytes_if_le((ui16)d[s].rev.Batk);
+        result &= file->write(&buf2, 2) == 2;
+        ui8 LCatk = 1; // one coefficient per lifting step
+        result &= file->write(&LCatk, 1) == 1;
+        if (coeff_type == 0) {
+          si8 v = (si8)d[s].rev.Aatk;
+          result &= file->write(&v, 1) == 1;
+        }
+        else {
+          buf2 = swap_bytes_if_le((ui16)d[s].rev.Aatk);
+          result &= file->write(&buf2, 2) == 2;
+        }
+      }
+      return result;
     }
 
     //////////////////////////////////////////////////////////////////////////

--- a/src/core/codestream/ojph_params_local.h
+++ b/src/core/codestream/ojph_params_local.h
@@ -168,6 +168,7 @@ namespace ojph {
 
     public:
       enum : ui16 {
+        RSIZ_WS_KERN_FLAG = 0x20,
         RSIZ_NLT_FLAG  =  0x200,
         RSIZ_HT_FLAG   = 0x4000,
         RSIZ_EXT_FLAG  = 0x8000,
@@ -407,6 +408,9 @@ namespace ojph {
       enum dwt_type : ui8 {
         DWT_IRV97 = 0,
         DWT_REV53 = 1,
+        DWT_REV13 = 2,  // reversible predict-only kernel; the low-pass
+                        // subband holds untouched even-indexed samples.
+                        // Signaled with an ATK marker segment of index 2.
       };
 
     public: // COD_MAIN and COC_MAIN common functions
@@ -429,6 +433,13 @@ namespace ojph {
       {
         assert(type == UNDEFINED || type == COD_MAIN || type == COC_MAIN);
         SPcod.wavelet_trans = reversible ? DWT_REV53 : DWT_IRV97;
+      }
+
+      ////////////////////////////////////////
+      void set_wavelet_kern(ui8 kernel)
+      {
+        assert(type == UNDEFINED || type == COD_MAIN || type == COC_MAIN);
+        SPcod.wavelet_trans = kernel;
       }
 
       ////////////////////////////////////////
@@ -532,6 +543,9 @@ namespace ojph {
 
       ////////////////////////////////////////
       bool is_reversible() const;
+
+      ////////////////////////////////////////
+      bool is_predict_only() const;
 
       ////////////////////////////////////////
       bool is_employing_color_transform() const
@@ -921,7 +935,7 @@ namespace ojph {
 
       void check_validity(const param_cod& cod, const param_qcd& qcd)
       {
-        if (cod.get_wavelet_kern() == param_cod::DWT_REV53)
+        if (cod.is_reversible())
           Ccap[0] &= 0xFFDF;
         else
           Ccap[0] |= 0x0020;
@@ -1168,6 +1182,10 @@ namespace ojph {
       }
 
       bool read(infile_base *file);
+      bool write(outfile_base *file);
+      void init_rev13();
+      bool is_used() const { return Latk != 0; }
+      bool is_predict_only() const;
 
       ui8 get_index() const { return (ui8)(Satk & 0xFF); }
       int get_coeff_type() const { return (Satk >> 8) & 0x7; }

--- a/src/core/codestream/ojph_params_local.h
+++ b/src/core/codestream/ojph_params_local.h
@@ -168,7 +168,10 @@ namespace ojph {
 
     public:
       enum : ui16 {
-        RSIZ_WS_KERN_FLAG = 0x20,
+        // T.801 Table A.2 capability bits
+        RSIZ_DFS_FLAG      = 0x20,  // arbitrary decomposition styles
+        RSIZ_ARB_KERN_FLAG = 0x40,  // arbitrary transformation kernels
+        RSIZ_WS_KERN_FLAG  = 0x80,  // whole-sample symmetric kernels
         RSIZ_NLT_FLAG  =  0x200,
         RSIZ_HT_FLAG   = 0x4000,
         RSIZ_EXT_FLAG  = 0x8000,

--- a/src/core/openjph/ojph_params.h
+++ b/src/core/openjph/ojph_params.h
@@ -119,6 +119,17 @@ namespace ojph {
   class OJPH_EXPORT param_cod
   {
   public:
+    enum wavelet_kernel : ui32 {
+      OJPH_WAVELET_IRV97 = 0, // irreversible 9/7 kernel
+      OJPH_WAVELET_REV53 = 1, // reversible 5/3 kernel
+      OJPH_WAVELET_REV13 = 2, // reversible predict-only (1/3) kernel; the
+                              // low-pass subband of each decomposition holds
+                              // the even-indexed samples of the previous
+                              // resolution, untouched by any filtering.
+                              // Signaled with an ATK marker segment (Part 2).
+    };
+
+  public:
     param_cod(local::param_cod* p) : state(p) {}
 
     // COD marker segment interface
@@ -128,11 +139,21 @@ namespace ojph {
     void set_progression_order(const char *name);
     void set_color_transform(bool color_transform);
     void set_reversible(bool reversible);
+    void set_wavelet_kern(ui32 kernel);
 
     ui32 get_num_decompositions() const;
     size get_block_dims() const;
     size get_log_block_dims() const;
     bool is_reversible() const;
+    ui32 get_wavelet_kern() const;
+    // True when the employed kernel has no effective update steps, so the
+    // low-pass subband of each decomposition holds the even-indexed samples
+    // of the previous resolution untouched; with a reversible kernel and
+    // lossless coding, resolution level r decodes to the image subsampled
+    // by 2^r.  The decision inspects the lifting steps signaled in the ATK
+    // marker segment, never the kernel index, so it is reliable for
+    // codestreams produced by other encoders.
+    bool is_predict_only() const;
     size get_precinct_size(ui32 level_num) const;
     size get_log_precinct_size(ui32 level_num) const;
     int get_progression_order() const;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,9 +52,22 @@ target_link_libraries(
   GTest::gtest_main
 )
 
+# configure rev13 (predict-only wavelet) tests (library API tests)
+add_executable(
+  test_rev13
+  test_rev13.cpp
+)
+
+target_link_libraries(
+  test_rev13
+  openjph
+  GTest::gtest_main
+)
+
 include(GoogleTest)
 gtest_add_tests(TARGET test_executables)
 gtest_add_tests(TARGET test_mixed_coc)
+gtest_add_tests(TARGET test_rev13)
 
 if (MSVC)
   add_custom_command(TARGET test_executables POST_BUILD

--- a/tests/test_rev13.cpp
+++ b/tests/test_rev13.cpp
@@ -1,0 +1,310 @@
+//***************************************************************************/
+// This software is released under the 2-Clause BSD license, included
+// below.
+//
+// Copyright (c) Mark Harfouche
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//***************************************************************************/
+// This file is part of the OpenJPH software implementation.
+// File: test_rev13.cpp
+// Author: Mark Harfouche
+// Date: 27 July 2026
+//***************************************************************************/
+
+// Tests for the reversible predict-only (rev13) wavelet, signaled with a
+// Part 2 ATK marker segment.  The defining property of this kernel is that
+// the low-pass subband of each decomposition holds the even-indexed samples
+// of the previous resolution untouched, so decoding r skipped resolutions
+// of a losslessly coded image returns exactly image[::2^r, ::2^r].
+
+#include <vector>
+
+#include "ojph_mem.h"
+#include "ojph_file.h"
+#include "ojph_codestream.h"
+#include "ojph_params.h"
+#include "gtest/gtest.h"
+
+namespace {
+
+// mask-like content (a disc on a background) plus scattered impulses, so
+// both smooth and detail subbands are exercised
+static ojph::si32 sample_value(ojph::ui32 x, ojph::ui32 y,
+                               ojph::ui32 width, ojph::ui32 height)
+{
+  ojph::si32 dx = (ojph::si32)x - (ojph::si32)(width / 2);
+  ojph::si32 dy = (ojph::si32)y - (ojph::si32)(height / 2);
+  ojph::si32 r = (ojph::si32)(width / 3);
+  ojph::si32 v = (dx * dx + dy * dy < r * r) ? 137 : 0;
+  if ((x * 31u + y * 17u) % 97u == 0)
+    v = (ojph::si32)((x + y) % 200u);
+  return v;
+}
+
+static void encode(ojph::mem_outfile& file,
+                   ojph::ui32 width, ojph::ui32 height,
+                   ojph::ui32 num_decomps, ojph::ui32 kernel,
+                   const std::vector<ojph::si32>* samples = NULL)
+{
+  ojph::codestream codestream;
+
+  ojph::param_siz siz = codestream.access_siz();
+  siz.set_image_extent(ojph::point(width, height));
+  siz.set_num_components(1);
+  siz.set_component(0, ojph::point(1, 1), 8, false);
+  siz.set_image_offset(ojph::point(0, 0));
+  siz.set_tile_offset(ojph::point(0, 0));
+
+  ojph::param_cod cod = codestream.access_cod();
+  cod.set_num_decomposition(num_decomps);
+  if (kernel == ojph::param_cod::OJPH_WAVELET_IRV97)
+    cod.set_reversible(false);
+  else {
+    cod.set_reversible(true);
+    cod.set_wavelet_kern(kernel);
+  }
+  codestream.set_planar(false);
+
+  file.open();
+  codestream.write_headers(&file);
+
+  ojph::ui32 next_comp;
+  ojph::line_buf* cur_line = codestream.exchange(NULL, next_comp);
+  for (ojph::ui32 y = 0; y < height; ++y)
+  {
+    for (ojph::ui32 x = 0; x < width; ++x)
+      cur_line->i32[x] = samples != NULL
+        ? (*samples)[(size_t)y * width + x]
+        : sample_value(x, y, width, height);
+    cur_line = codestream.exchange(cur_line, next_comp);
+  }
+  codestream.flush();
+  codestream.close();
+}
+
+static std::vector<ojph::si32> decode(ojph::mem_outfile& file,
+                                      ojph::ui32 skipped_res,
+                                      ojph::ui32& recon_width,
+                                      ojph::ui32& recon_height)
+{
+  ojph::mem_infile infile;
+  infile.open(file.get_data(), file.get_used_size());
+
+  ojph::codestream codestream;
+  codestream.read_headers(&infile);
+  codestream.restrict_input_resolution(skipped_res, skipped_res);
+  codestream.create();
+
+  ojph::param_siz siz = codestream.access_siz();
+  recon_width = siz.get_recon_width(0);
+  recon_height = siz.get_recon_height(0);
+
+  std::vector<ojph::si32> result((size_t)recon_width * recon_height);
+  for (ojph::ui32 y = 0; y < recon_height; ++y)
+  {
+    ojph::ui32 comp_num;
+    ojph::line_buf* line = codestream.pull(comp_num);
+    for (ojph::ui32 x = 0; x < recon_width; ++x)
+      result[(size_t)y * recon_width + x] = line->i32[x];
+  }
+  codestream.close();
+  return result;
+}
+
+// true when the main header (SOC .. first SOT) contains an ATK marker
+static bool main_header_has_atk(ojph::mem_outfile& file)
+{
+  const ojph::ui8* data = file.get_data();
+  size_t size = file.get_used_size();
+  size_t pos = 2; // skip SOC
+  while (pos + 4 <= size)
+  {
+    ojph::ui16 marker = (ojph::ui16)((data[pos] << 8) | data[pos + 1]);
+    if (marker == 0xFF90) // SOT
+      return false;
+    if (marker == 0xFF79) // ATK
+      return true;
+    ojph::ui16 length = (ojph::ui16)((data[pos + 2] << 8) | data[pos + 3]);
+    pos += 2u + length;
+  }
+  return false;
+}
+
+} // namespace
+
+///////////////////////////////////////////////////////////////////////////////
+// Full-resolution decoding must be lossless, and decoding r skipped
+// resolutions must return exactly image[::2^r, ::2^r] -- for even and odd
+// dimensions, including single-row and single-column images.
+TEST(TestRev13, LevelsAreExactSubsampling) {
+  const struct { ojph::ui32 width, height, num_decomps; } cases[] = {
+    { 256, 256, 3 },
+    { 255, 193, 3 },
+    {  17,  13, 2 },
+    {  64, 256, 4 },
+    {   1,  64, 2 },
+    {  64,   1, 2 },
+  };
+
+  for (auto& c : cases)
+  {
+    ojph::mem_outfile file;
+    encode(file, c.width, c.height, c.num_decomps,
+           ojph::param_cod::OJPH_WAVELET_REV13);
+
+    for (ojph::ui32 skip = 0; skip <= c.num_decomps; ++skip)
+    {
+      ojph::ui32 rw, rh;
+      std::vector<ojph::si32> recon = decode(file, skip, rw, rh);
+
+      ojph::ui32 step = 1u << skip;
+      ASSERT_EQ(rw, (c.width + step - 1) / step)
+        << c.width << "x" << c.height << " skip " << skip;
+      ASSERT_EQ(rh, (c.height + step - 1) / step)
+        << c.width << "x" << c.height << " skip " << skip;
+
+      for (ojph::ui32 y = 0; y < rh; ++y)
+        for (ojph::ui32 x = 0; x < rw; ++x)
+          ASSERT_EQ(recon[(size_t)y * rw + x],
+                    sample_value(x * step, y * step, c.width, c.height))
+            << c.width << "x" << c.height << " skip " << skip
+            << " at (" << x << ", " << y << ")";
+    }
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// The codestream must carry an ATK marker segment in its main header, and a
+// decoder must classify the kernel from the ATK lifting steps: reversible
+// and predict-only.  The Part 1 kernels must classify as not predict-only,
+// and their codestreams must not carry an ATK marker segment.
+TEST(TestRev13, SignalingAndDetection) {
+  {
+    ojph::mem_outfile file;
+    encode(file, 64, 64, 2, ojph::param_cod::OJPH_WAVELET_REV13);
+    EXPECT_TRUE(main_header_has_atk(file));
+
+    ojph::mem_infile infile;
+    infile.open(file.get_data(), file.get_used_size());
+    ojph::codestream codestream;
+    codestream.read_headers(&infile);
+    ojph::param_cod cod = codestream.access_cod();
+    EXPECT_EQ(cod.get_wavelet_kern(), ojph::param_cod::OJPH_WAVELET_REV13);
+    EXPECT_TRUE(cod.is_reversible());
+    EXPECT_TRUE(cod.is_predict_only());
+    codestream.close();
+  }
+
+  const ojph::ui32 part1_kernels[] = {
+    ojph::param_cod::OJPH_WAVELET_REV53,
+    ojph::param_cod::OJPH_WAVELET_IRV97,
+  };
+  for (ojph::ui32 kernel : part1_kernels)
+  {
+    ojph::mem_outfile file;
+    encode(file, 64, 64, 2, kernel);
+    EXPECT_FALSE(main_header_has_atk(file));
+
+    ojph::mem_infile infile;
+    infile.open(file.get_data(), file.get_used_size());
+    ojph::codestream codestream;
+    codestream.read_headers(&infile);
+    ojph::param_cod cod = codestream.access_cod();
+    EXPECT_EQ(cod.get_wavelet_kern(), kernel);
+    EXPECT_FALSE(cod.is_predict_only());
+    codestream.close();
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// A handcrafted image that demonstrates the difference between the kernels.
+// The image is zero everywhere except for one impulse at (1, 1) -- an
+// odd-indexed position in both directions, so it does not appear in
+// image[::2, ::2] at all: the exact subsample at one skipped resolution is
+// all zeros.  The 5/3 kernel's update step leaks the impulse into the
+// low-pass subband, so its first resolution level is NOT the exact
+// subsample; the predict-only kernel has no update step, so its first
+// resolution level is exactly the (all-zero) subsample.  Both kernels
+// remain lossless at full resolution.
+TEST(TestRev13, ImpulseAtOddPositionRev53LeaksRev13DoesNot) {
+  const ojph::ui32 width = 8, height = 8, num_decomps = 1;
+  std::vector<ojph::si32> image((size_t)width * height, 0);
+  image[1 * width + 1] = 100;
+
+  // the exact subsample image[::2, ::2] is all zeros
+  ojph::ui32 rw, rh;
+  {
+    ojph::mem_outfile file;
+    encode(file, width, height, num_decomps,
+           ojph::param_cod::OJPH_WAVELET_REV53, &image);
+
+    std::vector<ojph::si32> full = decode(file, 0, rw, rh);
+    EXPECT_EQ(full, image); // lossless at full resolution
+
+    std::vector<ojph::si32> level1 = decode(file, 1, rw, rh);
+    ASSERT_EQ(rw, 4u);
+    ASSERT_EQ(rh, 4u);
+    bool any_nonzero = false;
+    for (ojph::si32 v : level1)
+      any_nonzero = any_nonzero || (v != 0);
+    // the 5/3 update step leaks the odd-position impulse into the
+    // low-pass subband; if this ever starts failing, the 5/3 kernel is
+    // not being applied correctly
+    EXPECT_TRUE(any_nonzero)
+      << "rev53 level 1 unexpectedly equals the exact subsample";
+  }
+
+  {
+    ojph::mem_outfile file;
+    encode(file, width, height, num_decomps,
+           ojph::param_cod::OJPH_WAVELET_REV13, &image);
+
+    std::vector<ojph::si32> full = decode(file, 0, rw, rh);
+    EXPECT_EQ(full, image); // lossless at full resolution
+
+    std::vector<ojph::si32> level1 = decode(file, 1, rw, rh);
+    ASSERT_EQ(rw, 4u);
+    ASSERT_EQ(rh, 4u);
+    for (ojph::si32 v : level1)
+      ASSERT_EQ(v, 0); // exactly image[::2, ::2]
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// The reversible 5/3 path shares the quantization and capability code that
+// this feature reworked; make sure it remains lossless.
+TEST(TestRev13, Rev53RemainsLossless) {
+  ojph::mem_outfile file;
+  encode(file, 255, 193, 3, ojph::param_cod::OJPH_WAVELET_REV53);
+
+  ojph::ui32 rw, rh;
+  std::vector<ojph::si32> recon = decode(file, 0, rw, rh);
+  ASSERT_EQ(rw, 255u);
+  ASSERT_EQ(rh, 193u);
+  for (ojph::ui32 y = 0; y < rh; ++y)
+    for (ojph::ui32 x = 0; x < rw; ++x)
+      ASSERT_EQ(recon[(size_t)y * rw + x], sample_value(x, y, rw, rh))
+        << "at (" << x << ", " << y << ")";
+}


### PR DESCRIPTION
Thank you for the discussion on the approach. This implements the 1/3 wavelet as a custom ATK, and reads the ATK to decode the image correctly.

Notably, we do NOT build a whole API to define the ATK, instead we define a OpenJPH specific wavelet that we can reference by name. Please let me know if you agree or disagree with this direction.

It seems to really help and your structure is really powerful that I think the changes are quite contained.

The comments are likely overly verbose, let me know if you want me to really trim them, but I think I mostly understand the changes.

Closes #261 

<details><summary>Claude longer description</summary>

## What this adds

A reversible **predict-only ("1/3") wavelet**: the 5/3 kernel with its update step nulled, signaled with a JPEG 2000 **Part 2 ATK marker segment** (index 2, `Rsiz |= 0x8000 | 0x20`). With this kernel, the LL band of every decomposition holds the even-indexed samples of the previous resolution untouched, so decoding with r skipped resolutions returns exactly `image[::2^r, ::2^r]` — no filtering, no values absent from the original — while full-resolution decoding remains lossless. The intended use is AI-generated label/mask images (microscopy), where interpolated "in-between" values are illegal.

- `param_atk::init_rev13()` — the kernel. It keeps a **null** update step (`A=0, B=0, E=0`) rather than dropping it: with `m_init = 0` the first synthesis step operates on the even-indexed subsequence, so a predict-only kernel needs an even number of steps (a literal 1-step kernel corrupts reconstruction).
- `param_atk::write()` — ATK marker segment serialization (reversible, whole-sample symmetric, single-coefficient steps; byte layout mirrors `read()` and was cross-checked against a Kakadu-generated ATK stream).
- Public `param_cod::set_wavelet_kern()` / `get_wavelet_kern()`; `write_headers()` emits the ATK segment for kernels ≥ 2.
- `param_qcd::make_quant_steps()` and `param_cap` Ccap now route through `is_reversible()` so ATK-referenced kernels get correct QCD/CAP values (previously QCD was silently left uninitialized for `wavelet_trans >= 2`).
- `param_cod::is_predict_only()` — detects exact-subsampling kernels by inspecting the **ATK lifting steps**, never the kernel index (which is file-local in Part 2; your test suite's `simple_dec_irv53_bhvhb_low_latency.jph` uses index 2 for an irreversible 5/3, and correctly reports `false`).

## What did not change

The decode path. Your existing generic ATK machinery handles this kernel as-is — we verified that **stock OpenJPH (≥ 0.30) decodes these codestreams bit-exactly at every resolution level**, so only encoders need this patch.

## Testing

New self-contained library-API tests in `tests/test_rev13.cpp` (in-memory encode/decode, no reference codestreams needed, modeled on `test_mixed_coc.cpp`):

- full-res losslessness + `image[::2^r, ::2^r]` exactness at every level, for even/odd dimensions including single-row/column images;
- ATK marker presence and step-based kernel detection (`is_predict_only`), with Part 1 kernels asserting the negative;
- a handcrafted 8x8 image with a single impulse at odd coordinates (1, 1): the exact subsample is all zeros, and the test asserts the 5/3 update step *leaks* the impulse into resolution level 1 while the predict-only kernel returns exactly the all-zero subsample — both lossless at full resolution.

All 90 ctest tests pass (including the Kakadu ATK/DFS decode tests); shared+static builds.
- On 4096×4096 masks this kernel also compresses ~27% *better* than rev53 (no update-step smearing), ~13–20 ms encode / ~11 ms decode per image.

Happy to split, rename (e.g. the `rev13` name), add tests in your preferred style, or adjust the API surface (e.g. decoupling the public kernel enum from the ATK index) — whatever makes review easiest.

</details>
