### PR TITLE
fix(build): fix building AVX-512 runtime dispatch code with Clang/MSVC

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -79,7 +79,7 @@ else()
       endif()
 
       # Set compilation flags
-      if (MSVC)
+      if (MSVC AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         set_source_files_properties(codestream/ojph_codestream_avx.cpp PROPERTIES COMPILE_FLAGS "/arch:AVX")
         set_source_files_properties(codestream/ojph_codestream_avx2.cpp PROPERTIES COMPILE_FLAGS "/arch:AVX2")
         set_source_files_properties(coding/ojph_block_decoder_avx2.cpp PROPERTIES COMPILE_FLAGS "/arch:AVX2")


### PR DESCRIPTION
On certain setups, for example, FullLTO, MSVC-style architecture / instruction set flags are not enough for Clang/MSVC (clang-cl). Pass more fine-grained GNU-style arch / IS flags to Clang under MSVC, which are still accepted directly and resolve such issues.

Closes #326