### PR TITLE
Decode HT codestreams with more than one quality layer

### DIFF
--- a/src/core/codestream/ojph_codeblock.h
+++ b/src/core/codestream/ojph_codeblock.h
@@ -118,6 +118,15 @@ namespace ojph {
       ui32 num_passes;       // number of passes to be decoded
       ui32 Kmax;
       ui32 missing_msbs;
+      // Parsing state, live while the packets of a precinct are read. It has
+      // to survive from one quality layer of a codeblock to the next, which
+      // is why it lives here and not in precinct::parse.
+      // included   : has contributed to an earlier quality layer
+      // in_layer   : contributes to the packet being read now
+      // Lblock_m3  : Lblock biased by 3, so zero means 3
+      ui8 included;
+      ui8 in_layer;
+      ui8 Lblock_m3;
       coded_lists *next_coded;
 
       static const int prefix_buf_size = 8;

--- a/src/core/codestream/ojph_codeblock.h
+++ b/src/core/codestream/ojph_codeblock.h
@@ -121,12 +121,34 @@ namespace ojph {
       // Parsing state, live while the packets of a precinct are read. It has
       // to survive from one quality layer of a codeblock to the next, which
       // is why it lives here and not in precinct::parse.
-      // included   : has contributed to an earlier quality layer
-      // in_layer   : contributes to the packet being read now
-      // Lblock_m3  : Lblock biased by 3, so zero means 3
+      // placeholder_passes : 3*P0 (T.814 B.1), or all ones while the
+      //                      placeholder run is still open
+      // pass_index         : index of the codeblock's next coding pass
+      // pkt_*              : the byte counts the packet in hand contributes,
+      //                      handed from its header to its data
+      // sets_seen          : HT sets seen so far
+      // decoded_set_skip   : S_skip of the set being decoded (T.814 B.3)
+      // included           : has contributed to an earlier quality layer
+      // in_layer           : contributes to the packet being read now
+      // has_cleanup        : holds a real HT cleanup segment
+      // starts_new_set     : this packet began a new HT set
+      // Lblock_m3          : Lblock biased by 3, so zero means 3
+      // set_passes         : coding passes gathered in the current HT set
+      // zero_bitplanes     : P, the missing MSBs the packet header codes
+      ui32 placeholder_passes;
+      ui32 pass_index;
+      ui32 pkt_pre_skip;
+      ui32 pkt_cleanup;
+      ui32 pkt_refine;
+      ui16 sets_seen;
+      ui16 decoded_set_skip;
       ui8 included;
       ui8 in_layer;
+      ui8 has_cleanup;
+      ui8 starts_new_set;
       ui8 Lblock_m3;
+      ui8 set_passes;
+      ui8 zero_bitplanes;
       coded_lists *next_coded;
 
       static const int prefix_buf_size = 8;

--- a/src/core/codestream/ojph_codestream_local.cpp
+++ b/src/core/codestream/ojph_codestream_local.cpp
@@ -796,10 +796,18 @@ namespace ojph {
           received_markers |= 1;
           ojph::param_cod c(&cod);
           int num_qlayers = c.get_num_layers();
-          if (num_qlayers != 1)
-            OJPH_ERROR(0x00030053, "The current implementation supports "
-              "1 quality layer only.  This codestream has %d quality layers",
-              num_qlayers);
+          // T.800 Table A.17: a codestream carries at least one quality
+          // layer. Without this a codestream that says zero would decode to
+          // an empty image rather than being reported.
+          if (num_qlayers < 1)
+            OJPH_ERROR(0x00030053, "This codestream says it has %d quality "
+              "layers; there has to be at least one.", num_qlayers);
+          // The inclusion tag tree stores the layer of first inclusion in
+          // one byte per node, so it cannot represent a layer index above
+          // 255.
+          if (num_qlayers > 256)
+            OJPH_ERROR(0x00030058, "This codestream has %d quality layers; "
+              "at most 256 are supported.", num_qlayers);
         }
         else if (marker_idx == 4)
         {

--- a/src/core/codestream/ojph_codestream_local.cpp
+++ b/src/core/codestream/ojph_codestream_local.cpp
@@ -43,6 +43,7 @@
 #include "ojph_params.h"
 #include "ojph_codestream_local.h"
 #include "ojph_tile.h"
+#include "ojph_precinct.h" // for precinct::num_parse_tag_trees
 
 #include "../transform/ojph_colour.h"
 #include "../transform/ojph_transform.h"
@@ -211,8 +212,11 @@ namespace ojph {
       // We need 4 such tables. These tables store
       // 1. missing msbs and 2. their flags,
       // 3. number of layers and 4. their flags
+      // A precinct is parsed with one set of these per subband, so the
+      // buffer holds precinct::num_parse_tag_trees of them.
       precinct_scratch_needed_bytes =
-        4 * ((max_ratio * max_ratio * 4 + 2) / 3);
+        precinct::num_parse_tag_trees
+        * ((max_ratio * max_ratio * 4 + 2) / 3);
 
       allocator->pre_alloc_obj<ui8>(precinct_scratch_needed_bytes);
     }

--- a/src/core/codestream/ojph_codestream_local.cpp
+++ b/src/core/codestream/ojph_codestream_local.cpp
@@ -183,40 +183,38 @@ namespace ojph {
         allocator->pre_alloc_obj<param_tlm::Ttlm_Ptlm_pair>(num_tileparts);
 
       //precinct scratch buffer
-      // The precinct scratch is shared by all components, but each component
-      // may override the codeblock/precinct geometry via a COC marker.  The
-      // per-component tag-tree storage (resolution.cpp) is derived from that
-      // component's effective params, so size the shared buffer from the
-      // largest ratio across every component (the main COD and all COC
-      // overrides).  Sizing from the COD alone under-reserves the buffer for
-      // any component whose COC declares a smaller codeblock than the COD.
-      size ratio;
+      // Shared by all components, so sized from the largest codeblock count
+      // any of them reaches; a COC may declare a smaller codeblock than the
+      // COD, and sizing from the COD alone would under-reserve. Bounded by
+      // the component extent, as resolution::pre_alloc is.
+      size max_cbs(1, 1);
       for (ui32 c = 0; c < num_comps; ++c)
       {
         const param_cod* cdp = cod.get_coc(c);
         ui32 num_decomps = cdp->get_num_decompositions();
         size log_cb = cdp->get_log_block_dims();
+        ui32 shift_w = ojph_min(log_cb.w, (ui32)31);
+        ui32 shift_h = ojph_min(log_cb.h, (ui32)31);
         for (ui32 r = 0; r <= num_decomps; ++r)
         {
           size log_PP = cdp->get_log_precinct_size(r);
-          ratio.w = ojph_max(ratio.w, log_PP.w - ojph_min(log_cb.w, log_PP.w));
-          ratio.h = ojph_max(ratio.h, log_PP.h - ojph_min(log_cb.h, log_PP.h));
+          ui32 by_ratio_w = 1u << (log_PP.w - ojph_min(log_cb.w, log_PP.w));
+          ui32 by_ratio_h = 1u << (log_PP.h - ojph_min(log_cb.h, log_PP.h));
+          ui32 ds = num_decomps - r;
+          ui32 res_w = siz.get_recon_width(c) >> ojph_min(ds, (ui32)31);
+          ui32 res_h = siz.get_recon_height(c) >> ojph_min(ds, (ui32)31);
+          max_cbs.w = ojph_max(max_cbs.w,
+            ojph_min(by_ratio_w, (res_w >> shift_w) + 2));
+          max_cbs.h = ojph_max(max_cbs.h,
+            ojph_min(by_ratio_h, (res_h >> shift_h) + 2));
         }
       }
-      ui32 max_ratio = ojph_max(ratio.w, ratio.h);
-      max_ratio = 1 << max_ratio;
-      // assuming that we have a hierarchy of n levels.
-      // This needs 4/3 times the area, rounded up
-      // (rounding up leaves one extra entry).
-      // This exta entry is necessary
-      // We need 4 such tables. These tables store
-      // 1. missing msbs and 2. their flags,
-      // 3. number of layers and 4. their flags
-      // A precinct is parsed with one set of these per subband, so the
-      // buffer holds precinct::num_parse_tag_trees of them.
+      // Missing msbs, the layer of first inclusion, and a flag tree for
+      // each: one set per subband, for num_parse_tag_trees in all.
       precinct_scratch_needed_bytes =
-        precinct::num_parse_tag_trees
-        * ((max_ratio * max_ratio * 4 + 2) / 3);
+        (size_t)precinct::num_parse_tag_trees
+        * (size_t)precinct::num_tag_tree_bytes(
+                    precinct::num_tag_tree_levels(max_cbs));
 
       allocator->pre_alloc_obj<ui8>(precinct_scratch_needed_bytes);
     }

--- a/src/core/codestream/ojph_params_local.h
+++ b/src/core/codestream/ojph_params_local.h
@@ -559,6 +559,12 @@ namespace ojph {
       }
 
       ////////////////////////////////////////
+      ui32 get_num_layers() const
+      {
+        return SGCod.num_layers;
+      }
+
+      ////////////////////////////////////////
       // SOP and EPH usage is signalled only in Scod of the COD marker
       // segment; Scoc carries just the precinct bit (T.800 Table A.23). A
       // component that has a COC therefore inherits these two flags from

--- a/src/core/codestream/ojph_params_local.h
+++ b/src/core/codestream/ojph_params_local.h
@@ -559,11 +559,15 @@ namespace ojph {
       }
 
       ////////////////////////////////////////
+      // SOP and EPH usage is signalled only in Scod of the COD marker
+      // segment; Scoc carries just the precinct bit (T.800 Table A.23). A
+      // component that has a COC therefore inherits these two flags from
+      // the COD it overrides, rather than reading them as absent.
       bool packets_may_use_sop() const
       {
         if (type == COD_MAIN || type == COD_TILE)
           return (Scod & 2) == 2;
-        return false;
+        return top_cod != NULL ? top_cod->packets_may_use_sop() : false;
       }
 
       ////////////////////////////////////////
@@ -571,7 +575,7 @@ namespace ojph {
       {
         if (type == COD_MAIN || type == COD_TILE)
           return (Scod & 4) == 4;
-        return false;
+        return top_cod != NULL ? top_cod->packets_use_eph() : false;
       }
 
       ////////////////////////////////////////

--- a/src/core/codestream/ojph_precinct.cpp
+++ b/src/core/codestream/ojph_precinct.cpp
@@ -91,6 +91,12 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
+    ui32 precinct::num_tag_tree_levels(size num_cbs)
+    {
+      return 1 + ojph_max(log2ceil(num_cbs.w), log2ceil(num_cbs.h));
+    }
+
+    //////////////////////////////////////////////////////////////////////////
     ui32 precinct::prepare_precinct(int tag_tree_size, ui32* lev_idx,
                                     mem_elastic_allocator* elastic)
     {
@@ -107,8 +113,7 @@ namespace ojph {
         if (cb_idxs[s].siz.w == 0 || cb_idxs[s].siz.h == 0)
           continue;
 
-        ui32 num_levels = 1 +
-          ojph_max(log2ceil(cb_idxs[s].siz.w), log2ceil(cb_idxs[s].siz.h));
+        ui32 num_levels = num_tag_tree_levels(cb_idxs[s].siz);
 
         //create quad trees for inclusion and missing msbs
         tag_tree inc_tag, inc_tag_flags, mmsb_tag, mmsb_tag_flags;
@@ -354,8 +359,7 @@ namespace ojph {
           empty_packet = false;
         }
 
-        ui32 num_levels = 1 +
-          ojph_max(log2ceil(cb_idxs[s].siz.w), log2ceil(cb_idxs[s].siz.h));
+        ui32 num_levels = num_tag_tree_levels(cb_idxs[s].siz);
 
         //create quad trees for inclusion and missing msbs
         tag_tree inc_tag, inc_tag_flags, mmsb_tag, mmsb_tag_flags;

--- a/src/core/codestream/ojph_precinct.cpp
+++ b/src/core/codestream/ojph_precinct.cpp
@@ -393,6 +393,35 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
+    // Reads bytes into a caller supplied buffer with the same accounting
+    // bb_read_chunk does. Needed because the segments of one HT set can arrive
+    // in different packets and have to end up contiguous.
+    static bool read_bytes_into(bit_read_buf* bbp, ui8* dst, ui32 num_bytes)
+    {
+      ui32 bytes = ojph_min(num_bytes, bbp->bytes_left);
+      ui32 bytes_read = (ui32)bbp->file->read(dst, bytes);
+      if (num_bytes > bytes_read)
+        memset(dst + bytes_read, 0, num_bytes - bytes_read);
+      bbp->bytes_left -= bytes_read;
+      return bytes_read == bytes;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    // 3*P0 is not known while a codeblock is still inside its placeholder run,
+    // which can be spread over several packets.
+    static const ui32 placeholder_passes_unknown = 0xFFFFFFFFu;
+
+    //////////////////////////////////////////////////////////////////////////
+    // Consumes bytes of an HT set that a later set supersedes.
+    static void skip_bytes(bit_read_buf* bbp, infile_base* file, ui32 num_bytes)
+    {
+      ui32 bytes = ojph_min(num_bytes, bbp->bytes_left);
+      si64 start = file->tell();
+      file->seek((si64)bytes, infile_base::OJPH_SEEK_CUR);
+      bbp->bytes_left -= (ui32)(file->tell() - start);
+    }
+
+    //////////////////////////////////////////////////////////////////////////
     void precinct::parse(int tag_tree_size, ui32* lev_idx,
                          mem_elastic_allocator *elastic,
                          ui32 &data_left, infile_base *file, bool skipped,
@@ -428,6 +457,17 @@ namespace ojph {
               continue;
             cp->included = 0;
             cp->Lblock_m3 = 0;
+            cp->has_cleanup = 0;
+            cp->starts_new_set = 0;
+            cp->set_passes = 0;
+            cp->placeholder_passes = placeholder_passes_unknown;
+            cp->pass_index = 0;
+            cp->sets_seen = 0;
+            cp->zero_bitplanes = 0;
+            cp->decoded_set_skip = 0;
+            cp->pkt_pre_skip = 0;
+            cp->pkt_cleanup = 0;
+            cp->pkt_refine = 0;
           }
         }
       }
@@ -531,7 +571,7 @@ namespace ojph {
                 throw "error in parsing a tile header; "
                 "missing msbs are larger or equal to Kmax. The most likely "
                 "cause is a corruption in the bitstream.";
-              cp->missing_msbs = mmsbs;
+              cp->zero_bitplanes = (ui8)mmsbs;
               cp->included = 1;
             }
 
@@ -563,23 +603,6 @@ namespace ojph {
                 }
               }
             }
-            cp->num_passes = num_passes;
-
-            // Parse pass lengths
-            // When number of passes is one, one length.
-            // When number of passes is two or three, two lengths.
-            // When number of passes > 3, we have place holder passes;
-            // In this case, subtract multiples of 3 from the number of
-            // passes; for example, if we have 10 passes, we subtract 9,
-            // producing 1 pass.
-
-            // 1 => 1, 2 => 2, 3 => 3, 4 => 1, 5 => 2, 6 => 3
-            ui32 num_phld_passes = (num_passes - 1) / 3;
-            cp->missing_msbs += num_phld_passes;
-
-            num_phld_passes *= 3;
-            cp->num_passes = num_passes - num_phld_passes;
-            cp->pass_length[0] = cp->pass_length[1] = 0;
 
             // Lblock grows monotonically over the layers that include this
             // codeblock, so it lives with the codeblock.
@@ -587,39 +610,166 @@ namespace ojph {
             bit = 1;
             while (bit)
             {
-              // add any extra bits here
               if (bb_read_bit(&bb, bit) == false)
               { data_left = 0; throw "error reading from file p8"; }
               Lblock += bit;
             }
             cp->Lblock_m3 = (ui8)(Lblock - 3);
 
-            int bits = Lblock + 31 -
-              (int)count_leading_zeros(num_phld_passes + 1);
-            if (bb_read_bits(&bb, bits, bit) == false)
-            { data_left = 0; throw "error reading from file p9"; }
-            if (bit < 2)
-              throw "The cleanup segment of an HT codeblock cannot contain "
-                "less than 2 bytes";
-            if (bit >= 65535)
-              throw "The cleanup segment of an HT codeblock must contain "
-                "less than 65535 bytes";
-            cp->pass_length[0] = bit;
+            // T.814 B.2: segment boundaries lie at pass indices
+            //   T = union over k of (3*P0 + ceil(3k/2)),
+            // so past the placeholder run a cleanup segment covers one pass
+            // and the refinement segment after it covers up to two. Each
+            // segment carries its own length, so walk them one at a time.
+            ui32 remaining = num_passes;
+            cp->pkt_pre_skip = 0;
+            cp->pkt_cleanup = 0;
+            cp->pkt_refine = 0;
+            cp->starts_new_set = 0;
 
-            if (cp->num_passes > 1)
+            while (remaining > 0)
             {
-              //bits = Lblock + 31 - count_leading_zeros(cp->num_passes - 1);
-              // The following is simpler than the above, I think?
-              bits = Lblock + (cp->num_passes > 2 ? 1 : 0);
-              if (bb_read_bits(&bb, bits, bit) == false)
-              { data_left = 0; throw "error reading from file p10"; }
-              if (bit >= 2047)
-                throw "The refinement segment (SigProp and MagRep passes) of "
-                  "an HT codeblock must contain less than 2047 bytes";
-              cp->pass_length[1] = bit;
+              bool is_cleanup;
+              ui32 seg_passes;
+              ui32 seg_len;
+              int bits;
+
+              if (cp->placeholder_passes == placeholder_passes_unknown)
+              {
+                // A codeblock's 3*P0 placeholder passes carry no bytes and
+                // all lie ahead of its first HT set (T.814 B.1), but the run
+                // can be split over several packets like any other run of
+                // coding passes, so P0 is not known from the first
+                // contribution alone. What is known is that a real first HT
+                // cleanup segment is longer than one byte (T.814 B.3), so a
+                // length of zero means the run is still open.
+                //
+                // While it is open there is exactly one codeword segment
+                // either way, because no member of T lies below 3*P0, so
+                // only the width of that one length field is in question.
+                // Read the narrower field first; a zero picks the wider
+                // reading, whose remaining bits must be zero as well.
+                ui32 triple = 3 * ((cp->pass_index + remaining - 1) / 3);
+                int wide = Lblock + 31 - (int)count_leading_zeros(remaining);
+                int narrow = wide;
+                bool cleanup_in_reach = triple >= cp->pass_index;
+                if (cleanup_in_reach)
+                {
+                  ui32 n = triple - cp->pass_index + 1;
+                  narrow = Lblock + 31 - (int)count_leading_zeros(n);
+                }
+                if (bb_read_bits(&bb, narrow, bit) == false)
+                { data_left = 0; throw "error reading from file p9"; }
+                seg_len = bit;
+
+                if (seg_len != 0 && !cleanup_in_reach)
+                  throw "error in parsing a packet header; a codeblock "
+                    "still inside its placeholder run reports codeword "
+                    "segment bytes, but the segment cannot contain an HT "
+                    "cleanup pass. The most likely cause is a corruption "
+                    "in the bitstream.";
+
+                if (seg_len == 0)
+                { // still placeholder passes: no segment, no bytes
+                  if (wide > narrow
+                      && bb_read_bits(&bb, wide - narrow, bit) == false)
+                  { data_left = 0; throw "error reading from file p10"; }
+                  cp->pass_index += remaining;
+                  remaining = 0;
+                  continue;
+                }
+
+                cp->placeholder_passes = triple;
+                is_cleanup = true;
+                seg_passes = triple - cp->pass_index + 1;
+                bits = narrow;
+              }
+              else
+              {
+                if (cp->pass_index <= cp->placeholder_passes)
+                {
+                  // the tail of the placeholder run shares a codeword
+                  // segment with the first HT cleanup pass
+                  is_cleanup = true;
+                  seg_passes = cp->placeholder_passes + 1 - cp->pass_index;
+                }
+                else
+                {
+                  ui32 rel = cp->pass_index - cp->placeholder_passes;
+                  if (rel % 3 == 0)
+                  { is_cleanup = true;  seg_passes = 1; }
+                  else if (rel % 3 == 1)
+                  { is_cleanup = false; seg_passes = 2; }
+                  else
+                  { is_cleanup = false; seg_passes = 1; }
+                }
+
+                if (seg_passes > remaining)
+                  seg_passes = remaining;
+
+                bits = Lblock + 31 - (int)count_leading_zeros(seg_passes);
+                if (bb_read_bits(&bb, bits, bit) == false)
+                { data_left = 0; throw "error reading from file p9"; }
+                seg_len = bit;
+              }
+
+              // T.814 B.3 bounds a codeword segment's length, and the bound
+              // belongs here, where the length is read, because the packet
+              // body reader sizes an allocation from the accumulated lengths
+              // before it has looked at how many bytes the packet holds. A
+              // segment split over two codeword segments is bounded again
+              // over the concatenation, further below.
+              if (is_cleanup && seg_len == 1)
+                throw "The cleanup segment of an HT codeblock cannot "
+                  "contain exactly one byte";
+              if (is_cleanup && seg_len >= 65535)
+                throw "The cleanup segment of an HT codeblock must "
+                  "contain less than 65535 bytes";
+              if (!is_cleanup && seg_len >= 2047)
+                throw "The refinement segment (SigProp and MagRef passes) "
+                  "of an HT codeblock must contain less than 2047 bytes";
+
+              if (is_cleanup)
+              {
+                ++cp->sets_seen;
+                // A zero length cleanup segment means the HT set contributes
+                // nothing; such sets exist to skip magnitude bit-planes
+                // (T.814 B.3), and the refinement segment of the same set is
+                // empty too.
+                if (seg_len > 0)
+                {
+                  // A new HT set supersedes anything gathered before it.
+                  cp->pkt_pre_skip += cp->pkt_cleanup + cp->pkt_refine;
+                  cp->pkt_cleanup = seg_len;
+                  cp->pkt_refine = 0;
+                  cp->starts_new_set = 1;
+                  // Z_blk counts the coding passes of the HT set, so a
+                  // cleanup segment contributes exactly one however many
+                  // placeholder passes share its codeword segment.
+                  cp->set_passes = 1;
+                  // T.814 B.3: S_skip counts the HT sets ahead of the one
+                  // being decoded, so it has to be taken now. Empty sets
+                  // arriving later must not inflate it.
+                  cp->decoded_set_skip = (ui16)(cp->sets_seen - 1);
+                }
+              }
+              else if (seg_len > 0)
+              {
+                if (cp->starts_new_set || cp->has_cleanup)
+                {
+                  cp->pkt_refine += seg_len;
+                  cp->set_passes = (ui8)(cp->set_passes + seg_passes);
+                }
+                else
+                  cp->pkt_pre_skip += seg_len;
+              }
+
+              cp->pass_index += seg_passes;
+              remaining -= seg_passes;
             }
 
-            cp->in_layer = 1;
+            if (cp->pkt_cleanup || cp->pkt_refine || cp->pkt_pre_skip)
+              cp->in_layer = 1;
           }
         }
       }
@@ -648,28 +798,88 @@ namespace ojph {
             cp += cb_idxs[s].org.x + (y + cb_idxs[s].org.y) * band_width;
             for (ui32 x = 0; x < width; ++x, ++cp)
             {
-              if (cp->in_layer == 0)
+              if (cp->in_layer == 0 || data_left == 0)
                 continue;
-              if (data_left == 0)
-              { cp->pass_length[0] = cp->pass_length[1] = 0; continue; }
 
-              ui32 num_bytes = cp->pass_length[0] + cp->pass_length[1];
               if (skipped)
               { //no need to read
-                si64 cur_loc = file->tell();
-                ui32 t = ojph_min(num_bytes, bb.bytes_left);
-                file->seek(t, infile_base::OJPH_SEEK_CUR);
-                ui32 bytes_read = (ui32)(file->tell() - cur_loc);
+                skip_bytes(&bb, file,
+                  cp->pkt_pre_skip + cp->pkt_cleanup + cp->pkt_refine);
                 cp->pass_length[0] = cp->pass_length[1] = 0;
-                bb.bytes_left -= bytes_read;
-                assert(bytes_read == t || bb.bytes_left == 0);
+                continue;
               }
-              else if (!bb_read_chunk(&bb, num_bytes, cp->next_coded,
-                                      elastic))
-              { //no need to decode a broken codeblock
-                cp->pass_length[0] = cp->pass_length[1] = 0;
-                data_left = 0;
+
+              // Bytes of HT sets that a later set replaces are consumed and
+              // dropped.
+              if (cp->pkt_pre_skip)
+                skip_bytes(&bb, file, cp->pkt_pre_skip);
+
+              if (cp->starts_new_set)
+              {
+                ui32 total = cp->pkt_cleanup + cp->pkt_refine;
+                if (!bb_read_chunk(&bb, total, cp->next_coded, elastic))
+                {
+                  cp->pass_length[0] = cp->pass_length[1] = 0;
+                  data_left = 0;
+                  continue;
+                }
+                cp->pass_length[0] = cp->pkt_cleanup;
+                cp->pass_length[1] = cp->pkt_refine;
+                cp->has_cleanup = 1;
               }
+              else if (cp->pkt_refine)
+              {
+                // T.814 B.3: an HT segment's bytes are the concatenation of
+                // its codeword segments, so a refinement segment arriving
+                // after its cleanup segment is appended rather than replacing
+                // it.
+                ui32 held = cp->pass_length[0] + cp->pass_length[1];
+                coded_lists* previous = cp->next_coded;
+                elastic->get_buffer(held + cp->pkt_refine
+                  + coded_cb_header::prefix_buf_size
+                  + coded_cb_header::suffix_buf_size, cp->next_coded);
+                if (held && previous)
+                  memcpy(cp->next_coded->buf
+                    + coded_cb_header::prefix_buf_size,
+                    previous->buf + coded_cb_header::prefix_buf_size, held);
+                if (!read_bytes_into(&bb, cp->next_coded->buf
+                      + coded_cb_header::prefix_buf_size + held,
+                      cp->pkt_refine))
+                {
+                  cp->pass_length[0] = cp->pass_length[1] = 0;
+                  data_left = 0;
+                  continue;
+                }
+                cp->pass_length[1] += cp->pkt_refine;
+              }
+
+              // The limits above bound each codeword segment as it is read;
+              // these repeat them over the concatenation, which is what
+              // T.814 B.3 actually bounds, because a refinement segment can
+              // be split over two codeword segments in different packets.
+              if (cp->pass_length[0] == 1)
+                throw "The cleanup segment of an HT codeblock cannot "
+                  "contain exactly one byte";
+              if (cp->pass_length[0] >= 65535)
+                throw "The cleanup segment of an HT codeblock must contain "
+                  "less than 65535 bytes";
+              if (cp->pass_length[1] >= 2047)
+                throw "The refinement segment (SigProp and MagRef passes) of "
+                  "an HT codeblock must contain less than 2047 bytes";
+
+              // T.814 B.3: Z_blk, the number of coding passes the decoder
+              // processes, is 1 when the cleanup segment is the only
+              // non-empty segment of the set.
+              cp->num_passes = cp->pass_length[1] == 0
+                ? 1u : (ui32)cp->set_passes;
+
+              // T.814 B.3: S_blk = P + P0 + S_skip, where S_skip counts the
+              // HT sets ahead of the one being decoded. Reaching here means
+              // a cleanup segment was committed, so P0 is known.
+              assert(cp->placeholder_passes != placeholder_passes_unknown);
+              cp->missing_msbs = cp->zero_bitplanes
+                + cp->placeholder_passes / 3
+                + cp->decoded_set_skip;
             }
           }
         }

--- a/src/core/codestream/ojph_precinct.cpp
+++ b/src/core/codestream/ojph_precinct.cpp
@@ -38,6 +38,7 @@
 
 #include <climits>
 #include <cmath>
+#include <cstring>
 
 #include "ojph_mem.h"
 #include "ojph_params.h"
@@ -57,7 +58,12 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     struct tag_tree
     {
-      void init(ui8* buf, ui32 *lev_idx, ui32 num_levels, size s, int init_val)
+      // Points the tree at its storage without touching the contents, so a
+      // tree that an earlier packet of the same precinct left partly decoded
+      // can be picked up where it stopped. The decode path clears the whole
+      // of a precinct's tag tree storage in one go instead, which is enough
+      // because every one of its trees starts out all zeros.
+      void assign(ui8* buf, ui32 *lev_idx, ui32 num_levels, size s)
       {
         for (ui32 i = 0; i <= num_levels; ++i) //on extra level
           levs[i] = buf + lev_idx[i];
@@ -65,13 +71,18 @@ namespace ojph {
           levs[i] = (ui8*)INT_MAX; //make it crash on error
         width = s.w;
         height = s.h;
+        this->num_levels = num_levels;
+      }
+
+      void init(ui8* buf, ui32 *lev_idx, ui32 num_levels, size s, int init_val)
+      {
+        assign(buf, lev_idx, num_levels, s);
         for (ui32 i = 0; i < num_levels; ++i)
         {
           ui32 size = 1u << ((num_levels - 1 - i) << 1);
           memset(levs[i], init_val, size);
         }
         *levs[num_levels] = 0;
-        this->num_levels = num_levels;
       }
 
       ui8* get(ui32 x, ui32 y, ui32 lev)
@@ -330,18 +341,105 @@ namespace ojph {
 
 
     //////////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////
+    // Decodes one tag tree leaf up to a threshold, keeping partially decoded
+    // state so decoding can continue in a later quality layer.
+    //
+    // A node's value is a lower bound that grows as 0 bits are read; a 1 bit
+    // fixes the value, which the flags tree records. When the value reaches the
+    // threshold before being fixed, decoding stops: the caller only learns the
+    // value is at least the threshold, and a later layer with a higher
+    // threshold resumes from here.
+    //
+    // With one quality layer the threshold is always 1 and this reduces to
+    // reading one bit per level, which is what the single-layer path did.
+    static bool tag_tree_decode(bit_read_buf* bb, tag_tree& val,
+                                tag_tree& known, ui32 x, ui32 y,
+                                ui32 num_levels, ui32 threshold,
+                                ui32& result)
+    {
+      ui32 lower_bound = 0;
+      for (ui32 levp1 = num_levels; levp1 > 0; --levp1)
+      {
+        ui32 cur_lev = levp1 - 1;
+        ui8* v = val.get(x >> cur_lev, y >> cur_lev, cur_lev);
+        ui8* k = known.get(x >> cur_lev, y >> cur_lev, cur_lev);
+
+        if (*v < lower_bound)
+          *v = (ui8)lower_bound;
+
+        while (*k == 0 && *v < threshold)
+        {
+          ui32 bit;
+          if (bb_read_bit(bb, bit) == false)
+            return false;
+          if (bit)
+            *k = 1;
+          else
+            *v = (ui8)(*v + 1);
+        }
+
+        if (*k == 0)
+        {
+          result = *v;
+          return true;
+        }
+
+        lower_bound = *v;
+      }
+
+      result = lower_bound;
+      return true;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
     void precinct::parse(int tag_tree_size, ui32* lev_idx,
                          mem_elastic_allocator *elastic,
-                         ui32 &data_left, infile_base *file,
-                         bool skipped)
+                         ui32 &data_left, infile_base *file, bool skipped,
+                         ui32 layer)
     {
       assert(data_left > 0);
+
+      // A precinct's packets arrive in order of increasing quality layer,
+      // whichever progression order the codestream uses, so its first packet
+      // is where the state the others build on is cleared: the tag trees,
+      // which are decoded incrementally, and the per codeblock parse state in
+      // coded_cb_header. Every one of a precinct's tag trees starts out all
+      // zeros, so one memset over their storage does for all of them.
+      bool first_packet = (layer == 0);
+      if (first_packet)
+        memset(scratch, 0,
+               (size_t)num_parse_tag_trees * (size_t)tag_tree_size);
+
+      // Only codeblocks contributing to this packet have bytes in it.
+      for (int s = 0; s < 4; ++s)
+      {
+        if (bands[s].empty || cb_idxs[s].siz.w == 0 || cb_idxs[s].siz.h == 0)
+          continue;
+        ui32 band_width = bands[s].num_blocks.w;
+        for (ui32 y = 0; y < cb_idxs[s].siz.h; ++y)
+        {
+          coded_cb_header* cp = bands[s].coded_cbs;
+          cp += cb_idxs[s].org.x + (y + cb_idxs[s].org.y) * band_width;
+          for (ui32 x = 0; x < cb_idxs[s].siz.w; ++x, ++cp)
+          {
+            cp->in_layer = 0;
+            if (!first_packet)
+              continue;
+            cp->included = 0;
+            cp->Lblock_m3 = 0;
+          }
+        }
+      }
+
       bit_read_buf bb;
       bb_init(&bb, data_left, file);
       if (may_use_sop)
         bb_skip_sop(&bb);
 
-      bool empty_packet = true;
+      bool non_empty_bit_read = false;
+      bool zero_length_packet = false;
+
       for (int s = 0; s < 4; ++s)
       {
         if (bands[s].empty)
@@ -350,32 +448,31 @@ namespace ojph {
         if (cb_idxs[s].siz.w == 0 || cb_idxs[s].siz.h == 0)
           continue;
 
-        if (empty_packet) //one bit to check if the packet is empty
+        if (!non_empty_bit_read) //one bit to check if the packet is empty
         {
           ui32 bit;
           bb_read_bit(&bb, bit);
+          non_empty_bit_read = true;
           if (bit == 0) //empty packet
-          { bb_terminate(&bb, uses_eph); data_left = bb.bytes_left; return; }
-          empty_packet = false;
+          { zero_length_packet = true; break; }
         }
 
+        // The inclusion and missing MSB tag trees of this subband. They live
+        // in the precinct's own storage whenever it holds more than one
+        // packet, so that a packet picks them up where the packet before it
+        // left them.
         ui32 num_levels = num_tag_tree_levels(cb_idxs[s].siz);
-
-        //create quad trees for inclusion and missing msbs
+        ui8* base = scratch
+          + (size_t)s * num_trees_per_band * (size_t)tag_tree_size;
         tag_tree inc_tag, inc_tag_flags, mmsb_tag, mmsb_tag_flags;
-        inc_tag.init(scratch, lev_idx, num_levels, cb_idxs[s].siz, 0);
-        *inc_tag.get(0, 0, num_levels) = 0;
-        inc_tag_flags.init(scratch + tag_tree_size, lev_idx, num_levels,
-          cb_idxs[s].siz, 0);
-        *inc_tag_flags.get(0, 0, num_levels) = 0;
-        mmsb_tag.init(scratch + (tag_tree_size<<1), lev_idx, num_levels,
-          cb_idxs[s].siz, 0);
-        *mmsb_tag.get(0, 0, num_levels) = 0;
-        mmsb_tag_flags.init(scratch + (tag_tree_size<<1) + tag_tree_size,
-          lev_idx, num_levels, cb_idxs[s].siz, 0);
-        *mmsb_tag_flags.get(0, 0, num_levels) = 0;
+        inc_tag.assign(base, lev_idx, num_levels, cb_idxs[s].siz);
+        inc_tag_flags.assign(base + tag_tree_size, lev_idx, num_levels,
+          cb_idxs[s].siz);
+        mmsb_tag.assign(base + (tag_tree_size << 1), lev_idx, num_levels,
+          cb_idxs[s].siz);
+        mmsb_tag_flags.assign(base + (tag_tree_size << 1) + tag_tree_size,
+          lev_idx, num_levels, cb_idxs[s].siz);
 
-        //
         ui32 band_width = bands[s].num_blocks.w;
         ui32 width = cb_idxs[s].siz.w;
         ui32 height = cb_idxs[s].siz.h;
@@ -386,56 +483,57 @@ namespace ojph {
           for (ui32 x = 0; x < width; ++x, ++cp)
           {
             //process inclusion
-            bool empty_cb = false;
-            for (ui32 cl = num_levels; cl > 0; --cl)
+            if (cp->included)
             {
-              ui32 cur_lev = cl - 1;
-              empty_cb = *inc_tag.get(x>>cur_lev, y>>cur_lev, cur_lev) == 1;
-              if (empty_cb)
-                break;
-              //check received
-              if (*inc_tag_flags.get(x>>cur_lev, y>>cur_lev, cur_lev) == 0)
-              {
-                ui32 bit;
-                if (bb_read_bit(&bb, bit) == false)
-                { data_left = 0; throw "error reading from file p1"; }
-                empty_cb = (bit == 0);
-                *inc_tag.get(x>>cur_lev, y>>cur_lev, cur_lev) = (ui8)(1 - bit);
-                *inc_tag_flags.get(x>>cur_lev, y>>cur_lev, cur_lev) = 1;
-              }
-              if (empty_cb)
-                break;
+              // Already contributing: one bit says whether this layer adds
+              // anything.
+              ui32 bit;
+              if (bb_read_bit(&bb, bit) == false)
+              { data_left = 0; throw "error reading from file p1"; }
+              if (bit == 0)
+                continue;
             }
-
-            if (empty_cb)
-              continue;
-
-            //process missing msbs
-            ui32 mmsbs = 0;
-            for (ui32 levp1 = num_levels; levp1 > 0; --levp1)
+            else
             {
-              ui32 cur_lev = levp1 - 1;
-              mmsbs = *mmsb_tag.get(x>>levp1, y>>levp1, levp1);
-              //check received
-              if (*mmsb_tag_flags.get(x>>cur_lev, y>>cur_lev, cur_lev) == 0)
+              // Not yet contributing: the tag tree codes the layer of first
+              // inclusion, decoded up to this layer's threshold.
+              ui32 first_layer = 0;
+              if (tag_tree_decode(&bb, inc_tag, inc_tag_flags, x, y,
+                    num_levels, layer + 1, first_layer) == false)
+              { data_left = 0; throw "error reading from file p1"; }
+              if (first_layer > layer)
+                continue;
+
+              //process missing msbs
+              ui32 mmsbs = 0;
+              for (ui32 levp1 = num_levels; levp1 > 0; --levp1)
               {
-                ui32 bit = 0;
-                while (bit == 0)
+                ui32 cur_lev = levp1 - 1;
+                mmsbs = *mmsb_tag.get(x>>levp1, y>>levp1, levp1);
+                //check received
+                if (*mmsb_tag_flags.get(x>>cur_lev, y>>cur_lev,
+                                        cur_lev) == 0)
                 {
-                  if (bb_read_bit(&bb, bit) == false)
-                  { data_left = 0; throw "error reading from file p2"; }
-                  mmsbs += 1 - bit;
+                  ui32 bit = 0;
+                  while (bit == 0)
+                  {
+                    if (bb_read_bit(&bb, bit) == false)
+                    { data_left = 0; throw "error reading from file p2"; }
+                    mmsbs += 1 - bit;
+                  }
+                  *mmsb_tag.get(x>>cur_lev, y>>cur_lev, cur_lev) =
+                    (ui8)mmsbs;
+                  *mmsb_tag_flags.get(x>>cur_lev, y>>cur_lev, cur_lev) = 1;
                 }
-                *mmsb_tag.get(x>>cur_lev, y>>cur_lev, cur_lev) = (ui8)mmsbs;
-                *mmsb_tag_flags.get(x>>cur_lev, y>>cur_lev, cur_lev) = 1;
               }
-            }
 
-            if (mmsbs > cp->Kmax)
-              throw "error in parsing a tile header; "
-              "missing msbs are larger or equal to Kmax. The most likely "
-              "cause is a corruption in the bitstream.";
-            cp->missing_msbs = mmsbs;
+              if (mmsbs > cp->Kmax)
+                throw "error in parsing a tile header; "
+                "missing msbs are larger or equal to Kmax. The most likely "
+                "cause is a corruption in the bitstream.";
+              cp->missing_msbs = mmsbs;
+              cp->included = 1;
+            }
 
             //get number of passes
             ui32 bit, num_passes = 1;
@@ -483,7 +581,9 @@ namespace ojph {
             cp->num_passes = num_passes - num_phld_passes;
             cp->pass_length[0] = cp->pass_length[1] = 0;
 
-            int Lblock = 3;
+            // Lblock grows monotonically over the layers that include this
+            // codeblock, so it lives with the codeblock.
+            int Lblock = 3 + cp->Lblock_m3;
             bit = 1;
             while (bit)
             {
@@ -492,6 +592,7 @@ namespace ojph {
               { data_left = 0; throw "error reading from file p8"; }
               Lblock += bit;
             }
+            cp->Lblock_m3 = (ui8)(Lblock - 3);
 
             int bits = Lblock + 31 -
               (int)count_leading_zeros(num_phld_passes + 1);
@@ -517,59 +618,59 @@ namespace ojph {
                   "an HT codeblock must contain less than 2047 bytes";
               cp->pass_length[1] = bit;
             }
+
+            cp->in_layer = 1;
           }
         }
       }
-      if (empty_packet)
-      { // all subbands are empty
+
+      if (!non_empty_bit_read)
+      { // all subbands are empty, so the zero length bit was never read
         ui32 bit = 0;
         bb_read_bit(&bb, bit);
-        //assert(bit == 0);
       }
       bb_terminate(&bb, uses_eph);
-      //read codeblock data
-      for (int s = 0; s < 4; ++s)
-      {
-        if (bands[s].empty)
-          continue;
 
-        ui32 band_width = bands[s].num_blocks.w;
-        ui32 width = cb_idxs[s].siz.w;
-        ui32 height = cb_idxs[s].siz.h;
-        for (ui32 y = 0; y < height; ++y)
+      //read codeblock data
+      if (!zero_length_packet)
+      {
+        for (int s = 0; s < 4; ++s)
         {
-          coded_cb_header *cp = bands[s].coded_cbs;
-          cp += cb_idxs[s].org.x + (y + cb_idxs[s].org.y) * band_width;
-          for (ui32 x = 0; x < width; ++x, ++cp)
+          if (bands[s].empty)
+            continue;
+
+          ui32 band_width = bands[s].num_blocks.w;
+          ui32 width = cb_idxs[s].siz.w;
+          ui32 height = cb_idxs[s].siz.h;
+          for (ui32 y = 0; y < height; ++y)
           {
-            ui32 num_bytes = cp->pass_length[0] + cp->pass_length[1];
-            if (data_left)
+            coded_cb_header *cp = bands[s].coded_cbs;
+            cp += cb_idxs[s].org.x + (y + cb_idxs[s].org.y) * band_width;
+            for (ui32 x = 0; x < width; ++x, ++cp)
             {
-              if (num_bytes)
-              {
-                if (skipped)
-                { //no need to read
-                  si64 cur_loc = file->tell();
-                  ui32 t = ojph_min(num_bytes, bb.bytes_left);
-                  file->seek(t, infile_base::OJPH_SEEK_CUR);
-                  ui32 bytes_read = (ui32)(file->tell() - cur_loc);
-                  cp->pass_length[0] = cp->pass_length[1] = 0;
-                  bb.bytes_left -= bytes_read;
-                  assert(bytes_read == t || bb.bytes_left == 0);
-                }
-                else
-                {
-                  if (!bb_read_chunk(&bb, num_bytes, cp->next_coded, elastic))
-                  {
-                    //no need to decode a broken codeblock
-                    cp->pass_length[0] = cp->pass_length[1] = 0;
-                    data_left = 0;
-                  }
-                }
+              if (cp->in_layer == 0)
+                continue;
+              if (data_left == 0)
+              { cp->pass_length[0] = cp->pass_length[1] = 0; continue; }
+
+              ui32 num_bytes = cp->pass_length[0] + cp->pass_length[1];
+              if (skipped)
+              { //no need to read
+                si64 cur_loc = file->tell();
+                ui32 t = ojph_min(num_bytes, bb.bytes_left);
+                file->seek(t, infile_base::OJPH_SEEK_CUR);
+                ui32 bytes_read = (ui32)(file->tell() - cur_loc);
+                cp->pass_length[0] = cp->pass_length[1] = 0;
+                bb.bytes_left -= bytes_read;
+                assert(bytes_read == t || bb.bytes_left == 0);
+              }
+              else if (!bb_read_chunk(&bb, num_bytes, cp->next_coded,
+                                      elastic))
+              { //no need to decode a broken codeblock
+                cp->pass_length[0] = cp->pass_length[1] = 0;
+                data_left = 0;
               }
             }
-            else
-              cp->pass_length[0] = cp->pass_length[1] = 0;
           }
         }
       }

--- a/src/core/codestream/ojph_precinct.h
+++ b/src/core/codestream/ojph_precinct.h
@@ -61,6 +61,12 @@ namespace ojph {
         scratch = NULL; bands = NULL; coded = NULL;
         may_use_sop = uses_eph = false;
       }
+
+      // The number of levels the tag trees of a precinct spanning num_cbs
+      // codeblocks in one subband need: one per power of two of the wider
+      // span, plus the root level. Only meaningful for a subband that
+      // exists and that the precinct holds codeblocks of.
+      static ui32 num_tag_tree_levels(size num_cbs);
       ui32 prepare_precinct(int tag_tree_size, ui32* lev_idx,
                             mem_elastic_allocator *elastic);
       void write(outfile_base *file);

--- a/src/core/codestream/ojph_precinct.h
+++ b/src/core/codestream/ojph_precinct.h
@@ -61,20 +61,48 @@ namespace ojph {
         scratch = NULL; bands = NULL; coded = NULL;
         may_use_sop = uses_eph = false;
       }
+      enum : ui32 {
+        // The tag trees the packets of a precinct are parsed with: the
+        // quality layer of first inclusion and the number of missing MSBs,
+        // each paired with a tree of which of its nodes are already known,
+        // for each of the four subbands.
+        num_trees_per_band = 4,
+        num_parse_tag_trees = 4 * num_trees_per_band,
+      };
 
       // The number of levels the tag trees of a precinct spanning num_cbs
       // codeblocks in one subband need: one per power of two of the wider
       // span, plus the root level. Only meaningful for a subband that
       // exists and that the precinct holds codeblocks of.
       static ui32 num_tag_tree_levels(size num_cbs);
+      // The leaves of one tag tree of that many levels, and the bytes it
+      // occupies: a quad tree needs 4/3 of its leaf count, rounded up, and
+      // the rounding leaves the one extra entry the level above the root
+      // takes. resolution::pre_alloc has to reserve a precinct's tag tree
+      // storage before the codeblocks the precinct holds are known, so it
+      // asks for the levels the precinct to codeblock ratio allows, which
+      // is what a precinct the resolution holds in full spans;
+      // resolution::finalize_alloc then lays the trees out with the levels
+      // its precincts turned out to need. Both go through here, so the two
+      // cannot drift apart.
+      static ui32 num_tag_tree_leaves(ui32 num_levels)
+      { return 1u << ((num_levels - 1) << 1); }
+      static ui32 num_tag_tree_bytes(ui32 num_levels)
+      { return (num_tag_tree_leaves(num_levels) * 4 + 2) / 3; }
       ui32 prepare_precinct(int tag_tree_size, ui32* lev_idx,
                             mem_elastic_allocator *elastic);
       void write(outfile_base *file);
+      // Parses the packet carrying one quality layer of this precinct. The
+      // packets of a precinct arrive in order of increasing quality layer in
+      // every progression order, but not necessarily one after the other.
       void parse(int tag_tree_size, ui32* lev_idx,
                  mem_elastic_allocator *elastic,
-                 ui32& data_left, infile_base *file, bool skipped);
+                 ui32& data_left, infile_base *file, bool skipped,
+                 ui32 layer);
 
-      ui8 *scratch;
+      ui8 *scratch;    //storage for num_parse_tag_trees tag trees; the
+                       //precinct's own when it holds more than one packet,
+                       //otherwise the buffer shared by the whole codestream
       point img_point; //the precinct projected to full resolution
       rect cb_idxs[4]; //indices of codeblocks
       subband *bands;  //the subbands

--- a/src/core/codestream/ojph_resolution.cpp
+++ b/src/core/codestream/ojph_resolution.cpp
@@ -441,18 +441,27 @@ namespace ojph {
         if (bands[i].exists())
           bands[i].get_cb_indices(num_precincts, precincts);
 
-      // determine how to divide scratch into multiple levels of
-      // tag trees
-      size log_cb = cdp->get_log_block_dims();
-      log_PP.w -= (transform_flags & HORZ_TRX) ? 1 : 0;
-      log_PP.h -= (transform_flags & VERT_TRX) ? 1 : 0;
-      size ratio;
-      ratio.w = log_PP.w - ojph_min(log_cb.w, log_PP.w);
-      ratio.h = log_PP.h - ojph_min(log_cb.h, log_PP.h);
-      max_num_levels = ojph_max(ratio.w, ratio.h);
-      ui32 val = 1u << (max_num_levels << 1);
+      // determine how to divide the tag tree storage into multiple levels
+      // of tag trees. The trees of a resolution share one layout, sized by
+      // the most levels any of its precincts needs. That is the precinct to
+      // codeblock ratio for a precinct the resolution is large enough to
+      // hold in full, and less for one clipped by the tile or the image, so
+      // it is taken from the precincts themselves, which have just been
+      // given their codeblock indices.
+      max_num_levels = 1; //the root level is always there
+      for (ui64 i = 0; i < num_precincts.area(); ++i)
+        for (int s = 0; s < 4; ++s)
+        {
+          if (!bands[s].exists())
+            continue;
+          const size& cbs = precincts[i].cb_idxs[s].siz;
+          if (cbs.w == 0 || cbs.h == 0)
+            continue;
+          max_num_levels = ojph_max(max_num_levels,
+            precinct::num_tag_tree_levels(cbs));
+        }
+      ui32 val = 1u << ((max_num_levels - 1) << 1);
       tag_tree_size = (int)((val * 4 + 2) / 3);
-      ++max_num_levels;
       level_index[0] = 0;
       for (ui32 i = 1; i <= max_num_levels; ++i, val >>= 2)
         level_index[i] = level_index[i - 1] + val;

--- a/src/core/codestream/ojph_resolution.cpp
+++ b/src/core/codestream/ojph_resolution.cpp
@@ -196,6 +196,27 @@ namespace ojph {
         num_precincts.h = (try1 + (1 << log_PP.h) - 1) >> log_PP.h;
         num_precincts.h -= try0 >> log_PP.h;
         allocator->pre_alloc_obj<precinct>((size_t)num_precincts.area());
+
+        if (cdp->get_num_layers() > 1)
+        {
+          // Tag tree storage for every precinct; see resolution::
+          // finalize_alloc. The codeblocks each precinct holds are not known
+          // yet, so reserve for the most any precinct of this resolution can
+          // span, which is what the precinct to codeblock ratio allows.
+          size log_cb = cdp->get_log_block_dims();
+          size lp = log_PP;
+          if ((transform_flags & HORZ_TRX) && lp.w > 0)
+            --lp.w;
+          if ((transform_flags & VERT_TRX) && lp.h > 0)
+            --lp.h;
+          size max_cbs(1u << (lp.w - ojph_min(log_cb.w, lp.w)),
+                       1u << (lp.h - ojph_min(log_cb.h, lp.h)));
+          size_t bytes = (size_t)precinct::num_parse_tag_trees
+            * (size_t)precinct::num_tag_tree_bytes(
+                         precinct::num_tag_tree_levels(max_cbs));
+          allocator->pre_alloc_obj<ui8>(
+            bytes * (size_t)num_precincts.area());
+        }
       }
 
       //allocate lines
@@ -460,12 +481,29 @@ namespace ojph {
           max_num_levels = ojph_max(max_num_levels,
             precinct::num_tag_tree_levels(cbs));
         }
-      ui32 val = 1u << ((max_num_levels - 1) << 1);
-      tag_tree_size = (int)((val * 4 + 2) / 3);
+      tag_tree_size = (int)precinct::num_tag_tree_bytes(max_num_levels);
+      ui32 val = precinct::num_tag_tree_leaves(max_num_levels);
       level_index[0] = 0;
       for (ui32 i = 1; i <= max_num_levels; ++i, val >>= 2)
         level_index[i] = level_index[i - 1] + val;
       cur_precinct_loc = point(0, 0);
+      cur_parse_layer = 0;
+      this->num_layers = cdp->get_num_layers();
+
+      if (this->num_layers > 1 && num_precincts.area() > 0)
+      {
+        // A precinct holds one packet per quality layer and its tag trees are
+        // decoded across all of them, so it needs storage of its own. With a
+        // single quality layer a precinct holds one packet, for which the
+        // buffer shared by the whole codestream is enough; that is what the
+        // precincts were given above.
+        size_t bytes = (size_t)precinct::num_parse_tag_trees
+                     * (size_t)tag_tree_size;
+        ui64 num = num_precincts.area();
+        ui8* buf = allocator->post_alloc_obj<ui8>(bytes * (size_t)num);
+        for (ui64 i = 0; i < num; ++i, buf += bytes)
+          precincts[i].scratch = buf;
+      }
 
       //allocate lines
       if (skipped_res_for_recon == false)
@@ -1007,27 +1045,49 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void resolution::parse_all_precincts(ui32& data_left, infile_base* file)
+    // Reads one quality layer of every precinct of this resolution, which is
+    // what the progression orders that place quality layers outside the
+    // precinct loop, LRCP and RLCP, ask for. A tile part that runs out of
+    // bytes part way leaves cur_precinct_loc where it stopped, and the call
+    // the next tile part makes for the same layer picks up from there.
+    void resolution::parse_all_precincts(ui32 layer, ui32& data_left,
+                                         infile_base* file)
     {
+      if (layer < cur_parse_layer)
+        return; //this layer was read by an earlier tile part
+      if (layer > cur_parse_layer)
+      { cur_parse_layer = layer; cur_precinct_loc = point(0, 0); }
+
       precinct* p = precincts;
       ui32 idx = cur_precinct_loc.x + cur_precinct_loc.y * num_precincts.w;
       for (ui32 i = idx; i < num_precincts.area(); ++i)
       {
         if (data_left == 0)
-          break;
+          return;
         p[i].parse(tag_tree_size, level_index, elastic, data_left, file,
-          skipped_res_for_read);
+          skipped_res_for_read, layer);
         if (++cur_precinct_loc.x >= num_precincts.w)
         {
           cur_precinct_loc.x = 0;
           ++cur_precinct_loc.y;
         }
       }
+      //the layer is complete, so the next one starts over at the first
+      //precinct
+      cur_parse_layer = layer + 1;
+      cur_precinct_loc = point(0, 0);
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void resolution::parse_one_precinct(ui32& data_left, infile_base* file)
+    // Reads one quality layer of the precinct the spatial progression orders
+    // have reached. They place quality layers innermost, so the caller asks
+    // for every layer of a precinct before moving on to the next one.
+    void resolution::parse_one_precinct(ui32 layer, ui32& data_left,
+                                        infile_base* file)
     {
+      if (layer < cur_parse_layer)
+        return; //this layer was read by an earlier tile part
+
       ui32 idx = cur_precinct_loc.x + cur_precinct_loc.y * num_precincts.w;
       assert(idx < num_precincts.area());
 
@@ -1035,7 +1095,13 @@ namespace ojph {
         return;
       precinct* p = precincts + idx;
       p->parse(tag_tree_size, level_index, elastic, data_left, file,
-        skipped_res_for_read);
+        skipped_res_for_read, layer);
+      if (layer + 1 < num_layers)
+      {
+        cur_parse_layer = layer + 1;
+        return;
+      }
+      cur_parse_layer = 0;
       if (++cur_precinct_loc.x >= num_precincts.w)
       {
         cur_precinct_loc.x = 0;

--- a/src/core/codestream/ojph_resolution.cpp
+++ b/src/core/codestream/ojph_resolution.cpp
@@ -211,6 +211,14 @@ namespace ojph {
             --lp.h;
           size max_cbs(1u << (lp.w - ojph_min(log_cb.w, lp.w)),
                        1u << (lp.h - ojph_min(log_cb.h, lp.h)));
+          // A precinct holds no more codeblocks than its resolution
+          // spans. The + 2 covers grid alignment at both ends.
+          ui32 shift_w = ojph_min(log_cb.w, (ui32)31);
+          ui32 shift_h = ojph_min(log_cb.h, (ui32)31);
+          size res_cbs(((trx1 - trx0) >> shift_w) + 2,
+                       ((try1 - try0) >> shift_h) + 2);
+          max_cbs.w = ojph_min(max_cbs.w, res_cbs.w);
+          max_cbs.h = ojph_min(max_cbs.h, res_cbs.h);
           size_t bytes = (size_t)precinct::num_parse_tag_trees
             * (size_t)precinct::num_tag_tree_bytes(
                          precinct::num_tag_tree_levels(max_cbs));

--- a/src/core/codestream/ojph_resolution.h
+++ b/src/core/codestream/ojph_resolution.h
@@ -89,8 +89,9 @@ namespace ojph {
       bool get_top_left_precinct(point &top_left);
       void write_one_precinct(outfile_base *file);
       resolution *next_resolution() { return child_res; }
-      void parse_all_precincts(ui32& data_left, infile_base *file);
-      void parse_one_precinct(ui32& data_left, infile_base *file);
+      void parse_all_precincts(ui32 layer, ui32& data_left,
+                               infile_base *file);
+      void parse_one_precinct(ui32 layer, ui32& data_left, infile_base *file);
 
       ui32 get_num_bytes() const { return num_bytes; }
       ui32 get_num_bytes(ui32 resolution_num) const;
@@ -116,8 +117,14 @@ namespace ojph {
       size log_PP;
       ui32 max_num_levels;
       int tag_tree_size;
+      ui32 num_layers;
       ui32 level_index[20]; //more than enough
       point cur_precinct_loc; //used for progressing spatial modes (2, 3, 4)
+      ui32 cur_parse_layer;   //quality layer the parse expects next; with
+                              //cur_precinct_loc it says how far the parse of
+                              //this resolution has come, so that a tile part
+                              //that runs out of bytes resumes in the right
+                              //place
       const param_atk* atk;
       ui32 transform_flags;
       //wavelet machinery

--- a/src/core/codestream/ojph_tile.cpp
+++ b/src/core/codestream/ojph_tile.cpp
@@ -197,6 +197,7 @@ namespace ojph {
 
       sot.init(0, (ui16)tile_idx, 0, 1);
       prog_order = codestream->access_cod().get_progression_order();
+      num_layers = (ui32)codestream->access_cod().get_num_layers();
 
       //allocate tiles_comp
       const param_siz *szp = codestream->get_siz();
@@ -803,13 +804,23 @@ namespace ojph {
       try
       {
         //sequence the reading of precincts according to progression order
-        if (prog_order == OJPH_PO_LRCP || prog_order == OJPH_PO_RLCP)
+        if (prog_order == OJPH_PO_LRCP)
+        {
+          max_decompositions -= skipped_res_for_read;
+          for (ui32 l = 0; l < num_layers; ++l)
+            for (ui32 r = 0; r <= max_decompositions; ++r)
+              for (ui32 c = 0; c < num_comps; ++c)
+                if (data_left > 0)
+                  comps[c].parse_precincts(r, l, data_left, file);
+        }
+        else if (prog_order == OJPH_PO_RLCP)
         {
           max_decompositions -= skipped_res_for_read;
           for (ui32 r = 0; r <= max_decompositions; ++r)
-            for (ui32 c = 0; c < num_comps; ++c)
-              if (data_left > 0)
-                comps[c].parse_precincts(r, data_left, file);
+            for (ui32 l = 0; l < num_layers; ++l)
+              for (ui32 c = 0; c < num_comps; ++c)
+                if (data_left > 0)
+                  comps[c].parse_precincts(r, l, data_left, file);
         }
         else if (prog_order == OJPH_PO_RPCL)
         {
@@ -834,7 +845,11 @@ namespace ojph {
                 { smallest = cur; comp_num = c; }
               }
               if (found == true && data_left > 0)
-                comps[comp_num].parse_one_precinct(r, data_left, file);
+              { //quality layers are innermost, so read all of this
+                //precinct's packets before moving on
+                for (ui32 l = 0; l < num_layers && data_left > 0; ++l)
+                  comps[comp_num].parse_one_precinct(r, l, data_left, file);
+              }
               else
                 break;
             }
@@ -870,7 +885,12 @@ namespace ojph {
               }
             }
             if (found == true && data_left > 0)
-              comps[comp_num].parse_one_precinct(res_num, data_left, file);
+            { //quality layers are innermost, so read all of this precinct's
+              //packets before moving on
+              for (ui32 l = 0; l < num_layers && data_left > 0; ++l)
+                comps[comp_num].parse_one_precinct(res_num, l, data_left,
+                                                   file);
+            }
             else
               break;
           }
@@ -897,7 +917,11 @@ namespace ojph {
                 { smallest = cur; res_num = r; }
               }
               if (found == true && data_left > 0)
-                comps[c].parse_one_precinct(res_num, data_left, file);
+              { //quality layers are innermost, so read all of this
+                //precinct's packets before moving on
+                for (ui32 l = 0; l < num_layers && data_left > 0; ++l)
+                  comps[c].parse_one_precinct(res_num, l, data_left, file);
+              }
               else
                 break;
             }

--- a/src/core/codestream/ojph_tile.h
+++ b/src/core/codestream/ojph_tile.h
@@ -92,6 +92,7 @@ namespace ojph {
       ui32 *cur_line;
       ui8 *nlt_type3;
       int prog_order;
+      ui32 num_layers;
 
     private:
       param_sot sot;

--- a/src/core/codestream/ojph_tile_comp.cpp
+++ b/src/core/codestream/ojph_tile_comp.cpp
@@ -159,7 +159,7 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void tile_comp::parse_precincts(ui32 res_num, ui32& data_left,
+    void tile_comp::parse_precincts(ui32 res_num, ui32 layer, ui32& data_left,
                                     infile_base *file)
     {
       assert(res_num <= num_decomps);
@@ -171,13 +171,13 @@ namespace ojph {
         --res_num;
       }
       if (r) //resolution does not exist if r is NULL
-        r->parse_all_precincts(data_left, file);
+        r->parse_all_precincts(layer, data_left, file);
     }
 
 
     //////////////////////////////////////////////////////////////////////////
-    void tile_comp::parse_one_precinct(ui32 res_num, ui32& data_left,
-                                       infile_base *file)
+    void tile_comp::parse_one_precinct(ui32 res_num, ui32 layer,
+                                       ui32& data_left, infile_base *file)
     {
       assert(res_num <= num_decomps);
       res_num = num_decomps - res_num;
@@ -188,7 +188,7 @@ namespace ojph {
         --res_num;
       }
       if (r) //resolution does not exist if r is NULL
-        r->parse_one_precinct(data_left, file);
+        r->parse_one_precinct(layer, data_left, file);
     }
 
     //////////////////////////////////////////////////////////////////////////

--- a/src/core/codestream/ojph_tile_comp.h
+++ b/src/core/codestream/ojph_tile_comp.h
@@ -80,8 +80,9 @@ namespace ojph {
       void write_precincts(ui32 res_num, outfile_base *file);
       bool get_top_left_precinct(ui32 res_num, point &top_left);
       void write_one_precinct(ui32 res_num, outfile_base *file);
-      void parse_precincts(ui32 res_num, ui32& data_left, infile_base *file);
-      void parse_one_precinct(ui32 res_num, ui32& data_left, 
+      void parse_precincts(ui32 res_num, ui32 layer, ui32& data_left,
+                           infile_base *file);
+      void parse_one_precinct(ui32 res_num, ui32 layer, ui32& data_left, 
                               infile_base *file);
 
       ui32 get_num_bytes() const { return num_bytes; }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,9 +57,22 @@ target_link_libraries(
   GTest::gtest_main
 )
 
+# configure multi-layer decoding tests (library API tests)
+add_executable(
+  test_multi_layer_decode
+  test_multi_layer_decode.cpp
+)
+
+target_link_libraries(
+  test_multi_layer_decode
+  openjph
+  GTest::gtest_main
+)
+
 include(GoogleTest)
 gtest_add_tests(TARGET test_executables)
 gtest_add_tests(TARGET test_mixed_coc)
+gtest_add_tests(TARGET test_multi_layer_decode)
 
 if (MSVC)
   add_custom_command(TARGET test_executables POST_BUILD

--- a/tests/test_multi_layer_decode.cpp
+++ b/tests/test_multi_layer_decode.cpp
@@ -1,0 +1,637 @@
+//***************************************************************************/
+// This software is released under the 2-Clause BSD license, included
+// below.
+//
+// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
+// Copyright (c) 2019, The University of New South Wales, Australia
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//***************************************************************************/
+// This file is part of the OpenJPH software implementation.
+// File: test_multi_layer_decode.cpp
+// Author: Aous Naman
+// Date: 05 September 2026
+//***************************************************************************/
+//
+// These tests decode codestreams that carry more than one quality layer.
+//
+// The encoder writes one quality layer only, so the multi-layer codestreams
+// have to be built here.  They are built by re-layering a codestream the
+// encoder produced, using a transformation that adds layers without moving a
+// single byte of coded data:
+//
+//   A packet whose header begins with a 0 bit is an empty packet (T.800
+//   B.10.3).  It is one byte long, it includes no code-block, and there is
+//   nothing else in it.  So a one-layer codestream can be turned into an
+//   N-layer codestream by writing N into the number-of-layers field of the
+//   COD marker segment and inserting an empty packet everywhere the extra
+//   layers call for one.  All coded data stays in layer 0 and the added
+//   layers are empty, so the image the codestream represents is unchanged
+//   and the decoded samples must come out bit-identical.
+//
+// The added layers are also built in a second form, in which their packets
+// carry a header that includes none of the code-blocks rather than being
+// empty; see make_excluding_packet().  That one makes the decoder walk a
+// packet header in a layer other than the first, which the empty packet does
+// not.  Both forms contribute nothing, so both must decode identically.
+//
+// Where the empty packets go depends on the progression order, and that is
+// the part worth testing.  In LRCP the layer is the outermost loop, so the
+// added layers are one block of empty packets after all the real ones.  In
+// RLCP the layer sits inside the resolution loop, so a block of empty
+// packets follows each resolution.  In RPCL, PCRL and CPRL the layer is the
+// innermost loop, so a single empty packet follows every real packet.
+//
+// Building the new tile requires knowing where each packet of the original
+// ends.  Rather than parse packet headers, the packets are collected from a
+// second encoding of the same image that asks for tile-part divisions at
+// resolution and component level: with one precinct per resolution that puts
+// exactly one packet in each tile part, and tile-part boundaries are given by
+// the Psot fields.  The collected packets are then re-assembled in the order
+// each progression calls for.  Every test first re-assembles the one-layer
+// case and requires it to be byte-identical to what the encoder wrote, which
+// checks both the collected packets and the packet ordering used here.
+//
+// Everything is done in memory, so the tests need no external files.
+
+#include <algorithm>
+#include <cstddef>
+#include <cstring>
+#include <vector>
+
+#include "ojph_arch.h"
+#include "ojph_codestream.h"
+#include "ojph_file.h"
+#include "ojph_mem.h"
+#include "ojph_message.h"
+#include "ojph_params.h"
+#include "gtest/gtest.h"
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+// The image is small, but it has enough resolutions and components that the
+// five progression orders do not all produce the same packet sequence, and
+// enough detail that every code-block carries data.
+static const ojph::ui32 IMAGE_WIDTH        = 128;
+static const ojph::ui32 IMAGE_HEIGHT       = 128;
+static const ojph::ui32 NUM_COMPONENTS     = 3;
+static const ojph::ui32 NUM_DECOMPOSITIONS = 3;
+static const ojph::ui32 NUM_RESOLUTIONS    = NUM_DECOMPOSITIONS + 1;
+static const ojph::ui32 BLOCK_DIM          = 32;
+static const ojph::ui32 PACKETS_PER_LAYER  =
+  NUM_RESOLUTIONS * NUM_COMPONENTS;
+
+// Precincts are left at their default, which is the largest the standard
+// allows, so every resolution of every component holds exactly one precinct.
+// The re-layering below relies on that: it lets a packet be named by its
+// resolution and component alone, and it makes the number of packets in a
+// layer simply the number of resolutions times the number of components.
+
+// The empty packet: a single byte whose first bit, the zero length bit of
+// the packet header, is 0 (T.800 B.10.3).
+static const ojph::ui8 EMPTY_PACKET = 0x00;
+
+// How the packets of the added layers are written.
+enum added_layer_kind
+{
+  // one empty packet, which has no header past its leading 0 bit
+  EMPTY_PACKET_LAYER,
+  // a packet that has a header, but whose header includes no code-block
+  EXCLUDING_PACKET_LAYER
+};
+
+static const char* const PROGRESSION_ORDERS[] =
+  { "LRCP", "RLCP", "RPCL", "PCRL", "CPRL" };
+static const ojph::ui32 NUM_PROGRESSION_ORDERS = 5;
+
+// marker codes used while walking the codestream
+static const ojph::ui32 MARKER_COD = 0xFF52;
+static const ojph::ui32 MARKER_SOT = 0xFF90;
+static const ojph::ui32 MARKER_SOD = 0xFF93;
+static const ojph::ui32 MARKER_EOC = 0xFFD9;
+
+////////////////////////////////////////////////////////////////////////////////
+//                             byte level helpers
+////////////////////////////////////////////////////////////////////////////////
+static ojph::ui32 get_u16(const std::vector<ojph::ui8>& buf, size_t pos)
+{
+  return ((ojph::ui32)buf[pos] << 8) | (ojph::ui32)buf[pos + 1];
+}
+
+////////////////////////////////////////////////////////////////////////////////
+static ojph::ui32 get_u32(const std::vector<ojph::ui8>& buf, size_t pos)
+{
+  return ((ojph::ui32)buf[pos    ] << 24) | ((ojph::ui32)buf[pos + 1] << 16)
+       | ((ojph::ui32)buf[pos + 2] <<  8) | ((ojph::ui32)buf[pos + 3]      );
+}
+
+////////////////////////////////////////////////////////////////////////////////
+static void put_u16(std::vector<ojph::ui8>& buf, size_t pos, ojph::ui32 val)
+{
+  buf[pos    ] = (ojph::ui8)((val >> 8) & 0xFF);
+  buf[pos + 1] = (ojph::ui8)( val       & 0xFF);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+static void put_u32(std::vector<ojph::ui8>& buf, size_t pos, ojph::ui32 val)
+{
+  buf[pos    ] = (ojph::ui8)((val >> 24) & 0xFF);
+  buf[pos + 1] = (ojph::ui8)((val >> 16) & 0xFF);
+  buf[pos + 2] = (ojph::ui8)((val >>  8) & 0xFF);
+  buf[pos + 3] = (ojph::ui8)( val        & 0xFF);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//                              find_cod_segment
+////////////////////////////////////////////////////////////////////////////////
+// Returns the offset of the COD marker in the main header.  Every marker
+// segment of the main header carries a two byte length right after the
+// marker, so the header can be walked without knowing any of the segments.
+static size_t find_cod_segment(const std::vector<ojph::ui8>& buf)
+{
+  size_t pos = 2;                             // just past SOC
+  while (get_u16(buf, pos) != MARKER_SOT)
+  {
+    if (get_u16(buf, pos) == MARKER_COD)
+      return pos;
+    pos += 2 + get_u16(buf, pos + 2);
+  }
+  return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//                                  tile_part
+////////////////////////////////////////////////////////////////////////////////
+// One tile part of the codestream: where its SOT marker is, and the range of
+// bytes holding its packets.
+struct tile_part
+{
+  size_t sot_pos;                             // offset of the SOT marker
+  size_t body_pos;                            // first byte after SOD
+  size_t body_end;                            // one past the last packet byte
+};
+
+////////////////////////////////////////////////////////////////////////////////
+//                                     off
+////////////////////////////////////////////////////////////////////////////////
+// The offsets above are held as size_t, while an iterator advances by a signed
+// difference_type.  Make that conversion explicit here rather than repeat it at
+// every call site.
+static std::ptrdiff_t off(size_t offset)
+{
+  return static_cast<std::ptrdiff_t>(offset);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//                               scan_tile_parts
+////////////////////////////////////////////////////////////////////////////////
+// Lists the tile parts of a single tile codestream.  A tile part runs from
+// its SOT marker for Psot bytes; its packets start right after the SOD marker
+// that ends the tile-part header.
+static std::vector<tile_part> scan_tile_parts(const std::vector<ojph::ui8>& buf)
+{
+  std::vector<tile_part> parts;
+  size_t pos = 2;                             // just past SOC
+  while (get_u16(buf, pos) != MARKER_SOT)
+    pos += 2 + get_u16(buf, pos + 2);
+
+  while (pos < buf.size() && get_u16(buf, pos) == MARKER_SOT)
+  {
+    tile_part part;
+    part.sot_pos = pos;
+    part.body_end = pos + get_u32(buf, pos + 6);   // Psot
+
+    size_t hdr = pos + 2 + get_u16(buf, pos + 2);  // past the SOT segment
+    while (get_u16(buf, hdr) != MARKER_SOD)
+      hdr += 2 + get_u16(buf, hdr + 2);
+    part.body_pos = hdr + 2;
+
+    parts.push_back(part);
+    pos = part.body_end;
+  }
+  return parts;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//                           encode_test_codestream
+////////////////////////////////////////////////////////////////////////////////
+// Encodes a fixed synthetic image losslessly with the requested progression
+// order, and returns the codestream.  When tile_parts is true the tile is
+// split into one tile part per resolution and component.
+static std::vector<ojph::ui8> encode_test_codestream(const char* prog_order,
+                                                     bool tile_parts)
+{
+  ojph::codestream cs;
+
+  ojph::param_siz siz = cs.access_siz();
+  siz.set_image_extent(ojph::point(IMAGE_WIDTH, IMAGE_HEIGHT));
+  siz.set_num_components(NUM_COMPONENTS);
+  for (ojph::ui32 c = 0; c < NUM_COMPONENTS; ++c)
+    siz.set_component(c, ojph::point(1, 1), 8, false);
+  siz.set_image_offset(ojph::point(0, 0));
+  siz.set_tile_size(ojph::size(IMAGE_WIDTH, IMAGE_HEIGHT));
+  siz.set_tile_offset(ojph::point(0, 0));
+
+  ojph::param_cod cod = cs.access_cod();
+  cod.set_num_decomposition(NUM_DECOMPOSITIONS);
+  cod.set_block_dims(BLOCK_DIM, BLOCK_DIM);
+  cod.set_color_transform(false);
+  cod.set_reversible(true);
+  cod.set_progression_order(prog_order);
+
+  if (tile_parts)
+    cs.set_tilepart_divisions(true, true);
+  cs.set_planar(true);
+
+  ojph::mem_outfile out;
+  out.open();
+  cs.write_headers(&out);
+
+  ojph::ui32 next_comp = 0;
+  ojph::line_buf* line = cs.exchange(NULL, next_comp);
+  for (ojph::ui32 c = 0; c < NUM_COMPONENTS; ++c)
+    for (ojph::ui32 y = 0; y < IMAGE_HEIGHT; ++y)
+    {
+      ojph::si32* dp = line->i32;
+      for (ojph::ui32 x = 0; x < IMAGE_WIDTH; ++x)
+        dp[x] = (ojph::si32)
+          ((x * 7 + y * 13 + c * 29 + ((x * y) >> 3)) & 0xFF);
+      line = cs.exchange(line, next_comp);
+    }
+  cs.flush();
+
+  std::vector<ojph::ui8> buf(out.get_data(),
+                             out.get_data() + (size_t)out.tell());
+  cs.close();
+  return buf;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//                              collect_packets
+////////////////////////////////////////////////////////////////////////////////
+// Returns the coded bytes of each packet of the test image, indexed by
+// res * NUM_COMPONENTS + comp.
+//
+// The packets are read out of an LRCP encoding that was asked for tile-part
+// divisions at both resolution and component level.  For LRCP that gives one
+// tile part per resolution and component, in resolution major order (see
+// tile::flush()), and because every resolution holds a single precinct each
+// of those tile parts holds exactly one packet.  A packet's bytes depend only
+// on the code-blocks of its own precinct, never on the order the packets are
+// written in, so the same bytes serve every progression order; each test
+// checks that by re-assembling the one-layer codestream and comparing it with
+// what the encoder wrote.
+static std::vector<std::vector<ojph::ui8> > collect_packets()
+{
+  std::vector<ojph::ui8> buf = encode_test_codestream("LRCP", true);
+  std::vector<tile_part> parts = scan_tile_parts(buf);
+
+  std::vector<std::vector<ojph::ui8> > packets;
+  if (parts.size() != PACKETS_PER_LAYER)
+    return packets;                           // reported by the caller
+
+  for (size_t i = 0; i < parts.size(); ++i)
+    packets.push_back(
+      std::vector<ojph::ui8>(buf.begin() + off(parts[i].body_pos),
+                             buf.begin() + off(parts[i].body_end)));
+  return packets;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//                         num_code_blocks_in_precinct
+////////////////////////////////////////////////////////////////////////////////
+// The number of code-blocks held by the single precinct of the given
+// resolution.  Resolution 0 carries the LL band on its own, and every other
+// resolution carries HL, LH and HH; a band of bw by bh samples, starting at
+// the origin, is covered by ceil(bw / BLOCK_DIM) * ceil(bh / BLOCK_DIM)
+// code-blocks (T.800 B.7).
+static ojph::ui32 num_code_blocks_in_precinct(ojph::ui32 res)
+{
+  ojph::ui32 shift = (res == 0) ? NUM_DECOMPOSITIONS
+                                : NUM_DECOMPOSITIONS - res + 1;
+  ojph::ui32 bw = (IMAGE_WIDTH  + (1u << shift) - 1) >> shift;
+  ojph::ui32 bh = (IMAGE_HEIGHT + (1u << shift) - 1) >> shift;
+  ojph::ui32 num_blocks = ((bw + BLOCK_DIM - 1) / BLOCK_DIM)
+                        * ((bh + BLOCK_DIM - 1) / BLOCK_DIM);
+  return num_blocks * ((res == 0) ? 1u : 3u);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//                            make_excluding_packet
+////////////////////////////////////////////////////////////////////////////////
+// A packet that carries a header but includes none of its code-blocks; the
+// counterpart of the empty packet for a decoder that has to walk a packet
+// header in a layer other than the first.
+//
+// Its header is a 1 bit, saying the packet is not empty, followed by the
+// inclusion signalling of every code-block of the precinct, and then nothing
+// else, since no code-block contributes.  Every code-block of this image is
+// included in layer 0 -- the image has detail everywhere, so no code-block
+// is all zero -- and for a code-block that a previous layer already included
+// the inclusion signalling is a single bit, 0 meaning it does not contribute
+// to this layer (T.800 B.10.4).  So the header is one 1 bit and one 0 bit
+// per code-block, and because those bits are all 0 their order does not
+// matter, only how many there are.  The header is then padded to a byte with
+// 0 bits; no byte of it can reach 0xFF, so no bit stuffing arises.
+static std::vector<ojph::ui8> make_excluding_packet(ojph::ui32 res)
+{
+  ojph::ui32 num_bits = 1 + num_code_blocks_in_precinct(res);
+  std::vector<ojph::ui8> packet((num_bits + 7) / 8, 0);
+  packet[0] = 0x80;                           // the zero length bit, set
+  return packet;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//                                  packet_ref
+////////////////////////////////////////////////////////////////////////////////
+// Names one packet of the tile.  The precinct index is not needed because
+// there is only one precinct per resolution here.
+struct packet_ref
+{
+  packet_ref(ojph::ui32 r, ojph::ui32 c, ojph::ui32 l)
+  : res(r), comp(c), layer(l) {}
+  ojph::ui32 res;
+  ojph::ui32 comp;
+  ojph::ui32 layer;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+//                               packet_sequence
+////////////////////////////////////////////////////////////////////////////////
+// The order the packets of the tile appear in, for the given progression
+// order and number of layers; T.800 B.12.
+//
+// The position loops of RPCL, PCRL and CPRL are written out here as a loop
+// over resolutions, which is what they come to when every resolution holds
+// one precinct: all precincts then project to the top left corner of the
+// tile, so the position loop visits them in the order the loops nested
+// inside it impose.  That is component major, resolution minor for PCRL and
+// CPRL, and resolution major, component minor for RPCL.
+static std::vector<packet_ref> packet_sequence(const char* prog_order,
+                                               ojph::ui32 num_layers)
+{
+  std::vector<packet_ref> seq;
+  ojph::ui32 r, c, l;
+
+  if (strncmp(prog_order, "LRCP", 4) == 0)
+  {
+    for (l = 0; l < num_layers; ++l)
+      for (r = 0; r < NUM_RESOLUTIONS; ++r)
+        for (c = 0; c < NUM_COMPONENTS; ++c)
+          seq.push_back(packet_ref(r, c, l));
+  }
+  else if (strncmp(prog_order, "RLCP", 4) == 0)
+  {
+    for (r = 0; r < NUM_RESOLUTIONS; ++r)
+      for (l = 0; l < num_layers; ++l)
+        for (c = 0; c < NUM_COMPONENTS; ++c)
+          seq.push_back(packet_ref(r, c, l));
+  }
+  else if (strncmp(prog_order, "RPCL", 4) == 0)
+  {
+    for (r = 0; r < NUM_RESOLUTIONS; ++r)
+      for (c = 0; c < NUM_COMPONENTS; ++c)          // position, then comp
+        for (l = 0; l < num_layers; ++l)
+          seq.push_back(packet_ref(r, c, l));
+  }
+  else if (strncmp(prog_order, "PCRL", 4) == 0
+        || strncmp(prog_order, "CPRL", 4) == 0)
+  {
+    for (c = 0; c < NUM_COMPONENTS; ++c)            // position and comp
+      for (r = 0; r < NUM_RESOLUTIONS; ++r)
+        for (l = 0; l < num_layers; ++l)
+          seq.push_back(packet_ref(r, c, l));
+  }
+  return seq;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//                                assemble_tile
+////////////////////////////////////////////////////////////////////////////////
+// Lays the packets out in the given order.  Layer 0 carries all of the coded
+// data, so a packet of any other layer contributes nothing and is written in
+// whichever of the two forms the caller asked for.
+static std::vector<ojph::ui8> assemble_tile(
+  const std::vector<std::vector<ojph::ui8> >& packets,
+  const std::vector<packet_ref>& seq,
+  added_layer_kind kind)
+{
+  std::vector<ojph::ui8> body;
+  for (size_t i = 0; i < seq.size(); ++i)
+  {
+    if (seq[i].layer != 0)
+    {
+      if (kind == EMPTY_PACKET_LAYER)
+        body.push_back(EMPTY_PACKET);
+      else
+      {
+        std::vector<ojph::ui8> p = make_excluding_packet(seq[i].res);
+        body.insert(body.end(), p.begin(), p.end());
+      }
+    }
+    else
+    {
+      const std::vector<ojph::ui8>& p =
+        packets[seq[i].res * NUM_COMPONENTS + seq[i].comp];
+      body.insert(body.end(), p.begin(), p.end());
+    }
+  }
+  return body;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//                              relayer_codestream
+////////////////////////////////////////////////////////////////////////////////
+// Builds an equivalent codestream that declares num_layers quality layers.
+//
+// base is a one-layer, one-tile, one-tile-part codestream; body is the new
+// sequence of packets for its tile.  Everything up to and including the SOD
+// marker is kept as it stands, apart from two fields: the number of layers
+// in the COD marker segment, and Psot, which has to follow the length of the
+// tile part.
+static std::vector<ojph::ui8> relayer_codestream(
+  const std::vector<ojph::ui8>& base,
+  const std::vector<ojph::ui8>& body,
+  ojph::ui32 num_layers)
+{
+  std::vector<tile_part> parts = scan_tile_parts(base);
+  const tile_part& part = parts[0];
+
+  std::vector<ojph::ui8> out(base.begin(), base.begin() + off(part.body_pos));
+  out.insert(out.end(), body.begin(), body.end());
+  out.push_back((ojph::ui8)(MARKER_EOC >> 8));
+  out.push_back((ojph::ui8)(MARKER_EOC & 0xFF));
+
+  // SGcod in the COD segment holds the progression order in one byte and the
+  // number of layers in the two that follow it (T.800 A.6.1); the segment
+  // starts with the marker and the two byte Lcod, then Scod.
+  size_t cod_pos = find_cod_segment(out);
+  put_u16(out, cod_pos + 6, num_layers);
+
+  // Psot counts from the SOT marker to the end of the tile part.
+  put_u32(out, part.sot_pos + 6,
+          (ojph::ui32)(part.body_pos - part.sot_pos + body.size()));
+  return out;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//                                decode_image
+////////////////////////////////////////////////////////////////////////////////
+// Decodes a codestream held in memory and returns every sample of every
+// component, one component after the other.
+static std::vector<ojph::si32> decode_image(const std::vector<ojph::ui8>& buf)
+{
+  ojph::mem_infile in;
+  in.open(buf.data(), buf.size());
+
+  ojph::codestream cs;
+  cs.read_headers(&in);
+  cs.set_planar(true);
+  cs.create();
+
+  ojph::param_siz siz = cs.access_siz();
+  std::vector<ojph::si32> samples;
+  for (ojph::ui32 c = 0; c < NUM_COMPONENTS; ++c)
+  {
+    ojph::ui32 height = siz.get_recon_height(c);
+    ojph::ui32 width = siz.get_recon_width(c);
+    for (ojph::ui32 y = 0; y < height; ++y)
+    {
+      ojph::ui32 comp_num = 0;
+      ojph::line_buf* line = cs.pull(comp_num);
+      samples.insert(samples.end(), line->i32, line->i32 + width);
+    }
+  }
+  cs.close();
+  return samples;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//                             multi_layer_decode
+////////////////////////////////////////////////////////////////////////////////
+class multi_layer_decode : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    packets = collect_packets();
+    ASSERT_EQ(packets.size(), PACKETS_PER_LAYER)
+      << "the tile-part divided encoding did not produce one tile part per "
+      << "resolution and component, so the packets cannot be collected";
+  }
+
+  // Re-assembles the one-layer codestream from the collected packets and
+  // requires it to be what the encoder wrote, then returns both it and the
+  // codestream the same packets make when spread over num_layers layers.
+  void build(const char* prog_order, ojph::ui32 num_layers,
+             added_layer_kind kind,
+             std::vector<ojph::ui8>& one_layer,
+             std::vector<ojph::ui8>& many_layers)
+  {
+    one_layer = encode_test_codestream(prog_order, false);
+    std::vector<tile_part> parts = scan_tile_parts(one_layer);
+    ASSERT_EQ(parts.size(), 1u) << "expected a single tile part";
+
+    std::vector<ojph::ui8> body =
+      assemble_tile(packets, packet_sequence(prog_order, 1), kind);
+    ASSERT_EQ(body.size(), parts[0].body_end - parts[0].body_pos)
+      << "the re-assembled tile is not the length the encoder wrote";
+    ASSERT_TRUE(std::equal(body.begin(), body.end(),
+                           one_layer.begin() + off(parts[0].body_pos)))
+      << "the re-assembled tile differs from the one the encoder wrote, so "
+      << "either the collected packets or the packet order used here is "
+      << "wrong";
+
+    body = assemble_tile(packets, packet_sequence(prog_order, num_layers),
+                         kind);
+    many_layers = relayer_codestream(one_layer, body, num_layers);
+  }
+
+  std::vector<std::vector<ojph::ui8> > packets;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// The re-layered codestream must really carry the layers it claims: the
+// number of layers has to read back from the COD marker segment, and the
+// codestream has to have grown by exactly one byte for every empty packet
+// that was added.
+TEST_F(multi_layer_decode, added_layers_are_present_in_the_codestream)
+{
+  for (ojph::ui32 i = 0; i < NUM_PROGRESSION_ORDERS; ++i)
+    for (ojph::ui32 num_layers = 2; num_layers <= 3; ++num_layers)
+    {
+      SCOPED_TRACE(::testing::Message()
+        << PROGRESSION_ORDERS[i] << ", " << num_layers << " layers");
+      std::vector<ojph::ui8> one_layer, many_layers;
+      ASSERT_NO_FATAL_FAILURE(build(PROGRESSION_ORDERS[i], num_layers,
+                                    EMPTY_PACKET_LAYER, one_layer,
+                                    many_layers));
+
+      EXPECT_EQ(many_layers.size(),
+                one_layer.size() + PACKETS_PER_LAYER * (num_layers - 1));
+
+      ojph::mem_infile in;
+      in.open(many_layers.data(), many_layers.size());
+      ojph::codestream cs;
+      cs.read_headers(&in);
+      EXPECT_EQ((ojph::ui32)cs.access_cod().get_num_layers(), num_layers);
+      cs.close();
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// A codestream whose added layers contribute nothing holds the same image as
+// the one-layer codestream it was built from, so the two have to decode to
+// the same samples.  This is checked for both forms an added layer can take,
+// for two and three layers, and for every progression order; LRCP and RLCP
+// are the orders that place the layer outside the precinct loop, and RPCL,
+// PCRL and CPRL are the ones that place it innermost.
+TEST_F(multi_layer_decode, added_layers_decode_identically)
+{
+  const added_layer_kind kinds[] =
+    { EMPTY_PACKET_LAYER, EXCLUDING_PACKET_LAYER };
+  const char* const kind_names[] = { "empty packets", "excluding packets" };
+
+  for (ojph::ui32 k = 0; k < 2; ++k)
+    for (ojph::ui32 i = 0; i < NUM_PROGRESSION_ORDERS; ++i)
+      for (ojph::ui32 num_layers = 2; num_layers <= 3; ++num_layers)
+      {
+        SCOPED_TRACE(::testing::Message()
+          << PROGRESSION_ORDERS[i] << ", " << num_layers << " layers, "
+          << kind_names[k]);
+        std::vector<ojph::ui8> one_layer, many_layers;
+        ASSERT_NO_FATAL_FAILURE(build(PROGRESSION_ORDERS[i], num_layers,
+                                      kinds[k], one_layer, many_layers));
+
+        std::vector<ojph::si32> expected = decode_image(one_layer);
+        std::vector<ojph::si32> actual = decode_image(many_layers);
+        ASSERT_EQ(expected.size(),
+                  (size_t)NUM_COMPONENTS * IMAGE_WIDTH * IMAGE_HEIGHT);
+        EXPECT_EQ(actual, expected);
+      }
+}
+
+} // anonymous namespace


### PR DESCRIPTION
Fixes #89.

OpenJPH currently decodes only single-layer HT codestreams. `precinct::parse` reads one
packet per precinct and assumes it carries every contribution, so a codestream with
`SGcod.num_layers > 1` is rejected at header parse. This adds multi-layer decoding for all
five progression orders.

### What it does

A precinct's packets are now parsed one at a time with a quality-layer index, and the
sequencing loop gains a layer dimension — `l, r, c, p` for LRCP, `r, l, c, p` for RLCP, and
the layer read where the precinct is read for the three spatial orders. Per-code-block parse
state carries across layers, so a contribution's segments can arrive in different packets.

The segment rules follow T.814 Annex B: the general B.2 segment loop, zero-length HT sets,
cross-packet segment concatenation, `Z_blk` and `S_blk`, and the placeholder-run rule (P0
cannot be read off the first contribution, since a placeholder run may be split across
packets).

Two smaller things came out of the same work and are separate commits:

* Tag-tree storage per resolution was sized from the precinct/code-block *ratio*, which is
  generous for a precinct clipped by its tile. It is now sized from the code-blocks the
  precincts actually hold.
* A COC marker segment did not inherit SOP/EPH usage from the main COD (T.800 Table A.23),
  so a stream with COC plus SOP/EPH misparsed the SOP bytes as header bits.

### How it is split

The series is arranged so that review effort can concentrate on one commit:

| | commit | |
|---|---|---|
| 1 | `fix(decode): COC objects inherit SOP/EPH usage from the main COD` | independent bug fix |
| 2 | `refactor(decode): size a resolution's tag trees from its precincts` | |
| 3 | `refactor(decode): read one packet per precinct::parse call` | all the layer plumbing |
| 4 | `feat(decode): decode codestreams with more than one quality layer` | removes the guard |
| 5 | `test: cover decoding of multi-layer codestreams` | |

**Commits 1-3 keep the existing `num_layers != 1` guard, so they change nothing observable.**
Over a corpus of 151 codestreams — the 70 of `jp2k_test_codestreams`, the 73 of the
ISO/IEC 15444-4 conformance set, and the 8 attached to #89 — 86 decode on master, and at each
of commits 1-3 all 86 decode byte-identically, with nothing newly decoding and nothing lost.
Commit 4 removes the guard and turns the feature on. Each commit builds on its own.

### Verification

* **Byte-identical on everything that decodes today.** Across the 151-codestream corpus above,
  the full series decodes all 86 of master's outputs byte-for-byte, with 0 differing and 0
  regressions; 16 codestreams newly decode. Encoder output identical across five
  `ojph_compress` configurations.
* **Eleven conformance streams that master cannot decode now decode.** Master rejects every
  multi-layer stream — 28 of the 31 at the `num_layers` guard, and the three mixed-mode
  `ds0_hm_*` files earlier, at COD-SPcod — so the baseline is zero.

  | stream | layers | prog | against the ISO reference |
  |---|---|---|---|
  | `ds0_ht_02_b11` | 6 | LRCP | PAE 1, tolerance 1 |
  | `ds0_ht_02_b12` | 6 | LRCP | *no entry in the suite*; PAE 0 against the reference its `b11` sibling uses |
  | `ds0_ht_04_b11` | 20 | RLCP | PAE 2/2/2, tolerances 7/6/8 |
  | `ds0_ht_04_b12` | 20 | RLCP | PAE 2/2/2, tolerances 5/4/6 |
  | `ds0_ht_08_b11` | 30 | CPRL | PAE 32/30/33, tolerances 40/40/40 (suite decodes at `-reduce 1`) |
  | `ds0_ht_08_b15` | 30 | CPRL | PAE 0/1/0, tolerances 0/1/0 |
  | `ds0_ht_08_b16` | 30 | CPRL | PAE 0/0/0, exact |
  | `ds0_ht_10_b11` | 2 | LRCP | PAE 0/0/0, exact |
  | `ds0_ht_16_b11` | 3 | RLCP | PAE 0, exact |
  | `ds1_ht_01_b11` | 5 | LRCP | PAE 1, tolerance 1 |
  | `ds1_ht_01_b12` | 5 | LRCP | PAE 0, exact |

  Ten carry an entry in the suite's own cmake files and pass its PAE/MSE tolerances; four are
  exact. `ds0_ht_02_b12` has no entry there, so its comparison is mine rather than the
  suite's. `ds0_ht_16_b11` also decodes byte-identically to its single-layer sibling
  `ds0_ht_01_b11`. Five of the multi-layer codestreams attached to #89 newly decode as well.

  The three `ds0_ht_08` streams decode identically to OpenHTJ2K, on every sample. Worth a note
  if you reproduce it: they are 12-bit signed with three components, and `ojph_expand` has no
  sign-preserving output for that case — `.raw` preserves sign but is single-component, while
  PPM, TIFF and YUV clamp negatives to zero — so I compared sample values through the library
  API rather than through a written image.
* **A large multi-layer HT image from my own application** decodes to a byte-identical
  output before and after the change.
* **Builds warning-free** on MSVC x64, GCC 13.3, Clang 18.1.3, and Emscripten across all four
  variants your `emcc` workflow builds (SIMD/non-SIMD x Debug/Release). No new warning on any
  toolchain relative to master.
* **Fuzzed** with the libFuzzer targets from `OJPH_BUILD_FUZZER`, both `ojph_expand` and
  `ojph_compress`, 900s each against master as a baseline: 1.15M executions on expand and 48k
  on compress for this branch (1.17M / 66k on master), no crashes and no sanitizer reports on
  either. Peak RSS stayed at 468 MB. Coverage on this branch is higher than on master
  (cov 545 vs 513), which is the multi-layer path being reached.
* `ctest`: 97/97 -> 99/99 with the new tests.

### About the test

The multi-layer path cannot be covered the way the rest of the suite covers things. Every
other test generates its data with `ojph_compress`, but the encoder writes a single quality
layer and `param_cod` has no setter, so there is no round-trip to make.

The test therefore **generates its fixtures at run time** from a stream the library itself
encodes, by inserting packets that include no code-block to turn a one-layer codestream into
an N-layer one. Nothing binary is added to the repository. It covers the five progression
orders, two and three layers, and two forms of added layer — an empty packet, and a packet
that has a header but includes nothing, which makes the decoder walk a layer-1 packet header
and take the "already included" path.

The oracle is exact: the multi-layer stream must decode **bit-identically** to the one-layer
original, so no reference images are needed. Packet boundaries are located without a
packet-header parser, by encoding a second time with tile-part divisions, and the test asserts
its own layout model by re-assembling the one-layer tile and comparing it byte-for-byte with
what the encoder wrote.

**What the test does not cover**, stated plainly: a code-block whose passes are split *across*
layers, i.e. cross-packet segment concatenation and placeholder runs. That is not a matter of
effort — `ojph_compress` emits exactly one coding pass per code-block (the HT cleanup pass; HT
SigProp/MagRef encoding is not implemented), and a single pass cannot be split. Covering it
needs either an encoder that can write multiple passes or a committed multi-layer fixture.

I verified that path against the ISO/IEC 15444-4 conformance streams, which do exercise it,
but those are ISO-licensed and whether they belong in `jp2k_test_codestreams` is your call
rather than mine to make by putting them there. If you would like that coverage before this
merges, I am happy to prepare it — `ds0_ht_08_b11/_b15/_b16` (CPRL, 30 layers, COC on every
component, SOP+EPH) are good candidates, and they are what turned up the COC/SOP-EPH bug in
commit 1. Equally happy to leave it.

### Known limitations

* **The other twenty multi-layer conformance streams still do not decode**, each stopped by a
  feature OpenJPH does not have yet rather than by anything here — as they are for
  single-layer streams today: POC in the main header (`ds0_ht_03_b11/_b14`,
  `ds0_ht_15_b11/_b14`), POC in a tile (`ds0_ht_07_b11/_b15/_b16`), PPT
  (`ds1_ht_02_b11/_b12`), PPM (`ds1_ht_05_b11`), RGN (`ds0_ht_06_b11/_b15/_b18`),
  scalar-derived quantization in QCC (`ds0_ht_05_b11/_b12`, `ds1_ht_03_b11/_b12`), and mixed
  HT/T.800 mode (`ds0_hm_06_b11/_b18`, `ds0_hm_15_b8`, which master also rejects). The
  layer-aware sequencing here is a prerequisite for POC support, but POC itself is a separate
  feature.
* **At most 256 quality layers.** The inclusion tag tree stores the layer of first inclusion in
  one byte per node. Streams declaring more are rejected with a clear message rather than
  misparsed — `ht_216p_65535_layers.j2c` from #89 is one, and it is the only multi-layer
  codestream in that attachment set this PR does not decode. Lifting the limit means a wider
  node value for the inclusion tree specifically, since `ui8` is correct for the encoder's
  trees and the missing-MSB trees.
* **Memory.** Three costs, quoted in full:
  * `coded_cb_header` grows from 32 to 64 bytes per code-block, on **every** codestream,
    single-layer included, because the parse state has to survive between a code-block's
    packets.
  * On a codestream with more than one layer, each precinct gets its own tag-tree storage of
    16 tables, so its trees survive across its packets in every progression order. That is
    roughly 7 to 11 bytes per code-block at resolutions above 0, and 21 to 32 bytes at
    resolution 0, where a precinct holds only the LL band. Nothing on single-layer streams.
  * The shared precinct scratch grows from 4 tables to 16 — one buffer per codestream. For a
    precinct of 4x4 code-blocks that is 88 -> 352 bytes, and 1.33 -> 5.33 MiB in the largest
    case that can be constructed (precincts 2^15 samples wide with 64x64 code-blocks).
